### PR TITLE
Add build pipeline for GitHub Pages

### DIFF
--- a/.github/workflows/build-and-deploy-gh-pages.yaml
+++ b/.github/workflows/build-and-deploy-gh-pages.yaml
@@ -1,0 +1,58 @@
+#********************************************************************************
+# Copyright (c) 2021,2022 Mercedes-Benz Tech Innovation GmbH
+# Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#*******************************************************************************/
+
+name: Build and deploy gh-pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Build and deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build website
+        run: npm run build
+
+      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          # The following lines assign commit authorship to the official
+          # GH-Actions bot for deploys to `gh-pages` branch:
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          # The GH actions bot is used by default if you didn't specify the two fields.
+          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -18,7 +18,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #*******************************************************************************/
 
-name: Build and deploy gh-pages
+name: Verify website build
 
 on:
   pull_request:

--- a/.github/workflows/verify-build.yaml
+++ b/.github/workflows/verify-build.yaml
@@ -1,0 +1,48 @@
+#********************************************************************************
+# Copyright (c) 2021,2022 Mercedes-Benz Tech Innovation GmbH
+# Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#*******************************************************************************/
+
+name: Build and deploy gh-pages
+
+on:
+  pull_request:
+    branches:
+      - main
+
+# This job will try to build the website to find potential issues
+# before actually merging and deploying the page.
+# There are cases, where for example broken links will break the build, but
+# checking it on the local development server (npm start) will work smoothely.
+jobs:
+  build:
+    name: Build static website
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build website
+        run: npm run build

--- a/docs/release/trg-1/trg-1-2.md
+++ b/docs/release/trg-1/trg-1-2.md
@@ -1,0 +1,16 @@
+---
+title: TRG 1.02 - INSTALL.md
+---
+
+| Author               | Status | Created      | Post-History |
+|----------------------|--------|--------------|--------------|
+| Catena-X System Team | Draft  | 13-Sept-2022 | n/a          |
+
+## Description
+
+Repositories can have a `INSTALL.md` file.
+
+## Why
+
+Each repository must contain a `README.md` file which shall cover installation instructions. If necessary installation
+instructions can be separated into this `INSTALL.md` file.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,7 +17,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro">
+            to="/docs/introduction">
             Docusaurus Tutorial - 5min ⏱️
           </Link>
         </div>


### PR DESCRIPTION
This PR will add two workflows to build the docusaurus website and publish it via GitHub pages.

**'build-and-deploy-gh-pages.yaml'**:
This workflow will run on each push to the main branch. It builds the static site and push the result to the `gh-pages` branch.

**'verify-build.yaml'**:
This workflow will run for each pull-request and will execute the necessary build steps, without deploying the results somewhere. This is useful, because some issues like broken links are not easily discovered on local development, but break the build. 

NOTE: Before merging this PR, the `gh-page` branch should be created, so that the first run of this workflow will not fail