### PR TITLE
docs: add OSS requirements to TRG 2.03

### DIFF
--- a/docs/release/trg-2/assets/AUTHORS.txt
+++ b/docs/release/trg-2/assets/AUTHORS.txt
@@ -1,0 +1,7 @@
+#Authors
+
+The following people have contributed to this repository:
+
+- Contributor 1, Company Name, github.com/username or contributor@example.com
+
+Please add yourself to this list, if you contribute to the content.

--- a/docs/release/trg-2/assets/CODE_OF_CONDUCT.txt
+++ b/docs/release/trg-2/assets/CODE_OF_CONDUCT.txt
@@ -1,0 +1,46 @@
+# Community Code of Conduct
+
+**Version 1.2
+August 19, 2020**
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as community members, contributors, committers, and project leaders pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+*   Using welcoming and inclusive language
+*   Being respectful of differing viewpoints and experiences
+*   Gracefully accepting constructive criticism
+*   Focusing on what is best for the community
+*   Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+*   The use of sexualized language or imagery and unwelcome sexual attention or advances
+*   Trolling, insulting/derogatory comments, and personal or political attacks
+*   Public or private harassment
+*   Publishing others' private information, such as a physical or electronic address, without explicit permission
+*   Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+With the support of the Eclipse Foundation staff (the “Staff”), project committers and leaders are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project committers and leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when an individual is representing the Eclipse Foundation project or its community in public spaces. Examples of representing a project or community include posting via an official social media account, or acting as a project representative at an online or offline event. Representation of a project may be further defined and clarified by project committers, leaders, or the EMO.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Staff at codeofconduct@eclipse.org. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The Staff is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project committers or leaders who do not follow the Code of Conduct in good faith may face temporary or permanent repercussions as determined by the Staff.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org) , version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct/)

--- a/docs/release/trg-2/assets/CONTRIBUTING.txt
+++ b/docs/release/trg-2/assets/CONTRIBUTING.txt
@@ -1,0 +1,58 @@
+# Contributing to Eclipse Tractus-X
+
+Thanks for your interest in this project.
+
+## Project description
+
+The companies involved want to increase the automotive industry's
+competitiveness, improve efficiency through industry-specific cooperation and
+accelerate company processes through standardization and access to information
+and data. A special focus is also on SMEs, whose active participation is of
+central importance for the networkâ€™s success. That is why Catena-X has been
+conceived from the outset as an open network with solutions ready for SMEs,
+where these companies will be able to participate quickly and with little IT
+infrastructure investment. Tractus-X is meant to be the PoC project of the
+Catena-X alliance focusing on parts traceability.
+
+* https://projects.eclipse.org/projects/automotive.tractusx
+
+## Developer resources
+
+Information regarding source code management, builds, coding standards, and
+more.
+
+* https://projects.eclipse.org/projects/automotive.tractusx/developer
+
+The project maintains the source code repositories in the following GitHub organization:
+
+* https://github.com/eclipse-tractusx/
+
+## Eclipse Development Process
+
+This Eclipse Foundation open project is governed by the Eclipse Foundation
+Development Process and operates under the terms of the Eclipse IP Policy.
+
+* https://eclipse.org/projects/dev_process
+* https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf
+
+## Eclipse Contributor Agreement
+
+In order to be able to contribute to Eclipse Foundation projects you must
+electronically sign the Eclipse Contributor Agreement (ECA).
+
+* http://www.eclipse.org/legal/ECA.php
+
+The ECA provides the Eclipse Foundation with a permanent record that you agree
+that each of your contributions will comply with the commitments documented in
+the Developer Certificate of Origin (DCO). Having an ECA on file associated with
+the email address matching the "Author" field of your contribution's Git commits
+fulfills the DCO's requirement that you sign-off on your contributions.
+
+For more information, please see the Eclipse Committer Handbook:
+https://www.eclipse.org/projects/handbook/#resources-commit
+
+## Contact
+
+Contact the project developers via the project's "dev" list.
+
+* https://accounts.eclipse.org/mailing-list/tractusx-dev

--- a/docs/release/trg-2/assets/LICENSE.txt
+++ b/docs/release/trg-2/assets/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docs/release/trg-2/assets/NOTICE.txt
+++ b/docs/release/trg-2/assets/NOTICE.txt
@@ -1,0 +1,49 @@
+# Notices for Eclipse Tractus-X
+
+This content is produced and maintained by the Eclipse Tractus-X project.
+
+* Project home: https://projects.eclipse.org/projects/automotive.tractusx
+
+See the AUTHORS file(s) distributed with this work for additional information regarding authorship.
+
+## Trademarks
+
+Eclipse Tractus-X is a trademark of the Eclipse Foundation.
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+
+## Source Code
+
+The project maintains the following source code repositories
+in the GitHub organization https://github.com/eclipse-tractusx:
+
+* https://github.com/eclipse-tractusx/<my_product_repo1>
+* https://github.com/eclipse-tractusx/<my_product_repo2>
+
+
+## Third-party Content
+
+This project leverages the following third party content.
+
+See DEPENDENCIES file.
+
+## Cryptography
+
+Content may contain encryption software. The country in which you are currently
+may have restrictions on the import, possession, and use, and/or re-export to
+another country, of encryption software. BEFORE using any encryption software,
+please check the country's laws, regulations and policies concerning the import,
+possession, or use, and re-export of encryption software, to see if this is
+permitted.

