### PR TITLE
feat: add eclipse gh org checks

### DIFF
--- a/docs/github-checks.mdx
+++ b/docs/github-checks.mdx
@@ -1,0 +1,8 @@
+# Central Github Checks
+
+Central checks for all github repositories in [eclipse-tractusx](https://github.com/eclipse-tractusx) Github organization. You can check the details below or visit [here](https://tractusx-gh-org-checks.core.demo.catena-x.net/)
+
+<div>
+    <object type="text/html" data="https://tractusx-gh-org-checks.core.demo.catena-x.net/" width="100%" height="1000px" >
+    </object>
+</div>

--- a/sidebars.js
+++ b/sidebars.js
@@ -46,6 +46,7 @@ const sidebars = {
                 },
             ],
         },
+        'github-checks'
     ],
     kits: [
         'kits',


### PR DESCRIPTION
- Central Github Checks page
- Embedded `https://tractusx-gh-org-checks.core.demo.catena-x.net/`

Remarks: 

- Url currently unreachable until [corresponding PR](https://github.com/catenax-ng/k8s-cluster-stack/pull/296) is approved and merged
- Double scrollbar will be addressed in a future gh-org-checks release, not from this application