### PR TITLE
Dark theme palette overwrited

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -18,13 +18,22 @@
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme='dark'] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
+[data-theme="dark"] {
+  --ifm-color-primary: #faa023;
+  --ifm-color-primary-dark: #f99407;
+  --ifm-color-primary-darker: #ed8c05;
+  --ifm-color-primary-darkest: #c37304;
+  --ifm-color-primary-light: #fbac3f;
+  --ifm-color-primary-lighter: #fbb24d;
+  --ifm-color-primary-lightest: #fcc477;
+  --ifm-navbar-background-color: #000;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+}
+
+.footer--dark {
+  --ifm-footer-background-color: #000;
+}
+
+.navbar {
+  box-shadow: none;
 }


### PR DESCRIPTION
At `src/css/custom.css` the dark theme colours have been overwritten with the _Figma_ specifications.

Note: The header's background colour needs to be fixed, it must blend with the background of the body in future tasks.