### PR TITLE
dark theme palette overwritten

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -19,12 +19,18 @@
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
+  --ifm-color-primary: #faa023;
+  --ifm-color-primary-dark: #f99407;
+  --ifm-color-primary-darker: #ed8c05;
+  --ifm-color-primary-darkest: #c37304;
+  --ifm-color-primary-light: #fbac3f;
+  --ifm-color-primary-lighter: #fbb24d;
+  --ifm-color-primary-lightest: #fcc477;
+  --ifm-background-color: #1e1e1e;
+  --ifm-navbar-background-color: #000;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+}
+
+.footer--dark {
+  --ifm-footer-background-color: #000;
 }


### PR DESCRIPTION
The dark theme colours are substituted according to the planning to match the desired design. The background colour of the footer & navigation is set to black for the moment, future changes in the background styles could be added.