--- a/docs/release/trg-2/assets/SECURITY.txt
+++ b/docs/release/trg-2/assets/SECURITY.txt
@@ -1,0 +1,6 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report a found vulnerability here:
+[https://www.eclipse.org/security/](https://www.eclipse.org/security/)

--- a/docs/release/trg-2/trg-2-3.md
+++ b/docs/release/trg-2/trg-2-3.md
@@ -2,25 +2,94 @@
 title: TRG 2.03 - Repo structure
 ---
 
-| Author               | Status | Created     | Post-History    |
-|----------------------|--------|-------------|-----------------|
-| Catena-X System Team | Active | 10-Nov-2022 | Initial release |
+| Author                | Status | Created     | Post-History                         |
+|-----------------------|--------|-------------|--------------------------------------|
+| Catena-X System Team  |        | 10-Nov-2022 | Initial release                      |
+| Catena-X System Team  | Active | 24-Nov-2022 | add FOSS/Eclipse related basic files |
 
 ## Description
 
-The following repository structure is recommended:
+:::info
+
+This TRG applies only to Eclipse-Tractusx GitHub repositories, not to Catenax-NG GitHub repositories. For Catenax-NG
+please [read this](https://github.com/catenax-ng/foss-example#readme) for OSS related files.
+
+:::
+
+All repositories must contain the following files and folders:
 
 ```shell
 /docs
 /charts
+AUTHORS.txt
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+DEPENDENCIES
+LICENSE.txt
+NOTICE.md
 README.md
 INSTALL.md
+SECURITY.md
 ```
 
 ## Why
 
-- The `/docs` directory should contain product related documentation for the Tractus-X product.
-- The `/charts` directory must contain the Helm chart files for the Tractus-X product.
-- The `README.md` file shall contain a basic product description and installation instructions (and/or reference
-  to `INSTALL.md`).
-- The `INSTALL.md` shall contain a detailed installation instruction for the Tractus-X product.
+To make your repository Open Source ready and apply to Eclipse standards as well as to Eclipse-TractusX TRGs the
+given repository structure must be met.
+
+### Directories
+
+#### /docs
+
+The `/docs` directory should contain detailed product related documentation for the Tractus-X product. Folder structure
+inside this directory is the responsibility of the repository owner/product team.
+
+#### /charts
+
+The `/charts` directory must contain the Helm chart files for the Tractus-X product. For more information about Helm
+Chart structure, refer to [TRG 5.01 ff](../trg-5/trg-5-1).
+
+### Files
+
+#### AUTHORS.md (optional)
+
+Add a `AUTHORS.md` file at root level to your GitHub repository if you want to mention the authors of the code. Example
+content can be found [here](assets/AUTHORS.txt).
+
+#### CODE_OF_CONDUCT.md
+
+Add a `CODE_OF_CONDUCT.md` file at root level to your GitHub repository with content of
+this [example](assets/CODE_OF_CONDUCT.txt).
+
+#### CONTRIBUTING.md
+
+Add a `CONTRIBUTING.md` file at root level to your GitHub repository with content of
+this [example](assets/CONTRIBUTING.txt).
+
+#### DEPENDENCIES
+
+Add a `DEPENDENCIES` file at root level to your GitHub repository. The file contains a list of all 3rd party libraries
+used with your code. Create the content for this file using the Eclipse Dash
+Tool: [Example](https://github.com/eclipse-tractusx/sldt-semantic-hub/blob/main/DEPENDENCIES), created
+with [Eclipse Dash Tool](https://github.com/eclipse/dash-licenses#readme).
+
+#### LICENSE
+
+Add a `LICENSE` file at root level to your GitHub repository with content of [Apache-2.0 license](assets/LICENSE.txt).
+
+#### NOTICE.md
+
+Add a `NOTICE.md` file at root level to your GitHub repository with content of this [example](assets/NOTICE.txt).
+
+#### README.md
+
+The `README.md` file shall contain a basic product description and installation instructions (and/or reference
+to `INSTALL.md`).
+
+#### INSTALL.md
+
+The `INSTALL.md` shall contain a detailed installation instruction for the Tractus-X product.
+
+#### SECURITY.md
+
+Add a `SECURITY.md` file at root level to your GitHub repository with content of this [example](assets/SECURITY.txt).


### PR DESCRIPTION
Add more details to repository structure requirements for Eclipse-Tractusx repositories to be OSS/Eclipse compliant.