### PR TITLE
Fix/blog content

### DIFF
--- a/blog/2023-02-10-portal-is-live.md
+++ b/blog/2023-02-10-portal-is-live.md
@@ -12,11 +12,11 @@ authors:
     email: daniel.miehle@bmw.de
 ---
 
-<!--truncate-->
-
 ![eclipse tractus x logo](@site/static/img/logo-blog.png)
 
 We are thrilled to announce the launch of the Developer Portal for the Eclipse Tractus-X project! This portal is designed to provide developers with an easy way to access all of our resources and documentation.
+
+<!--truncate-->
 
 With this new portal, we aim to make it easier than ever before for developers around the world to get started building amazing projects on top of the Catena-X network. We have included our initial KITs and developer guides that will help you develop your solution. Step by step we will also provide a comprehensive overview of useful reference material.
 

--- a/blog/2023-02-10-portal-is-live.md
+++ b/blog/2023-02-10-portal-is-live.md
@@ -16,4 +16,8 @@ authors:
 
 ![eclipse tractus x logo](@site/static/img/logo-blog.png)
 
-We are thrilled to announce the launch of the Developer Portal for the Eclipse Tractus-X project! This portal is designed to provide developers with an easy way to access all of our resources and documentation. With this new portal, we aim to make it easier than ever before for developers around the world to get started building amazing projects on top of the Catena-X network. We have included our initial KITs and developer guides that will help you develop your solution. Step by step we will also provide a comprehensive overview of useful reference material. The best part? All these resources are free and open-source! So what’s stopping you from taking advantage right now? Let’s get coding together and build something amazing with Tractus-X today!
+We are thrilled to announce the launch of the Developer Portal for the Eclipse Tractus-X project! This portal is designed to provide developers with an easy way to access all of our resources and documentation.
+
+With this new portal, we aim to make it easier than ever before for developers around the world to get started building amazing projects on top of the Catena-X network. We have included our initial KITs and developer guides that will help you develop your solution. Step by step we will also provide a comprehensive overview of useful reference material.
+
+The best part? All these resources are free and open-source! So what’s stopping you from taking advantage right now? Let’s get coding together and build something amazing with Tractus-X today!


### PR DESCRIPTION
In the `blog/2023-02-10-portal-is-live.md` file, the content of the post is been truncated to display the image and the first paragraph at the News page level like previously discussed