### PR TITLE
Add/community and versions pages content

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -130,6 +130,11 @@ const config = {
             position: 'left',
             label: 'Developer Hub',
           },
+          {
+            to: "/community",
+            position: "left",
+            label: "Community",
+          },
           /* {to: '/blog', label: 'Blog', position: 'left'}, */
           {
             href: 'https://github.com/eclipse-tractusx/eclipse-tractusx.github.io',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -135,6 +135,11 @@ const config = {
             position: "left",
             label: "Community",
           },
+          {
+            to: "/versions",
+            position: "left",
+            label: "Versions",
+          },
           /* {to: '/blog', label: 'Blog', position: 'left'}, */
           {
             href: 'https://github.com/eclipse-tractusx/eclipse-tractusx.github.io',

--- a/src/pages/community.md
+++ b/src/pages/community.md
@@ -1,0 +1,9 @@
+---
+title: Community
+---
+
+# Community
+
+## How can I contribute to Tractus-X?
+
+Anyone can become a contributor or committer to the Eclipse Tractus-X project as part of the Eclipse development process. To build an active open-source community, all ecosystem participants are encouraged to report and fix bugs / patches and implement enhancements according to the Tractus-X timeline and backlog. More coming soon.

--- a/src/pages/versions.md
+++ b/src/pages/versions.md
@@ -1,0 +1,29 @@
+---
+title: Versions
+---
+
+# Versions
+
+## Releases
+
+To realize an active open-source community the Catena-X association will support the coordination of the Eclipse Tractus-X project in 2023, which was initiated by the companies of the Catena-X consortia. In addition, a release roadmap will be published in a reasonable amount of time.
+
+The release roadmap will include a timeline of more than six months to allow end-user and software providers sufficient time to adopt changes. In case of breaking changes, the changes will be announced early enough and an upgrade period will to be coordinated with all affected partners in the future.
+
+## Release Cycle
+
+Tractus-X releases are currently planned to happen four times a year depending on the type of service. The release process can be divided in three phases:
+
+- Feature Definition
+- Feature Implementation
+- Bug Fixing and Stabilization
+
+## Versioning
+
+Following the [Semantic Versioning](https://semver.org/) terminology, Tractus-X versions are expressed as below:
+
+- MAJOR version (1.Y.Z) when you make incompatible API changes. Participants of the operating environment must implement the latest version immediately to ensure the overall compatibility and functionality of the data space.
+
+- MINOR version (X.1.Z) when you add functionality in a backwards compatible manner. Participants of the operating environment should implement at least one of the recent two minor releases.
+
+- PATCH version (X.Y.1) when you make backwards compatible bug fixes. Participants of the operating environment should implement the latest patch version as soon as possible to ensure security among other things.


### PR DESCRIPTION
This PR solves issue #96 

Both pages has been added as `.md` files under the `./src/pages` folder along with the corresponding `NavBar` items: `Community` and `Versions`.

The resultant UI looks like:

- Community page:
<img width="1752" alt="Screenshot 2023-01-26 at 11 43 47" src="https://user-images.githubusercontent.com/68547995/214821141-2817e7af-7483-47ab-bae3-153e4fa806d3.png">

- Versions page:
<img width="1746" alt="Screenshot 2023-01-26 at 11 43 33" src="https://user-images.githubusercontent.com/68547995/214821210-cc21d923-0a32-430b-b59b-d83c920d35a4.png">
