### PR TITLE
NOTICE.md trademark content added to comply legal requirements

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -8,7 +8,7 @@ See the AUTHORS file(s) distributed with this work for additional information re
 
 ## Trademarks
 
-Eclipse Tractus-X is a trademark of the Eclipse Foundation.
+Eclipse Tractus-X is a trademark of the Eclipse Foundation. Eclipse, and the Eclipse Logo are registered trademarks of the Eclipse Foundation.
 
 ## Copyright
 


### PR DESCRIPTION
This PR modify the content of the `NOTICE.md` file, ## Trademarks section:

**Eclipse Tractus-X is a trademark of the Eclipse Foundation. Eclipse, and the Eclipse Logo are registered trademarks of the Eclipse Foundation.**

@SebastianBezold @danielmiehle 