### PR TITLE
add footer content in Eclipse Foundation section

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -98,6 +98,31 @@ const config = {
         style: 'dark',
         links: [
           {
+            title: 'Eclipse Foundation',
+            items: [
+              {
+                label: "Main Eclipse Foundation website",
+                href: "http://www.eclipse.org",
+              },
+              {
+                label: "Privacy policy",
+                href: "http://www.eclipse.org/legal/privacy.php",
+              },
+              {
+                label: "Website terms of use",
+                href: "http://www.eclipse.org/legal/termsofuse.php",
+              },
+              {
+                label: "Copyright agent",
+                href: "http://www.eclipse.org/legal/copyright.php",
+              },
+              {
+                label: "Legal",
+                href: "http://www.eclipse.org/legal",
+              },
+            ],
+          },
+          {
             title: 'Community',
             items: [
               {


### PR DESCRIPTION
This PR includes more content to the footer of the web page, where the section/column `Eclipse Foundation` is added with its respective links to external pages, the UI displays:  

<img width="1597" alt="Screenshot 2023-01-16 at 10 55 38" src="https://user-images.githubusercontent.com/68547995/212649843-94f6b9ce-e7a4-4321-a194-c6e733a513e2.png">

This PR fixed issue #60 
