### PR TITLE
Change/navbar styles

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -46,6 +46,31 @@
   --ifm-navbar-link-color: #fff;
 }
 
+.navbar {
+  height: 74px;
+}
+
+.navbar__items {
+  margin: 0 20px;
+}
+
+.navbar__brand {
+  font-family: "Manrope", sans-serif;
+  margin-right: 32px;
+}
+
+.navbar__title {
+  font-weight: bolder;
+  font-size: 18px;
+}
+
+.navbar__link {
+  margin: 0 16px;
+  font-family: "Manrope", sans-serif;
+  font-size: 14px;
+  font-weight: bold;
+}
+
 .footer--dark {
   --ifm-footer-background-color: #000;
 }


### PR DESCRIPTION
This PR solves issue #86 

The new look of the top navigation bar is: 

<img width="1764" alt="Screenshot 2023-01-25 at 19 30 50" src="https://user-images.githubusercontent.com/68547995/214651736-cd389fe0-8c88-4f46-972a-b715cd4c90ab.png">

Where the height has been increase and the spacing between the items as well, the font-size is decrease, the left and right padding of the logo and Github link is increased

