### PR TITLE
Add Copyright Header to components

### DIFF
--- a/src/components/AboutUsCard/index.js
+++ b/src/components/AboutUsCard/index.js
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
 import React from "react";
 import Link from "@docusaurus/Link";
 import styles from "./styles.module.css";

--- a/src/components/AboutUsCard/index.js
+++ b/src/components/AboutUsCard/index.js
@@ -1,14 +1,22 @@
-/********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
- *
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- *
+ * 
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
 import React from "react";

--- a/src/components/AboutUsContent/index.js
+++ b/src/components/AboutUsContent/index.js
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
 import React from "react";
 import styles from "./styles.module.css";
 

--- a/src/components/AboutUsContent/index.js
+++ b/src/components/AboutUsContent/index.js
@@ -1,14 +1,22 @@
-/********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
- *
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- *
+ * 
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
 import React from "react";

--- a/src/components/AboutUsHeader/index.js
+++ b/src/components/AboutUsHeader/index.js
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
 import React from "react";
 import Link from "@docusaurus/Link";
 import TractusXSvg from '../../../static/img/logo_tractus-x.svg'

--- a/src/components/AboutUsHeader/index.js
+++ b/src/components/AboutUsHeader/index.js
@@ -1,14 +1,22 @@
-/********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
- *
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- *
+ * 
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
 import React from "react";

--- a/src/components/CarouselComponent/index.js
+++ b/src/components/CarouselComponent/index.js
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
 import React from "react";
 import Link from "@docusaurus/Link";
 import Slider from "react-slick";

--- a/src/components/CarouselComponent/index.js
+++ b/src/components/CarouselComponent/index.js
@@ -1,14 +1,22 @@
-/********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
- *
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- *
+ * 
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
 import React from "react";

--- a/src/components/DeveloperContent/index.js
+++ b/src/components/DeveloperContent/index.js
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
 import React from "react";
 import styles from "./styles.module.css";
 

--- a/src/components/DeveloperContent/index.js
+++ b/src/components/DeveloperContent/index.js
@@ -1,14 +1,22 @@
-/********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
- *
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- *
+ * 
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
 import React from "react";

--- a/src/components/DeveloperHeader/index.js
+++ b/src/components/DeveloperHeader/index.js
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
 import React from "react";
 import KitsCoreSvg from '@site/static/img/kits&core.svg'
 

--- a/src/components/DeveloperHeader/index.js
+++ b/src/components/DeveloperHeader/index.js
@@ -1,14 +1,22 @@
-/********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
- *
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- *
+ * 
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
 import React from "react";

--- a/src/components/FAQsComponent/index.js
+++ b/src/components/FAQsComponent/index.js
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
 import React from "react";
 import Link from "@docusaurus/Link";
 

--- a/src/components/FAQsComponent/index.js
+++ b/src/components/FAQsComponent/index.js
@@ -1,14 +1,22 @@
-/********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
- *
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- *
+ * 
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
 import React from "react";

--- a/src/components/HomePageHeader/index.js
+++ b/src/components/HomePageHeader/index.js
@@ -1,14 +1,22 @@
-/********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
- *
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- *
+ * 
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
 import React from "react";

--- a/src/components/HomePageHeader/index.js
+++ b/src/components/HomePageHeader/index.js
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
 import React from "react";
 import Link from "@docusaurus/Link";
 import NewsTicker from "../NewsTicker";

--- a/src/components/KitsCard/index.js
+++ b/src/components/KitsCard/index.js
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
 import React from "react";
 import styles from "./styles.module.css";
 

--- a/src/components/KitsCard/index.js
+++ b/src/components/KitsCard/index.js
@@ -1,14 +1,22 @@
-/********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
- *
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- *
+ * 
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
 import React from "react";

--- a/src/components/KitsGallery/index.js
+++ b/src/components/KitsGallery/index.js
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
 import React from "react";
 import Link from "@docusaurus/Link";
 import styles from "./styles.module.css";

--- a/src/components/KitsGallery/index.js
+++ b/src/components/KitsGallery/index.js
@@ -1,14 +1,22 @@
-/********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
- *
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- *
+ * 
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
 import React from "react";

--- a/src/components/NewsTicker/index.js
+++ b/src/components/NewsTicker/index.js
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
 import React from "react";
 import Link from "@docusaurus/Link";
 import styles from "./styles.module.css";

--- a/src/components/NewsTicker/index.js
+++ b/src/components/NewsTicker/index.js
@@ -1,14 +1,22 @@
-/********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
- *
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- *
+ * 
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
 import React from "react";

--- a/src/pages/AboutUs/index.js
+++ b/src/pages/AboutUs/index.js
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
 import React from "react";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";

--- a/src/pages/AboutUs/index.js
+++ b/src/pages/AboutUs/index.js
@@ -1,14 +1,22 @@
-/********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
- *
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- *
+ * 
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
 import React from "react";

--- a/src/pages/Developer/index.js
+++ b/src/pages/Developer/index.js
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
 import React from "react";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";

--- a/src/pages/Developer/index.js
+++ b/src/pages/Developer/index.js
@@ -1,14 +1,22 @@
-/********************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
- *
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- *
+ * 
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
- *
- * SPDX-License-Identifier: EPL-2.0
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
 import React from "react";

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,3 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
 import React from "react";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";


### PR DESCRIPTION
This PR solves issue #74 

The next header:

![Screenshot 2023-01-24 at 15 38 37](https://user-images.githubusercontent.com/68547995/214324035-87770ca6-cd02-41f8-9eba-2f16f440751b.png)

Has been added to the `React` components and pages in:
- `.src/components/*`
-  `./src/pages/AboutUs`
- `./src/pages/Developer` 
