### PR TITLE
Add/product overview

### DIFF
--- a/src/components/KitsGallery/index.js
+++ b/src/components/KitsGallery/index.js
@@ -60,9 +60,9 @@ export default function KitsGallery() {
 
         <div className={styles.gallery_container}>
           {
-            kits.map((kit)=> {
+            kits.map((kit, index)=> {
               return(
-                <div className={styles.gallery_item}>
+                <div key={index} className={styles.gallery_item}>
                   <Link to={kit.pageRoute} className={styles.gallery_link}>
                     <img src={kit.img} className={styles.item_img}/>
                   </Link>

--- a/src/components/KitsGallery/index.js
+++ b/src/components/KitsGallery/index.js
@@ -75,4 +75,3 @@ export default function KitsGallery() {
     </section>
   );
 }
-

--- a/src/components/ProductOverview/index.js
+++ b/src/components/ProductOverview/index.js
@@ -19,13 +19,55 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
- import React from "react";
- import styles from "./styles.module.css";
+import React from "react";
+import ProductOverviewCard from "../ProductOverviewCard";
+
+import styles from "./styles.module.css";
  
- export default function ProductOverview() {
-   return (
-     <section className={styles.about_us}>
-       <h1>Product Overview</h1>
-     </section>
-   );
- }
+export default function ProductOverview() {
+	const products = [
+    {
+        productName: "first",
+        productDescription: "bla",
+        githubRepo:  "leading-product-repo-link-one",
+        committers: [
+            "@githubhandle",
+            "@anothergithubhandle,"
+        ],
+        mailTo: "mailto:dev-mailing?subject=abc"
+    },
+		{
+			productName: "second",
+			productDescription: "bla bla",
+			githubRepo:  "leading-product-repo-link-two",
+			committers: [
+					"@githubhandle",
+					"@anothergithubhandle,"
+			],
+			mailTo: "mailto:dev-mailing?subject=abc"
+		},
+		{
+			productName: "third",
+			productDescription: "bla bla bla",
+			githubRepo:  "leading-product-repo-link-third",
+			committers: [
+					"@githubhandle",
+					"@anothergithubhandle,"
+			],
+			mailTo: "mailto:dev-mailing?subject=abc"
+		},
+	]
+
+  return (
+  	<section className={styles.product_overview}>
+    	<h1>Product Overview</h1>
+    	<div className={styles.container}>
+				{products.map((product, index) => {
+					return(
+					<ProductOverviewCard key={index} {...product} />
+					)
+				})}
+    	</div>
+   </section>
+  );
+}

--- a/src/components/ProductOverview/index.js
+++ b/src/components/ProductOverview/index.js
@@ -38,8 +38,7 @@ export default function ProductOverview() {
 				"https://github.com/ntruchsess",
 				"https://github.com/oyo"
 			],
-			// mailTo:"<a href="tractusx-dev@eclipse.org?subject= Request Portal & Marketplace Team">Contact Us</a>"
-			mailTo: "tractusx-dev@eclipse.org"
+			mailTo: "tractusx-dev@eclipse.org?subject=Request Portal and Marketplace Team"
 		},
 	]
 

--- a/src/components/ProductOverview/index.js
+++ b/src/components/ProductOverview/index.js
@@ -19,30 +19,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import React from "react";
-import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-import Layout from "@theme/Layout";
-import DeveloperHeader from "../../components/DeveloperHeader";
-import DeveloperContent from "../../components/DeveloperContent";
-import KitsGallery from "../../components/KitsGallery";
-import ProductOverview from "../../components/ProductOverview";
-
-import styles from "./styles.module.css";
-
-
-export default function DeveloperPage() {
-  const { siteConfig } = useDocusaurusContext();
-  return (
-    <Layout
-      title={'Developer'}
-      description="Description will go into a meta tag in <head />"
-    >
-      <DeveloperHeader />
-      <main>
-        <DeveloperContent />
-        <KitsGallery />
-        <ProductOverview />
-      </main>
-    </Layout>
-  );
-}
+ import React from "react";
+ import styles from "./styles.module.css";
+ 
+ export default function ProductOverview() {
+   return (
+     <section className={styles.about_us}>
+       <h1>Product Overview</h1>
+     </section>
+   );
+ }

--- a/src/components/ProductOverview/index.js
+++ b/src/components/ProductOverview/index.js
@@ -41,36 +41,6 @@ export default function ProductOverview() {
 			// mailTo:"<a href="tractusx-dev@eclipse.org?subject= Request Portal & Marketplace Team">Contact Us</a>"
 			mailTo: "tractusx-dev@eclipse.org"
 		},
-		{
-			productName: "Portal & Marketplaces",
-			productDescription: "The Portal & Marketplaces product offers the entry point into the Catena-X data room for registration, (technical) onboarding and beyond that for all participants. In addition, marketplaces enable solution providers to offer various solutions (e.g., business applications, services). to end customers.", 
-			githubRepo: [
-				"https://github.com/eclipse-tractusx/portal-backend",
-			  "https://github.com/eclipse-tractusx/portal-frontend"
-			], 
-			committers: [
-				"https://github.com/evegufy", 
-				"https://github.com/ntruchsess",
-				"https://github.com/oyo"
-			],
-			// mailTo:"<a href="tractusx-dev@eclipse.org?subject= Request Portal & Marketplace Team">Contact Us</a>"
-			mailTo: "tractusx-dev@eclipse.org"
-		},
-		{
-			productName: "Portal & Marketplaces",
-			productDescription: "The Portal & Marketplaces product offers the entry point into the Catena-X data room for registration, (technical) onboarding and beyond that for all participants. In addition, marketplaces enable solution providers to offer various solutions (e.g., business applications, services). to end customers.", 
-			githubRepo: [
-				"https://github.com/eclipse-tractusx/portal-backend",
-			  "https://github.com/eclipse-tractusx/portal-frontend"
-			], 
-			committers: [
-				"https://github.com/evegufy", 
-				"https://github.com/ntruchsess",
-				"https://github.com/oyo"
-			],
-			// mailTo:"<a href="tractusx-dev@eclipse.org?subject= Request Portal & Marketplace Team">Contact Us</a>"
-			mailTo: "tractusx-dev@eclipse.org"
-		},
 	]
 
   return (

--- a/src/components/ProductOverview/index.js
+++ b/src/components/ProductOverview/index.js
@@ -27,18 +27,20 @@ import styles from "./styles.module.css";
 export default function ProductOverview() {
 	const products = [
     {
-        productName: "first",
-        productDescription: "bla",
+        productName: "First Product Name",
+        productDescription: "Lorem kfrk spofsfsm sifsif ilrfrfm oslwd holla Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et",
         githubRepo:  "leading-product-repo-link-one",
         committers: [
             "@githubhandle",
-            "@anothergithubhandle,"
+            "@anothergithubhandle,",
+            "@anothergithubhandle,",
+
         ],
         mailTo: "mailto:dev-mailing?subject=abc"
     },
 		{
-			productName: "second",
-			productDescription: "bla bla",
+			productName: "Second Product Name",
+			productDescription: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, Lorem kfrk spofsfsm sifsif ilrfrfm oslwd holla coca cola kilo espantised diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et bla bla",
 			githubRepo:  "leading-product-repo-link-two",
 			committers: [
 					"@githubhandle",
@@ -47,9 +49,19 @@ export default function ProductOverview() {
 			mailTo: "mailto:dev-mailing?subject=abc"
 		},
 		{
-			productName: "third",
-			productDescription: "bla bla bla",
+			productName: "Third Product Name",
+			productDescription: "bla bla bla Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et",
 			githubRepo:  "leading-product-repo-link-third",
+			committers: [
+					"@githubhandle",
+					"@anothergithubhandle,"
+			],
+			mailTo: "mailto:dev-mailing?subject=abc"
+		},
+		{
+			productName: "Fourth Product Name",
+			productDescription: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et bla bla bla bla",
+			githubRepo:  "leading-product-repo-link-fourth",
 			committers: [
 					"@githubhandle",
 					"@anothergithubhandle,"
@@ -60,7 +72,6 @@ export default function ProductOverview() {
 
   return (
   	<section className={styles.product_overview}>
-    	<h1>Product Overview</h1>
     	<div className={styles.container}>
 				{products.map((product, index) => {
 					return(

--- a/src/components/ProductOverview/index.js
+++ b/src/components/ProductOverview/index.js
@@ -73,11 +73,13 @@ export default function ProductOverview() {
   return (
   	<section className={styles.product_overview}>
     	<div className={styles.container}>
-				{products.map((product, index) => {
-					return(
-					<ProductOverviewCard key={index} {...product} />
-					)
-				})}
+				<div className={styles.product_box}>
+					{products.map((product, index) => {
+						return(
+						<ProductOverviewCard key={index} {...product} />
+						)
+					})}
+				</div>
     	</div>
    </section>
   );

--- a/src/components/ProductOverview/index.js
+++ b/src/components/ProductOverview/index.js
@@ -21,27 +21,11 @@
 
 import React from "react";
 import ProductOverviewCard from "../ProductOverviewCard";
+import { products } from "../../../utils/products";
 
 import styles from "./styles.module.css";
  
 export default function ProductOverview() {
-  const products = [
-    {
-      productName: "Portal & Marketplaces",
-      productDescription: "The Portal & Marketplaces product offers the entry point into the Catena-X data room for registration, (technical) onboarding and beyond that for all participants. In addition, marketplaces enable solution providers to offer various solutions (e.g., business applications, services). to end customers.", 
-      githubRepo: [
-        "https://github.com/eclipse-tractusx/portal-backend",
-        "https://github.com/eclipse-tractusx/portal-frontend"
-      ], 
-      committers: [
-        "https://github.com/evegufy", 
-        "https://github.com/ntruchsess",
-        "https://github.com/oyo"
-      ],
-      mailTo: "tractusx-dev@eclipse.org?subject=Request Portal and Marketplace Team"
-    },
-  ]
-
   return (
     <section className={styles.product_overview}>
       <div className={styles.container}>

--- a/src/components/ProductOverview/index.js
+++ b/src/components/ProductOverview/index.js
@@ -25,34 +25,34 @@ import ProductOverviewCard from "../ProductOverviewCard";
 import styles from "./styles.module.css";
  
 export default function ProductOverview() {
-	const products = [
-		{
-			productName: "Portal & Marketplaces",
-			productDescription: "The Portal & Marketplaces product offers the entry point into the Catena-X data room for registration, (technical) onboarding and beyond that for all participants. In addition, marketplaces enable solution providers to offer various solutions (e.g., business applications, services). to end customers.", 
-			githubRepo: [
-				"https://github.com/eclipse-tractusx/portal-backend",
-			  "https://github.com/eclipse-tractusx/portal-frontend"
-			], 
-			committers: [
-				"https://github.com/evegufy", 
-				"https://github.com/ntruchsess",
-				"https://github.com/oyo"
-			],
-			mailTo: "tractusx-dev@eclipse.org?subject=Request Portal and Marketplace Team"
-		},
-	]
+  const products = [
+    {
+      productName: "Portal & Marketplaces",
+      productDescription: "The Portal & Marketplaces product offers the entry point into the Catena-X data room for registration, (technical) onboarding and beyond that for all participants. In addition, marketplaces enable solution providers to offer various solutions (e.g., business applications, services). to end customers.", 
+      githubRepo: [
+        "https://github.com/eclipse-tractusx/portal-backend",
+        "https://github.com/eclipse-tractusx/portal-frontend"
+      ], 
+      committers: [
+        "https://github.com/evegufy", 
+        "https://github.com/ntruchsess",
+        "https://github.com/oyo"
+      ],
+      mailTo: "tractusx-dev@eclipse.org?subject=Request Portal and Marketplace Team"
+    },
+  ]
 
   return (
-  	<section className={styles.product_overview}>
-    	<div className={styles.container}>
-				<div className={styles.product_box}>
-					{products.map((product, index) => {
-						return(
-						<ProductOverviewCard key={index} {...product} />
-						)
-					})}
-				</div>
-    	</div>
+    <section className={styles.product_overview}>
+      <div className={styles.container}>
+        <div className={styles.product_box}>
+          {products.map((product, index) => {
+            return(
+            <ProductOverviewCard key={index} {...product} />
+            )
+          })}
+        </div>
+      </div>
    </section>
   );
 }

--- a/src/components/ProductOverview/index.js
+++ b/src/components/ProductOverview/index.js
@@ -26,47 +26,20 @@ import styles from "./styles.module.css";
  
 export default function ProductOverview() {
 	const products = [
-    {
-        productName: "First Product Name",
-        productDescription: "Lorem kfrk spofsfsm sifsif ilrfrfm oslwd holla Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et",
-        githubRepo:  "leading-product-repo-link-one",
-        committers: [
-            "@githubhandle",
-            "@anothergithubhandle,",
-            "@anothergithubhandle,",
-
-        ],
-        mailTo: "mailto:dev-mailing?subject=abc"
-    },
 		{
-			productName: "Second Product Name",
-			productDescription: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, Lorem kfrk spofsfsm sifsif ilrfrfm oslwd holla coca cola kilo espantised diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et bla bla",
-			githubRepo:  "leading-product-repo-link-two",
+			productName: "Portal & Marketplaces",
+			productDescription: "The Portal & Marketplaces product offers the entry point into the Catena-X data room for registration, (technical) onboarding and beyond that for all participants. In addition, marketplaces enable solution providers to offer various solutions (e.g., business applications, services). to end customers.", 
+			githubRepo: [
+				"https://github.com/eclipse-tractusx/portal-backend",
+			  "https://github.com/eclipse-tractusx/portal-frontend"
+			], 
 			committers: [
-					"@githubhandle",
-					"@anothergithubhandle,"
+				"https://github.com/evegufy", 
+				"https://github.com/ntruchsess",
+				"https://github.com/oyo"
 			],
-			mailTo: "mailto:dev-mailing?subject=abc"
-		},
-		{
-			productName: "Third Product Name",
-			productDescription: "bla bla bla Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et",
-			githubRepo:  "leading-product-repo-link-third",
-			committers: [
-					"@githubhandle",
-					"@anothergithubhandle,"
-			],
-			mailTo: "mailto:dev-mailing?subject=abc"
-		},
-		{
-			productName: "Fourth Product Name",
-			productDescription: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et bla bla bla bla",
-			githubRepo:  "leading-product-repo-link-fourth",
-			committers: [
-					"@githubhandle",
-					"@anothergithubhandle,"
-			],
-			mailTo: "mailto:dev-mailing?subject=abc"
+			// mailTo:"<a href="tractusx-dev@eclipse.org?subject= Request Portal & Marketplace Team">Contact Us</a>"
+			mailTo: "tractusx-dev@eclipse.org"
 		},
 	]
 

--- a/src/components/ProductOverview/index.js
+++ b/src/components/ProductOverview/index.js
@@ -41,6 +41,36 @@ export default function ProductOverview() {
 			// mailTo:"<a href="tractusx-dev@eclipse.org?subject= Request Portal & Marketplace Team">Contact Us</a>"
 			mailTo: "tractusx-dev@eclipse.org"
 		},
+		{
+			productName: "Portal & Marketplaces",
+			productDescription: "The Portal & Marketplaces product offers the entry point into the Catena-X data room for registration, (technical) onboarding and beyond that for all participants. In addition, marketplaces enable solution providers to offer various solutions (e.g., business applications, services). to end customers.", 
+			githubRepo: [
+				"https://github.com/eclipse-tractusx/portal-backend",
+			  "https://github.com/eclipse-tractusx/portal-frontend"
+			], 
+			committers: [
+				"https://github.com/evegufy", 
+				"https://github.com/ntruchsess",
+				"https://github.com/oyo"
+			],
+			// mailTo:"<a href="tractusx-dev@eclipse.org?subject= Request Portal & Marketplace Team">Contact Us</a>"
+			mailTo: "tractusx-dev@eclipse.org"
+		},
+		{
+			productName: "Portal & Marketplaces",
+			productDescription: "The Portal & Marketplaces product offers the entry point into the Catena-X data room for registration, (technical) onboarding and beyond that for all participants. In addition, marketplaces enable solution providers to offer various solutions (e.g., business applications, services). to end customers.", 
+			githubRepo: [
+				"https://github.com/eclipse-tractusx/portal-backend",
+			  "https://github.com/eclipse-tractusx/portal-frontend"
+			], 
+			committers: [
+				"https://github.com/evegufy", 
+				"https://github.com/ntruchsess",
+				"https://github.com/oyo"
+			],
+			// mailTo:"<a href="tractusx-dev@eclipse.org?subject= Request Portal & Marketplace Team">Contact Us</a>"
+			mailTo: "tractusx-dev@eclipse.org"
+		},
 	]
 
   return (

--- a/src/components/ProductOverview/styles.module.css
+++ b/src/components/ProductOverview/styles.module.css
@@ -5,7 +5,7 @@
 
 .product_overview {
 	width: 100%;
-	height: fit-content;
+	height: auto;
 	padding: 5rem 0;
 	display: flex;
 	justify-content: center;
@@ -13,14 +13,36 @@
 }
 
 .container {
-	width: 50vw;
+	width: 70vw;
 	height: fit-content;
+	padding: 0 7vw;
+}
+
+.product_box {
 	display: grid;
-	grid-template-columns: repeat(3, 1fr);
+	grid-template-columns: repeat(3, 32%);
 	column-gap: 1.5rem;
 	row-gap: 2rem;
 }
 
-@media screen and (max-width: 996px) {
-	
+@media screen and (max-width: 1230px) {
+	.container {
+		width: 80vw;
+		padding: 0 5vw;
+	}
+
+	.product_box {
+		grid-template-columns: repeat(2, 1fr);
+	}
+}
+
+@media screen and (max-width: 730px) {
+	.container {
+		width: 70vw;
+		padding: 0;
+	}
+
+	.product_box {
+		grid-template-columns: repeat(1, 1fr);
+	}
 }

--- a/src/components/ProductOverview/styles.module.css
+++ b/src/components/ProductOverview/styles.module.css
@@ -6,16 +6,15 @@
 .product_overview {
 	width: 100%;
 	height: auto;
-	padding: 5rem 0;
+	padding: 1rem 0;
 	display: flex;
 	justify-content: center;
 	align-items: center;
 }
 
 .container {
-	width: 80vw;
+	width: 100%;
 	height: fit-content;
-	padding: 0 7vw;
 }
 
 .product_box {
@@ -25,10 +24,9 @@
 	row-gap: 2rem;
 }
 
-@media screen and (max-width: 996px) {
+@media screen and (max-width: 1280px) {
 	.container {
-		width: 70vw;
-		padding: 0 5vw;
+		width: 90vw;
 	}
 
 	.product_box {
@@ -38,8 +36,7 @@
 
 @media screen and (max-width: 720px) {
 	.container {
-		width: 70vw;
-		padding: 0;
+		width: 80vw;
 	}
 
 	.product_box {

--- a/src/components/ProductOverview/styles.module.css
+++ b/src/components/ProductOverview/styles.module.css
@@ -3,7 +3,23 @@
 * and scoped locally.
 */
 
+.product_overview {
+	width: 100%;
+	height: fit-content;
+	padding: 5rem 0;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
 
+.container {
+	width: 50vw;
+	height: fit-content;
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	column-gap: 1.5rem;
+	row-gap: 2rem;
+}
 
 @media screen and (max-width: 996px) {
 	

--- a/src/components/ProductOverview/styles.module.css
+++ b/src/components/ProductOverview/styles.module.css
@@ -43,3 +43,4 @@
 		grid-template-columns: repeat(1, 1fr);
 	}
 }
+

--- a/src/components/ProductOverview/styles.module.css
+++ b/src/components/ProductOverview/styles.module.css
@@ -1,0 +1,10 @@
+/**
+* CSS files with the .module.css suffix will be treated as CSS modules
+* and scoped locally.
+*/
+
+
+
+@media screen and (max-width: 996px) {
+	
+}

--- a/src/components/ProductOverview/styles.module.css
+++ b/src/components/ProductOverview/styles.module.css
@@ -13,7 +13,7 @@
 }
 
 .container {
-	width: 70vw;
+	width: 80vw;
 	height: fit-content;
 	padding: 0 7vw;
 }
@@ -25,9 +25,9 @@
 	row-gap: 2rem;
 }
 
-@media screen and (max-width: 1230px) {
+@media screen and (max-width: 996px) {
 	.container {
-		width: 80vw;
+		width: 70vw;
 		padding: 0 5vw;
 	}
 
@@ -36,7 +36,7 @@
 	}
 }
 
-@media screen and (max-width: 730px) {
+@media screen and (max-width: 720px) {
 	.container {
 		width: 70vw;
 		padding: 0;

--- a/src/components/ProductOverview/styles.module.css
+++ b/src/components/ProductOverview/styles.module.css
@@ -43,4 +43,3 @@
 		grid-template-columns: repeat(1, 1fr);
 	}
 }
-

--- a/src/components/ProductOverview/styles.module.css
+++ b/src/components/ProductOverview/styles.module.css
@@ -4,42 +4,43 @@
 */
 
 .product_overview {
-	width: 100%;
-	height: auto;
-	padding: 1rem 0;
-	display: flex;
-	justify-content: center;
-	align-items: center;
+  width: 100%;
+  height: auto;
+  padding: 1rem 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .container {
-	width: 100%;
-	height: fit-content;
+  width: 100%;
+  height: fit-content;
 }
 
 .product_box {
-	display: grid;
-	grid-template-columns: repeat(3, 32%);
-	column-gap: 1.5rem;
-	row-gap: 2rem;
+  display: grid;
+  grid-template-columns: repeat(3, 32%);
+  column-gap: 1.5rem;
+  row-gap: 2rem;
 }
 
 @media screen and (max-width: 1280px) {
-	.container {
-		width: 90vw;
-	}
+  .container {
+    width: 90vw;
+  }
 
-	.product_box {
-		grid-template-columns: repeat(2, 1fr);
-	}
+  .product_box {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 @media screen and (max-width: 720px) {
-	.container {
-		width: 80vw;
-	}
+  .container {
+    width: 80vw;
+  }
 
-	.product_box {
-		grid-template-columns: repeat(1, 1fr);
-	}
+  .product_box {
+    grid-template-columns: repeat(1, 1fr);
+  }
 }
+

--- a/src/components/ProductOverviewCard/index.js
+++ b/src/components/ProductOverviewCard/index.js
@@ -23,14 +23,20 @@ import React from "react";
 import styles from "./styles.module.css";
  
 export default function ProductOverviewCard({productName, productDescription, githubRepo, committers,mailTo}) {
-  return (
+  const MAX_LENGTH = 160;
+
+	return (
     <div className={styles.card}>
 			<div className={styles.title}>
 				<h3>{productName}</h3>
 			</div>
 
 			<div className={styles.card_description}>
-				<p>{productDescription}</p>
+				{
+					productDescription.length > MAX_LENGTH ? 
+						<p>{productDescription.substring(0, MAX_LENGTH)}...</p> :
+						<p>{productDescription}</p>
+				}
 			</div>
 
 			<div className={styles.subtitle}>

--- a/src/components/ProductOverviewCard/index.js
+++ b/src/components/ProductOverviewCard/index.js
@@ -26,6 +26,8 @@ export default function ProductOverviewCard({productName, productDescription, gi
   const [release, setRelease] = useState()
   let owner = githubRepo[0].split('/')[3]
   let repo = githubRepo[0].split('/')[4]
+  
+  let emailAddress = mailTo.split('?')[0];
 
   const MAX_LENGTH = 160;
 
@@ -107,7 +109,7 @@ export default function ProductOverviewCard({productName, productDescription, gi
       <div className={styles.card_contact}>
         <h5>Email:</h5>
         <a href={`mailto:${mailTo}`}>
-          {mailTo}
+          {emailAddress}
         </a>
       </div>
       

--- a/src/components/ProductOverviewCard/index.js
+++ b/src/components/ProductOverviewCard/index.js
@@ -25,17 +25,56 @@ import styles from "./styles.module.css";
 export default function ProductOverviewCard({productName, productDescription, githubRepo, committers,mailTo}) {
   return (
     <div className={styles.card}>
-			<h3>{productName}</h3>
-			<p>{productDescription}</p>
-			<p>{githubRepo}</p>		
-			{
-				committers?.map((committer, index)=> {
-					return (
-					<p key={index}>{committer}</p>
-					)
-				})
-			}		
-			<p>{mailTo}</p>
+			<div className={styles.title}>
+				<h3>{productName}</h3>
+			</div>
+
+			<div className={styles.card_description}>
+				<p>{productDescription}</p>
+			</div>
+
+			<div className={styles.subtitle}>
+				<h4>GitHub</h4>
+			</div>
+
+			<hr/>
+			
+			<div className={styles.card_github}>
+				<p>
+					<strong>
+						<a href={githubRepo}>
+							To Repository &gt;
+						</a>
+					</strong>
+				</p>
+				<p>
+					<strong>Committers:</strong> <br/>
+					<ul>
+						{
+							committers?.map((committer, index)=> {
+								return (
+									<li key={index}>{committer}</li>
+								)
+							})
+						}
+					</ul>
+				</p>			
+			</div>
+
+			<div className={styles.subtitle}>
+				<h4>Contact</h4>
+			</div>
+
+			<hr/>
+
+			<div className={styles.card_contact}>
+				<h4>Email:</h4>
+				<p>{mailTo}</p>
+			</div>
+
+			<div className={styles.version}>
+		    <h3>Version: 1.0.0</h3>
+			</div>	
     </div>
   );
 }

--- a/src/components/ProductOverviewCard/index.js
+++ b/src/components/ProductOverviewCard/index.js
@@ -19,11 +19,36 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import React from "react";
+import React, {useState, useEffect} from "react";
 import styles from "./styles.module.css";
  
 export default function ProductOverviewCard({productName, productDescription, githubRepo, committers,mailTo}) {
+	const [release, setRelease] = useState()
+	let owner = githubRepo[0].split('/')[3]
+	let repo = githubRepo[0].split('/')[4]
+
   const MAX_LENGTH = 160;
+
+	useEffect(() => {
+    fetch(`https://api.github.com/repos/${owner}/${repo}/releases/latest`,{
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+				'Accept': 'application/vnd.github.html+json'
+			}
+		}).then((res) => res.json())
+			.then((data) => {
+				setRelease(data.name)
+			})
+			.catch(err => console.log(err))
+  }, []);
+
+	const handleVersionString = (string) => {
+		let str = string.toLowerCase()
+		if (str.startsWith('v')) {
+			return str.slice(1)
+		} return str
+	}
 
 	return (
     <div className={styles.card}>
@@ -85,10 +110,12 @@ export default function ProductOverviewCard({productName, productDescription, gi
 					{mailTo}
 				</a>
 			</div>
-
-			<div className={styles.version}>
-		    {/* <h3>Version: 1.0.0</h3> */}
-			</div>	
+			
+			{
+				release != undefined ? 
+				<div className={styles.version}>Version:{handleVersionString(release)}</div> : 
+				<div className={styles.empty}></div>
+			}
     </div>
   );
 }

--- a/src/components/ProductOverviewCard/index.js
+++ b/src/components/ProductOverviewCard/index.js
@@ -1,0 +1,41 @@
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * 
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import React from "react";
+import styles from "./styles.module.css";
+ 
+export default function ProductOverviewCard({productName, productDescription, githubRepo, committers,mailTo}) {
+  return (
+    <div className={styles.card}>
+			<h3>{productName}</h3>
+			<p>{productDescription}</p>
+			<p>{githubRepo}</p>		
+			{
+				committers?.map((committer, index)=> {
+					return (
+					<p key={index}>{committer}</p>
+					)
+				})
+			}		
+			<p>{mailTo}</p>
+    </div>
+  );
+}

--- a/src/components/ProductOverviewCard/index.js
+++ b/src/components/ProductOverviewCard/index.js
@@ -81,11 +81,13 @@ export default function ProductOverviewCard({productName, productDescription, gi
 
 			<div className={styles.card_contact}>
 				<h5>Email:</h5>
-				<p>{mailTo}</p>
+				<a href={`mailto:${mailTo}`}>
+					{mailTo}
+				</a>
 			</div>
 
 			<div className={styles.version}>
-		    <h3>Version: 1.0.0</h3>
+		    {/* <h3>Version: 1.0.0</h3> */}
 			</div>	
     </div>
   );

--- a/src/components/ProductOverviewCard/index.js
+++ b/src/components/ProductOverviewCard/index.js
@@ -47,7 +47,6 @@ export default function ProductOverviewCard({productName, productDescription, gi
 						</a>
 					</strong>
 				</p>
-				<p>
 					<strong>Committers:</strong> <br/>
 					<ul>
 						{
@@ -57,8 +56,7 @@ export default function ProductOverviewCard({productName, productDescription, gi
 								)
 							})
 						}
-					</ul>
-				</p>			
+					</ul>		
 			</div>
 
 			<div className={styles.subtitle}>

--- a/src/components/ProductOverviewCard/index.js
+++ b/src/components/ProductOverviewCard/index.js
@@ -51,9 +51,9 @@ export default function ProductOverviewCard({productName, productDescription, gi
 				</strong>
 					<ul>
 						{
-							githubRepo?.map((committer, index)=> {
+							githubRepo?.map((repository, index)=> {
 								return (
-									<li key={index}><a href={committer}>{committer}</a></li>
+									<li key={index}><a href={repository}>{repository.substring(19, (repository.length))}</a></li>
 								)
 							})
 						}
@@ -66,7 +66,7 @@ export default function ProductOverviewCard({productName, productDescription, gi
 						{
 							committers?.map((committer, index)=> {
 								return (
-									<li key={index}><a href={committer}>{committer}</a></li>
+									<li key={index}><a href={committer}>{`@${committer.substring(19, (committer.length))}`}</a></li>
 								)
 							})
 						}

--- a/src/components/ProductOverviewCard/index.js
+++ b/src/components/ProductOverviewCard/index.js
@@ -23,99 +23,99 @@ import React, {useState, useEffect} from "react";
 import styles from "./styles.module.css";
  
 export default function ProductOverviewCard({productName, productDescription, githubRepo, committers,mailTo}) {
-	const [release, setRelease] = useState()
-	let owner = githubRepo[0].split('/')[3]
-	let repo = githubRepo[0].split('/')[4]
+  const [release, setRelease] = useState()
+  let owner = githubRepo[0].split('/')[3]
+  let repo = githubRepo[0].split('/')[4]
 
   const MAX_LENGTH = 160;
 
-	useEffect(() => {
-    fetch(`https://api.github.com/repos/${owner}/${repo}/releases/latest`,{
-			method: 'GET',
-			headers: {
-				'Content-Type': 'application/json',
-				'Accept': 'application/vnd.github.html+json'
-			}
-		}).then((res) => res.json())
-			.then((data) => {
-				setRelease(data.name)
-			})
-			.catch(err => console.log(err))
+  useEffect(() => {
+  fetch(`https://api.github.com/repos/${owner}/${repo}/releases/latest`,{
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/vnd.github.html+json'
+    }
+    }).then((res) => res.json())
+      .then((data) => {
+        setRelease(data.name)
+      })
+      .catch(err => console.log(err))
   }, []);
 
-	const handleVersionString = (string) => {
-		let str = string.toLowerCase()
-		if (str.startsWith('v')) {
-			return str.slice(1)
-		} return str
-	}
+  const handleVersionString = (string) => {
+    let str = string.toLowerCase()
+    if (str.startsWith('v')) {
+      return str.slice(1)
+    } return str
+  }
 
-	return (
+  return (
     <div className={styles.card}>
-			<div className={styles.title}>
-				<h3>{productName}</h3>
-			</div>
+      <div className={styles.title}>
+        <h3>{productName}</h3>
+      </div>
 
-			<div className={styles.card_description}>
-				{
-					productDescription.length > MAX_LENGTH ? 
-						<p>{productDescription.substring(0, MAX_LENGTH)}...</p> :
-						<p>{productDescription}</p>
-				}
-			</div>
+      <div className={styles.card_description}>
+        {
+          productDescription.length > MAX_LENGTH ? 
+            <p>{productDescription.substring(0, MAX_LENGTH)}...</p> :
+            <p>{productDescription}</p>
+        }
+      </div>
 
-			<div className={styles.subtitle}>
-				<h4>GitHub</h4>
-			</div>
+      <div className={styles.subtitle}>
+        <h4>GitHub</h4>
+      </div>
 
-			<hr/>
-			
-			<div className={styles.card_github}>
-				<strong>
-					<h5>Repository:</h5>
-				</strong>
-					<ul>
-						{
-							githubRepo?.map((repository, index)=> {
-								return (
-									<li key={index}><a href={repository}>{repository.substring(19, (repository.length))}</a></li>
-								)
-							})
-						}
-					</ul>	
-				
-				<strong>
-					<h5>Committers:</h5>
-				</strong>
-					<ul>
-						{
-							committers?.map((committer, index)=> {
-								return (
-									<li key={index}><a href={committer}>{`@${committer.substring(19, (committer.length))}`}</a></li>
-								)
-							})
-						}
-					</ul>		
-			</div>
+      <hr/>
+      
+      <div className={styles.card_github}>
+        <strong>
+          <h5>Repository:</h5>
+        </strong>
+          <ul>
+            {
+              githubRepo?.map((repository, index)=> {
+                return (
+                  <li key={index}><a href={repository}>{repository.substring(19, (repository.length))}</a></li>
+                )
+              })
+            }
+          </ul>	
+        
+        <strong>
+          <h5>Committers:</h5>
+        </strong>
+        <ul>
+          {
+            committers?.map((committer, index)=> {
+              return (
+                <li key={index}><a href={committer}>{`@${committer.substring(19, (committer.length))}`}</a></li>
+              )
+            })
+          }
+        </ul>		
+      </div>
 
-			<div className={styles.subtitle}>
-				<h4>Contact</h4>
-			</div>
+      <div className={styles.subtitle}>
+        <h4>Contact</h4>
+      </div>
 
-			<hr/>
+      <hr/>
 
-			<div className={styles.card_contact}>
-				<h5>Email:</h5>
-				<a href={`mailto:${mailTo}`}>
-					{mailTo}
-				</a>
-			</div>
-			
-			{
-				release != undefined ? 
-				<div className={styles.version}>Version:{handleVersionString(release)}</div> : 
-				<div className={styles.empty}></div>
-			}
+      <div className={styles.card_contact}>
+        <h5>Email:</h5>
+        <a href={`mailto:${mailTo}`}>
+          {mailTo}
+        </a>
+      </div>
+      
+      {
+        release != undefined ? 
+        <div className={styles.version}>Version:{handleVersionString(release)}</div> : 
+        <div className={styles.empty}></div>
+      }
     </div>
   );
 }

--- a/src/components/ProductOverviewCard/index.js
+++ b/src/components/ProductOverviewCard/index.js
@@ -40,19 +40,27 @@ export default function ProductOverviewCard({productName, productDescription, gi
 			<hr/>
 			
 			<div className={styles.card_github}>
-				<p>
-					<strong>
-						<a href={githubRepo}>
-							To Repository &gt;
-						</a>
-					</strong>
-				</p>
-					<strong>Committers:</strong> <br/>
+				<strong>
+					<h5>Repository:</h5>
+				</strong>
+					<ul>
+						{
+							githubRepo?.map((committer, index)=> {
+								return (
+									<li key={index}><a href={committer}>{committer}</a></li>
+								)
+							})
+						}
+					</ul>	
+				
+				<strong>
+					<h5>Committers:</h5>
+				</strong>
 					<ul>
 						{
 							committers?.map((committer, index)=> {
 								return (
-									<li key={index}>{committer}</li>
+									<li key={index}><a href={committer}>{committer}</a></li>
 								)
 							})
 						}
@@ -66,7 +74,7 @@ export default function ProductOverviewCard({productName, productDescription, gi
 			<hr/>
 
 			<div className={styles.card_contact}>
-				<h4>Email:</h4>
+				<h5>Email:</h5>
 				<p>{mailTo}</p>
 			</div>
 

--- a/src/components/ProductOverviewCard/styles.module.css
+++ b/src/components/ProductOverviewCard/styles.module.css
@@ -1,0 +1,10 @@
+/**
+* CSS files with the .module.css suffix will be treated as CSS modules
+* and scoped locally.
+*/
+
+
+
+@media screen and (max-width: 996px) {
+	
+}

--- a/src/components/ProductOverviewCard/styles.module.css
+++ b/src/components/ProductOverviewCard/styles.module.css
@@ -4,92 +4,93 @@
 */
 
 .card {
-	width: 100%;
-	height: 100%;
-	padding: 2rem 0;
-	display: flex;
-	flex-direction: column;
-	background-color: #000;
-	border: 1px solid #ed8c05;
-	border-radius: 15px;
-	color: #fff;
-	position: relative;
+  width: 100%;
+  height: 100%;
+  padding: 2rem 0;
+  display: flex;
+  flex-direction: column;
+  background-color: #000;
+  border: 1px solid #ed8c05;
+  border-radius: 15px;
+  color: #fff;
+  position: relative;
 }
 
 .title {
-	width: 90%;
-	height: auto;
-	background-color: #ed8c05;
-	padding-left: 1rem;
-	padding-top: 0.5rem;
-	padding-bottom: 0.5rem;
+  width: 90%;
+  height: auto;
+  background-color: #ed8c05;
+  padding-left: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
 }
 
 .title h3 {
-	margin: auto 0;
+  margin: auto 0;
 }
 
 .subtitle {
-	width: 40%;
-	background-color: #ed8c05;
-	padding-left: 0.5rem;
-	padding-top: 0.3rem;
-	padding-bottom: 0.3rem;
+  width: 40%;
+  background-color: #ed8c05;
+  padding-left: 0.5rem;
+  padding-top: 0.3rem;
+  padding-bottom: 0.3rem;
 }
 
 .subtitle h4 {
-	margin: auto 0;
+  margin: auto 0;
 }
 
 hr {
-	width: 90%;
-	margin: 0;
-	background-color: #faa023;
+  width: 90%;
+  margin: 0;
+  background-color: #faa023;
 }
 
 .card_description {
-	padding: 0.5rem 1.2rem;
-	margin: 0.5rem 0;
+  padding: 0.5rem 1.2rem;
+  margin: 0.5rem 0;
 }
 
 .card_description p {
-	font-weight: 300;
-	line-height: 1.7;
+  font-weight: 300;
+  line-height: 1.7;
 }
 
 .card_github {
-	padding: 0.5rem 1.2rem;
-	margin: 0.5rem 0;
+  padding: 0.5rem 1.2rem;
+  margin: 0.5rem 0;
 }
 
 .card_github ul {
-	list-style: square;
+  list-style: square;
 }
 
 .card_contact {
-	padding: 0.5rem 1.2rem;
-	margin: 1rem 0;
+  padding: 0.5rem 1.2rem;
+  margin: 1rem 0;
 }
 
 .card_contact p {
-	color: #ed8c05;
+  color: #ed8c05;
 }
 
 .version {
-	position: absolute;
-	bottom: 0;
-	background-color: #ed8c05;
-	width: 100%;
-	display: flex;
-	justify-content: center;
-	padding: 0.5rem 0;
-	border-radius: 0 0 15px 15px;
+  position: absolute;
+  bottom: 0;
+  background-color: #ed8c05;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem 0;
+  border-radius: 0 0 15px 15px;
 }
 
 .version h3 {
-	margin: auto 0;
+  margin: auto 0;
 }
 
 .empty {
-	background-color: #000;
+  background-color: #000;
 }
+

--- a/src/components/ProductOverviewCard/styles.module.css
+++ b/src/components/ProductOverviewCard/styles.module.css
@@ -3,7 +3,96 @@
 * and scoped locally.
 */
 
+.card {
+	width: 100%;
+	height: 100%;
+	padding: 2rem 0;
+	display: flex;
+	flex-direction: column;
+	background-color: #fff;
+	color: #1c1c1c;
+	position: relative;
+	-webkit-box-shadow: 7px 7px 10px 0px rgba(74,74,74,1);
+	-moz-box-shadow: 7px 7px 10px 0px rgba(74,74,74,1);
+	box-shadow: 7px 7px 10px 0px rgba(74,74,74,1);
+}
 
+.title {
+	width: 90%;
+	height: auto;
+	background-color: #ed8c05;
+	padding-left: 1rem;
+	padding-top: 0.5rem;
+	padding-bottom: 0.5rem;
+}
+
+.title h3 {
+	margin: auto 0;
+}
+
+.subtitle {
+	width: 35%;
+	background-color: #ed8c05;
+	padding-left: 1rem;
+	padding-top: 0.3rem;
+	padding-bottom: 0.3rem;
+}
+
+.subtitle h4 {
+	margin: auto 0;
+}
+
+hr {
+	width: 90%;
+	margin: 0;
+	background-color: #faa023;
+}
+
+.card_description {
+	padding: 0.5rem 1.2rem;
+	margin: 0.5rem 0;
+}
+
+.card_description p {
+	font-weight: 300;
+	line-height: 1.7;
+}
+
+.card_github {
+	padding: 0.5rem 1.2rem;
+	margin: 0.5rem 0;
+}
+
+.card_github ul {
+	list-style: square;
+}
+
+.card_contact {
+	padding: 0.5rem 1.2rem;
+	margin: 1rem 0;
+}
+
+.card_contact h4 {
+	color: #1c1c1c;
+}
+
+.card_contact p {
+	color: #ed8c05;
+}
+
+.version {
+	position: absolute;
+	bottom: 0;
+	background-color: #ed8c05;
+	width: 100%;
+	display: flex;
+	justify-content: center;
+	padding: 0.5rem 0;
+}
+
+.version h3 {
+	margin: auto 0;
+}
 
 @media screen and (max-width: 996px) {
 	

--- a/src/components/ProductOverviewCard/styles.module.css
+++ b/src/components/ProductOverviewCard/styles.module.css
@@ -9,8 +9,9 @@
 	padding: 2rem 0;
 	display: flex;
 	flex-direction: column;
-	background-color: #fff;
-	color: #1c1c1c;
+	background-color: #000;
+	border: 1px solid #ed8c05;
+	color: #fff;
 	position: relative;
 	-webkit-box-shadow: 7px 7px 10px 0px rgba(74,74,74,1);
 	-moz-box-shadow: 7px 7px 10px 0px rgba(74,74,74,1);
@@ -70,10 +71,6 @@ hr {
 .card_contact {
 	padding: 0.5rem 1.2rem;
 	margin: 1rem 0;
-}
-
-.card_contact h4 {
-	color: #1c1c1c;
 }
 
 .card_contact p {

--- a/src/components/ProductOverviewCard/styles.module.css
+++ b/src/components/ProductOverviewCard/styles.module.css
@@ -93,4 +93,3 @@ hr {
 .empty {
 	background-color: #000;
 }
-

--- a/src/components/ProductOverviewCard/styles.module.css
+++ b/src/components/ProductOverviewCard/styles.module.css
@@ -31,9 +31,9 @@
 }
 
 .subtitle {
-	width: 35%;
+	width: 40%;
 	background-color: #ed8c05;
-	padding-left: 1rem;
+	padding-left: 0.5rem;
 	padding-top: 0.3rem;
 	padding-bottom: 0.3rem;
 }

--- a/src/components/ProductOverviewCard/styles.module.css
+++ b/src/components/ProductOverviewCard/styles.module.css
@@ -11,11 +11,9 @@
 	flex-direction: column;
 	background-color: #000;
 	border: 1px solid #ed8c05;
+	border-radius: 15px;
 	color: #fff;
 	position: relative;
-	-webkit-box-shadow: 7px 7px 10px 0px rgba(74,74,74,1);
-	-moz-box-shadow: 7px 7px 10px 0px rgba(74,74,74,1);
-	box-shadow: 7px 7px 10px 0px rgba(74,74,74,1);
 }
 
 .title {
@@ -85,6 +83,7 @@ hr {
 	display: flex;
 	justify-content: center;
 	padding: 0.5rem 0;
+	border-radius: 0 0 15px 15px;
 }
 
 .version h3 {

--- a/src/components/ProductOverviewCard/styles.module.css
+++ b/src/components/ProductOverviewCard/styles.module.css
@@ -90,6 +90,7 @@ hr {
 	margin: auto 0;
 }
 
-@media screen and (max-width: 996px) {
-	
+.empty {
+	background-color: #000;
 }
+

--- a/src/pages/Developer/index.js
+++ b/src/pages/Developer/index.js
@@ -25,7 +25,6 @@ import Layout from "@theme/Layout";
 import DeveloperHeader from "../../components/DeveloperHeader";
 import DeveloperContent from "../../components/DeveloperContent";
 import KitsGallery from "../../components/KitsGallery";
-import ProductOverview from "../../components/ProductOverview";
 
 import styles from "./styles.module.css";
 
@@ -41,7 +40,6 @@ export default function DeveloperPage() {
       <main>
         <DeveloperContent />
         <KitsGallery />
-        <ProductOverview />
       </main>
     </Layout>
   );

--- a/src/pages/community.mdx
+++ b/src/pages/community.mdx
@@ -1,11 +1,17 @@
 ---
 title: Community
 ---
+import ProductOverview from '@site/src/components/ProductOverview'
 
 # Community
 
 ## How can I contribute to Tractus-X?
 
 Anyone can become a contributor or committer to the Eclipse Tractus-X project as part of the Eclipse development process. To build an active open-source community, all ecosystem participants are encouraged to report and fix bugs / patches and implement enhancements according to the Tractus-X timeline and backlog.\
+
+## Products
+
+<ProductOverview />
+
 
 More coming soon...

--- a/utils/products.js
+++ b/utils/products.js
@@ -1,0 +1,16 @@
+export const products = [
+  {
+    productName: "Portal & Marketplaces",
+    productDescription: "The Portal & Marketplaces product offers the entry point into the Catena-X data room for registration, (technical) onboarding and beyond that for all participants. In addition, marketplaces enable solution providers to offer various solutions (e.g., business applications, services). to end customers.", 
+    githubRepo: [
+      "https://github.com/eclipse-tractusx/portal-backend",
+      "https://github.com/eclipse-tractusx/portal-frontend"
+    ], 
+    committers: [
+      "https://github.com/evegufy", 
+      "https://github.com/ntruchsess",
+      "https://github.com/oyo"
+    ],
+    mailTo: "tractusx-dev@eclipse.org?subject=Request Portal and Marketplace Team"
+  },
+]


### PR DESCRIPTION
This PR solves issue #110

Includes 2 new components:
- `src/components/ProductOverview`
- `src/components/ProductOverviewCard`

The data is preserved in the `ProductOverview` component in a JSON format, where it's been mapped to generate each `ProductOverviewCard`, each object should contain the next properties:

```javascript
{
      productName: "Example Name",
      productDescription: "this is an example of a description.", 
      githubRepo: [
        "https://github.com/username/repository-name",
        "other....."
      ], 
      committers: [
        "https://github.com/username", 
        "other....."
      ],
      mailTo: "example@email.com?subject= example subject"
    },
``` 

_**The description is limited to 160 characters in the UI & to fetch the version from the repository, the first `githubRepo` (in case of more) is considered the lead one**_

The resultant UI: **important** the screenshot shows 3 columns, but the PR only includes the first card, which is the true data provided, is an example to show the difference when the version is fetched and when it is not.

<img width="1749" alt="Screenshot 2023-02-09 at 16 02 37" src="https://user-images.githubusercontent.com/68547995/217857779-2956387c-730b-4086-84a1-9ee7eab71edd.png">
