### PR TITLE
chore: update docusaurus version 2.3.1

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,7 +1,7 @@
 npm/npmjs/-/accepts/1.3.8, MIT, approved, clearlydefined
 npm/npmjs/-/acorn-import-assertions/1.8.0, MIT, approved, clearlydefined
 npm/npmjs/-/acorn-walk/8.2.0, MIT, approved, clearlydefined
-npm/npmjs/-/acorn/8.8.1, MIT, approved, clearlydefined
+npm/npmjs/-/acorn/8.8.1, MIT, approved, #6951
 npm/npmjs/-/address/1.2.2, MIT, approved, clearlydefined
 npm/npmjs/-/aggregate-error/3.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/ajv-formats/2.1.1, MIT, approved, clearlydefined
@@ -10,7 +10,7 @@ npm/npmjs/-/ajv-keywords/5.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/ajv/6.12.6, MIT, approved, #979
 npm/npmjs/-/ajv/8.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/ajv/8.12.0, MIT AND OFL-1.1 AND (EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0), approved, #6025
-npm/npmjs/-/algoliasearch-helper/3.11.2, MIT, approved, #6628
+npm/npmjs/-/algoliasearch-helper/3.11.3, MIT, approved, #6628
 npm/npmjs/-/algoliasearch/4.14.3, MIT, approved, clearlydefined
 npm/npmjs/-/ansi-align/3.0.1, ISC, approved, clearlydefined
 npm/npmjs/-/ansi-html-community/0.0.8, Apache-2.0, approved, clearlydefined
@@ -59,7 +59,7 @@ npm/npmjs/-/boxen/6.2.1, MIT, approved, clearlydefined
 npm/npmjs/-/brace-expansion/1.1.11, MIT, approved, clearlydefined
 npm/npmjs/-/brace-expansion/2.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/braces/3.0.2, MIT, approved, clearlydefined
-npm/npmjs/-/browserslist/4.21.4, MIT, approved, clearlydefined
+npm/npmjs/-/browserslist/4.21.4, MIT, approved, #7034
 npm/npmjs/-/buffer-from/1.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/buffer/6.0.3, MIT, approved, clearlydefined
 npm/npmjs/-/bytes/3.0.0, MIT, approved, clearlydefined
@@ -128,7 +128,7 @@ npm/npmjs/-/connect-history-api-fallback/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/consola/2.15.3, MIT, approved, clearlydefined
 npm/npmjs/-/content-disposition/0.5.2, MIT, approved, clearlydefined
 npm/npmjs/-/content-disposition/0.5.4, MIT, approved, clearlydefined
-npm/npmjs/-/content-type/1.0.4, MIT, approved, clearlydefined
+npm/npmjs/-/content-type/1.0.4, MIT, approved, #6950
 npm/npmjs/-/convert-source-map/1.9.0, MIT, approved, clearlydefined
 npm/npmjs/-/cookie-signature/1.0.6, MIT, approved, clearlydefined
 npm/npmjs/-/cookie/0.5.0, MIT, approved, clearlydefined
@@ -229,7 +229,7 @@ npm/npmjs/-/esrecurse/4.3.0, BSD-2-Clause, approved, clearlydefined
 npm/npmjs/-/estraverse/4.3.0, BSD-2-Clause, approved, #518
 npm/npmjs/-/estraverse/5.3.0, BSD-2-Clause AND MIT, approved, #1557
 npm/npmjs/-/esutils/2.0.3, BSD-2-Clause AND BSD-3-Clause, approved, #120
-npm/npmjs/-/eta/1.12.3, MIT, approved, clearlydefined
+npm/npmjs/-/eta/2.0.0, , restricted, clearlydefined
 npm/npmjs/-/etag/1.8.1, MIT, approved, clearlydefined
 npm/npmjs/-/eval/0.1.8, MIT, approved, clearlydefined
 npm/npmjs/-/eventemitter3/4.0.7, MIT, approved, clearlydefined
@@ -350,7 +350,7 @@ npm/npmjs/-/icss-utils/5.1.0, ISC, approved, clearlydefined
 npm/npmjs/-/ieee754/1.2.1, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/-/ignore/5.2.4, MIT, approved, #5907
 npm/npmjs/-/image-size/1.0.2, MIT, approved, clearlydefined
-npm/npmjs/-/immer/9.0.17, MIT, approved, clearlydefined
+npm/npmjs/-/immer/9.0.17, MIT, approved, #7037
 npm/npmjs/-/import-fresh/3.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/import-lazy/2.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/imurmurhash/0.1.4, MIT, approved, clearlydefined
@@ -530,7 +530,7 @@ npm/npmjs/-/neo-async/2.6.2, MIT, approved, clearlydefined
 npm/npmjs/-/no-case/3.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/node-emoji/1.11.0, MIT, approved, clearlydefined
 npm/npmjs/-/node-fetch-h2/2.3.0, MIT, approved, clearlydefined
-npm/npmjs/-/node-fetch/2.6.7, MIT, approved, clearlydefined
+npm/npmjs/-/node-fetch/2.6.7, MIT, approved, #6954
 npm/npmjs/-/node-forge/1.3.1, (BSD-3-Clause OR GPL-2.0-only) AND MIT, approved, #3014
 npm/npmjs/-/node-readfiles/0.2.0, MIT, approved, #3479
 npm/npmjs/-/node-releases/2.0.8, MIT, approved, #1954
@@ -556,7 +556,7 @@ npm/npmjs/-/on-finished/2.4.1, MIT, approved, clearlydefined
 npm/npmjs/-/on-headers/1.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/once/1.4.0, ISC, approved, clearlydefined
 npm/npmjs/-/onetime/5.1.2, MIT, approved, clearlydefined
-npm/npmjs/-/open/8.4.0, MIT, approved, clearlydefined
+npm/npmjs/-/open/8.4.0, MIT, approved, #7102
 npm/npmjs/-/opener/1.5.2, MIT OR WTFPL OR (MIT AND WTFPL), approved, clearlydefined
 npm/npmjs/-/p-cancelable/1.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/p-limit/2.3.0, MIT, approved, clearlydefined
@@ -699,7 +699,7 @@ npm/npmjs/-/rechoir/0.6.2, MIT, approved, #981
 npm/npmjs/-/recursive-readdir/2.2.3, MIT, approved, clearlydefined
 npm/npmjs/-/redux-devtools-extension/2.13.9, MIT, approved, clearlydefined
 npm/npmjs/-/redux-thunk/2.4.2, MIT, approved, clearlydefined
-npm/npmjs/-/redux/4.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/redux/4.2.0, CC0-1.0 AND MIT, approved, #7046
 npm/npmjs/-/reftools/1.1.9, BSD-3-Clause AND (BSD-3-Clause AND MIT), approved, #3490
 npm/npmjs/-/regenerate-unicode-properties/10.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/regenerate/1.4.2, MIT, approved, clearlydefined
@@ -832,7 +832,7 @@ npm/npmjs/-/swagger2openapi/7.0.8, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/-/tapable/1.1.3, MIT, approved, clearlydefined
 npm/npmjs/-/tapable/2.2.1, MIT, approved, clearlydefined
 npm/npmjs/-/terser-webpack-plugin/5.3.6, MIT, approved, clearlydefined
-npm/npmjs/-/terser/5.16.1, BSD-2-Clause, approved, clearlydefined
+npm/npmjs/-/terser/5.16.1, BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause AND ISC, approved, #7045
 npm/npmjs/-/text-table/0.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/thenify-all/1.6.0, MIT, approved, clearlydefined
 npm/npmjs/-/thenify/3.3.1, MIT, approved, clearlydefined
@@ -857,7 +857,7 @@ npm/npmjs/-/type-fest/2.19.0, CC0-1.0 OR MIT OR (CC0-1.0 AND MIT), approved, cle
 npm/npmjs/-/type-is/1.6.18, MIT, approved, clearlydefined
 npm/npmjs/-/typedarray-to-buffer/3.1.5, MIT, approved, clearlydefined
 npm/npmjs/-/typescript/4.9.4, Apache-2.0 AND (CC-BY-4.0 AND LicenseRef-scancode-khronos AND LicenseRef-scancode-unicode AND MIT AND W3C-20150513), approved, #4979
-npm/npmjs/-/ua-parser-js/0.7.32, MIT, approved, clearlydefined
+npm/npmjs/-/ua-parser-js/0.7.33, MIT, approved, clearlydefined
 npm/npmjs/-/uc.micro/1.0.6, MIT, approved, #1022
 npm/npmjs/-/unherit/1.1.3, MIT, approved, clearlydefined
 npm/npmjs/-/unicode-canonical-property-names-ecmascript/2.0.0, MIT, approved, clearlydefined
@@ -896,6 +896,7 @@ npm/npmjs/-/use-composed-ref/1.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/use-editable/2.3.3, MIT, approved, clearlydefined
 npm/npmjs/-/use-isomorphic-layout-effect/1.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/use-latest/1.2.1, MIT, approved, clearlydefined
+npm/npmjs/-/use-sync-external-store/1.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/util-deprecate/1.0.2, MIT, approved, #5885
 npm/npmjs/-/util/0.10.4, MIT, approved, clearlydefined
 npm/npmjs/-/utila/0.4.0, MIT, approved, clearlydefined
@@ -1103,30 +1104,33 @@ npm/npmjs/@babel/template/7.20.7, MIT AND BSD-2-Clause AND BSD-3-Clause, approve
 npm/npmjs/@babel/traverse/7.20.12, MIT, approved, #4570
 npm/npmjs/@babel/types/7.20.7, MIT, approved, #4626
 npm/npmjs/@colors/colors/1.5.0, MIT, approved, clearlydefined
-npm/npmjs/@docsearch/css/3.3.2, MIT, approved, #6633
-npm/npmjs/@docsearch/react/3.3.2, MIT, approved, #6646
-npm/npmjs/@docusaurus/core/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/cssnano-preset/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/logger/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/mdx-loader/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/@docsearch/css/3.3.3, MIT, approved, #6633
+npm/npmjs/@docsearch/react/3.3.3, MIT, approved, #6646
+npm/npmjs/@docusaurus/core/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/cssnano-preset/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/logger/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/mdx-loader/2.3.1, , restricted, clearlydefined
 npm/npmjs/@docusaurus/module-type-aliases/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/plugin-content-blog/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/plugin-content-docs/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/plugin-content-pages/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/plugin-debug/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/plugin-google-analytics/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/plugin-google-gtag/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/plugin-sitemap/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/preset-classic/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/@docusaurus/module-type-aliases/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/plugin-content-blog/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/plugin-content-docs/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/plugin-content-pages/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/plugin-debug/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/plugin-google-analytics/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/plugin-google-gtag/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/plugin-google-tag-manager/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/plugin-sitemap/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/preset-classic/2.3.1, , restricted, clearlydefined
 npm/npmjs/@docusaurus/react-loadable/5.5.2, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/theme-classic/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/theme-common/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/theme-search-algolia/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/theme-translations/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/@docusaurus/theme-classic/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/theme-common/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/theme-search-algolia/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/theme-translations/2.3.1, , restricted, clearlydefined
 npm/npmjs/@docusaurus/types/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/utils-common/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/utils-validation/2.2.0, MIT, approved, clearlydefined
-npm/npmjs/@docusaurus/utils/2.2.0, MIT, approved, clearlydefined
+npm/npmjs/@docusaurus/types/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/utils-common/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/utils-validation/2.3.1, , restricted, clearlydefined
+npm/npmjs/@docusaurus/utils/2.3.1, , restricted, clearlydefined
 npm/npmjs/@emotion/babel-plugin/11.10.5, MIT, approved, clearlydefined
 npm/npmjs/@emotion/cache/11.10.5, MIT, approved, clearlydefined
 npm/npmjs/@emotion/hash/0.9.0, MIT, approved, clearlydefined
@@ -1176,7 +1180,7 @@ npm/npmjs/@polka/url/1.0.0-next.21, MIT, approved, clearlydefined
 npm/npmjs/@popperjs/core/2.11.6, MIT, approved, clearlydefined
 npm/npmjs/@redocly/ajv/8.11.0, MIT, approved, clearlydefined
 npm/npmjs/@redocly/openapi-core/1.0.0-beta.120, MIT AND Apache-2.0, approved, #6639
-npm/npmjs/@reduxjs/toolkit/1.9.1, MIT, approved, clearlydefined
+npm/npmjs/@reduxjs/toolkit/1.9.1, MIT AND (BSD-2-Clause AND MIT) AND Apache-2.0, approved, #7050
 npm/npmjs/@sideway/address/4.1.4, BSD-3-Clause AND MIT, approved, #3098
 npm/npmjs/@sideway/formula/3.0.1, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/@sideway/pinpoint/2.0.0, BSD-3-Clause, approved, clearlydefined
@@ -1246,7 +1250,7 @@ npm/npmjs/@types/sockjs/0.3.33, MIT, approved, clearlydefined
 npm/npmjs/@types/unist/2.0.6, MIT, approved, clearlydefined
 npm/npmjs/@types/ws/8.5.4, MIT, approved, #6016
 npm/npmjs/@types/yargs-parser/21.0.0, MIT, approved, clearlydefined
-npm/npmjs/@types/yargs/17.0.19, MIT, approved, clearlydefined
+npm/npmjs/@types/yargs/17.0.19, MIT, approved, #7054
 npm/npmjs/@webassemblyjs/ast/1.11.1, MIT, approved, clearlydefined
 npm/npmjs/@webassemblyjs/floating-point-hex-parser/1.11.1, MIT, approved, clearlydefined
 npm/npmjs/@webassemblyjs/helper-api-error/1.11.1, MIT, approved, clearlydefined

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "eclipse-tractusx-github-io",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/preset-classic": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/preset-classic": "^2.3.1",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@mdx-js/react": "^1.6.22",
@@ -1986,18 +1986,18 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.2.tgz",
-      "integrity": "sha512-dctFYiwbvDZkksMlsmc7pj6W6By/EjnVXJq5TEPd05MwQe+dcdHJgaIn1c8wfsucxHpIsdrUcgSkACHCq6aIhw=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.3.tgz",
+      "integrity": "sha512-6SCwI7P8ao+se1TUsdZ7B4XzL+gqeQZnBc+2EONZlcVa0dVrk0NjETxozFKgMv0eEGH8QzP1fkN+A1rH61l4eg=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.2.tgz",
-      "integrity": "sha512-ugILab2TYKSh6IEHf6Z9xZbOovsYbsdfo60PBj+Bw+oMJ1MHJ7pBt1TTcmPki1hSgg8mysgKy2hDiVdPm7XWSQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.3.tgz",
+      "integrity": "sha512-pLa0cxnl+G0FuIDuYlW+EBK6Rw2jwLw9B1RHIeS4N4s2VhsfJ/wzeCi3CWcs5yVfxLd5ZK50t//TMA5e79YT7Q==",
       "dependencies": {
         "@algolia/autocomplete-core": "1.7.4",
         "@algolia/autocomplete-preset-algolia": "1.7.4",
-        "@docsearch/css": "3.3.2",
+        "@docsearch/css": "3.3.3",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
@@ -2018,9 +2018,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
+      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
       "dependencies": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -2032,13 +2032,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/cssnano-preset": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-common": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-common": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -2059,7 +2059,7 @@
         "del": "^6.1.1",
         "detect-port": "^1.3.0",
         "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "html-minifier-terser": "^6.1.0",
@@ -2106,9 +2106,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.2.0.tgz",
-      "integrity": "sha512-mAAwCo4n66TMWBH1kXnHVZsakW9VAXJzTO4yZukuL3ro4F+JtkMwKfh42EG75K/J/YIFQG5I/Bzy0UH/hFxaTg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
+      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -2120,9 +2120,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
-      "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.3.1.tgz",
+      "integrity": "sha512-2lAV/olKKVr9qJhfHFCaqBIl8FgYjbUFwgUnX76+cULwQYss+42ZQ3grHGFvI0ocN2X55WcYe64ellQXz7suqg==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
@@ -2132,14 +2132,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.2.0.tgz",
-      "integrity": "sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.3.1.tgz",
+      "integrity": "sha512-Gzga7OsxQRpt3392K9lv/bW4jGppdLFJh3luKRknCKSAaZrmVkOQv2gvCn8LAOSZ3uRg5No7AgYs/vpL8K94lA==",
       "dependencies": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2166,6 +2166,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz",
       "integrity": "sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==",
+      "dev": true,
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
         "@docusaurus/types": "2.2.0",
@@ -2182,17 +2183,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.2.0.tgz",
-      "integrity": "sha512-0mWBinEh0a5J2+8ZJXJXbrCk1tSTNf7Nm4tYAl5h2/xx+PvH/Bnu0V+7mMljYm/1QlDYALNIIaT/JcoZQFUN3w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.3.1.tgz",
+      "integrity": "sha512-f5LjqX+9WkiLyGiQ41x/KGSJ/9bOjSD8lsVhPvYeUYHCtYpuiDKfhZE07O4EqpHkBx4NQdtQDbp+aptgHSTuiw==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-common": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-common": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -2211,18 +2212,37 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.2.0.tgz",
-      "integrity": "sha512-BOazBR0XjzsHE+2K1wpNxz5QZmrJgmm3+0Re0EVPYFGW8qndCWGNtXW/0lGKhecVPML8yyFeAmnUCIs7xM2wPw==",
+    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/module-type-aliases": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.3.1.tgz",
+      "integrity": "sha512-DxztTOBEruv7qFxqUtbsqXeNcHqcVEIEe+NQoI1oi2DBmKBhW/o0MIal8lt+9gvmpx3oYtlwmLOOGepxZgJGkw==",
+      "dependencies": {
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/module-type-aliases": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -2241,16 +2261,54 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.2.0.tgz",
-      "integrity": "sha512-+OTK3FQHk5WMvdelz8v19PbEbx+CNT6VSpx7nVOvMNs5yJCKvmqBJBQ2ZSxROxhVDYn+CZOlmyrC56NSXzHf6g==",
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/types": "2.3.1",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-pages": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.3.1.tgz",
+      "integrity": "sha512-E80UL6hvKm5VVw8Ka8YaVDtO6kWWDVUK4fffGvkpQ/AJQDOg99LwOXKujPoICC22nUFTsZ2Hp70XvpezCsFQaA==",
+      "dependencies": {
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -2263,14 +2321,33 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.2.0.tgz",
-      "integrity": "sha512-p9vOep8+7OVl6r/NREEYxf4HMAjV8JMYJ7Bos5fCFO0Wyi9AZEo0sCTliRd7R8+dlJXZEgcngSdxAUo/Q+CJow==",
+    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-debug": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.3.1.tgz",
+      "integrity": "sha512-Ujpml1Ppg4geB/2hyu2diWnO49az9U2bxM9Shen7b6qVcyFisNJTkVG2ocvLC7wM1efTJcUhBO6zAku2vKJGMw==",
+      "dependencies": {
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -2283,18 +2360,56 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.2.0.tgz",
-      "integrity": "sha512-+eZVVxVeEnV5nVQJdey9ZsfyEVMls6VyWTIj8SmX0k5EbqGvnIfET+J2pYEuKQnDIHxy+syRMoRM6AHXdHYGIg==",
+    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-analytics": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.3.1.tgz",
+      "integrity": "sha512-OHip0GQxKOFU8n7gkt3TM4HOYTXPCFDjqKbMClDD3KaDnyTuMp/Zvd9HSr770lLEscgPWIvzhJByRAClqsUWiQ==",
+      "dependencies": {
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
       },
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
@@ -2302,13 +2417,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.2.0.tgz",
-      "integrity": "sha512-6SOgczP/dYdkqUMGTRqgxAS1eTp6MnJDAQMy8VCF1QKbWZmlkx4agHDexihqmYyCujTYHqDAhm1hV26EET54NQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.3.1.tgz",
+      "integrity": "sha512-uXtDhfu4+Hm+oqWUySr3DNI5cWC/rmP6XJyAk83Heor3dFjZqDwCbkX8yWPywkRiWev3Dk/rVF8lEn0vIGVocA==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2319,17 +2434,73 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.2.0.tgz",
-      "integrity": "sha512-0jAmyRDN/aI265CbWZNZuQpFqiZuo+5otk2MylU9iVrz/4J7gSc+ZJ9cy4EHrEsW7PV8s1w18hIEsmcA1YgkKg==",
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-common": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-tag-manager": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.3.1.tgz",
+      "integrity": "sha512-Ww2BPEYSqg8q8tJdLYPFFM3FMDBCVhEM4UUqKzJaiRMx3NEoly3qqDRAoRDGdIhlC//Rf0iJV9cWAoq2m6k3sw==",
+      "dependencies": {
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.3.1.tgz",
+      "integrity": "sha512-8Yxile/v6QGYV9vgFiYL+8d2N4z4Er3pSHsrD08c5XI8bUXxTppMwjarDUTH/TRTfgAWotRbhJ6WZLyajLpozA==",
+      "dependencies": {
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-common": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
@@ -2342,26 +2513,65 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.2.0.tgz",
-      "integrity": "sha512-yKIWPGNx7BT8v2wjFIWvYrS+nvN04W+UameSFf8lEiJk6pss0kL6SG2MRvyULiI3BDxH+tj6qe02ncpSPGwumg==",
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/plugin-content-blog": "2.2.0",
-        "@docusaurus/plugin-content-docs": "2.2.0",
-        "@docusaurus/plugin-content-pages": "2.2.0",
-        "@docusaurus/plugin-debug": "2.2.0",
-        "@docusaurus/plugin-google-analytics": "2.2.0",
-        "@docusaurus/plugin-google-gtag": "2.2.0",
-        "@docusaurus/plugin-sitemap": "2.2.0",
-        "@docusaurus/theme-classic": "2.2.0",
-        "@docusaurus/theme-common": "2.2.0",
-        "@docusaurus/theme-search-algolia": "2.2.0",
-        "@docusaurus/types": "2.2.0"
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.3.1.tgz",
+      "integrity": "sha512-OQ5W0AHyfdUk0IldwJ3BlnZ1EqoJuu2L2BMhqLbqwNWdkmzmSUvlFLH1Pe7CZSQgB2YUUC/DnmjbPKk/qQD0lQ==",
+      "dependencies": {
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/plugin-content-blog": "2.3.1",
+        "@docusaurus/plugin-content-docs": "2.3.1",
+        "@docusaurus/plugin-content-pages": "2.3.1",
+        "@docusaurus/plugin-debug": "2.3.1",
+        "@docusaurus/plugin-google-analytics": "2.3.1",
+        "@docusaurus/plugin-google-gtag": "2.3.1",
+        "@docusaurus/plugin-google-tag-manager": "2.3.1",
+        "@docusaurus/plugin-sitemap": "2.3.1",
+        "@docusaurus/theme-classic": "2.3.1",
+        "@docusaurus/theme-common": "2.3.1",
+        "@docusaurus/theme-search-algolia": "2.3.1",
+        "@docusaurus/types": "2.3.1"
       },
       "engines": {
         "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
       },
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
@@ -2381,22 +2591,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.2.0.tgz",
-      "integrity": "sha512-kjbg/qJPwZ6H1CU/i9d4l/LcFgnuzeiGgMQlt6yPqKo0SOJIBMPuz7Rnu3r/WWbZFPi//o8acclacOzmXdUUEg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.3.1.tgz",
+      "integrity": "sha512-SelSIDvyttb7ZYHj8vEUhqykhAqfOPKk+uP0z85jH72IMC58e7O8DIlcAeBv+CWsLbNIl9/Hcg71X0jazuxJug==",
       "dependencies": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/module-type-aliases": "2.2.0",
-        "@docusaurus/plugin-content-blog": "2.2.0",
-        "@docusaurus/plugin-content-docs": "2.2.0",
-        "@docusaurus/plugin-content-pages": "2.2.0",
-        "@docusaurus/theme-common": "2.2.0",
-        "@docusaurus/theme-translations": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-common": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/module-type-aliases": "2.3.1",
+        "@docusaurus/plugin-content-blog": "2.3.1",
+        "@docusaurus/plugin-content-docs": "2.3.1",
+        "@docusaurus/plugin-content-pages": "2.3.1",
+        "@docusaurus/theme-common": "2.3.1",
+        "@docusaurus/theme-translations": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-common": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -2419,17 +2629,55 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-common": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.2.0.tgz",
-      "integrity": "sha512-R8BnDjYoN90DCL75gP7qYQfSjyitXuP9TdzgsKDmSFPNyrdE3twtPNa2dIN+h+p/pr+PagfxwWbd6dn722A1Dw==",
+    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/module-type-aliases": "2.2.0",
-        "@docusaurus/plugin-content-blog": "2.2.0",
-        "@docusaurus/plugin-content-docs": "2.2.0",
-        "@docusaurus/plugin-content-pages": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/types": "2.3.1",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-common": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.3.1.tgz",
+      "integrity": "sha512-RYmYl2OR2biO+yhmW1aS5FyEvnrItPINa+0U2dMxcHpah8reSCjQ9eJGRmAgkZFchV1+aIQzXOI1K7LCW38O0g==",
+      "dependencies": {
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/module-type-aliases": "2.3.1",
+        "@docusaurus/plugin-content-blog": "2.3.1",
+        "@docusaurus/plugin-content-docs": "2.3.1",
+        "@docusaurus/plugin-content-pages": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2437,6 +2685,7 @@
         "parse-numeric-range": "^1.3.0",
         "prism-react-renderer": "^1.3.5",
         "tslib": "^2.4.0",
+        "use-sync-external-store": "^1.2.0",
         "utility-types": "^3.10.0"
       },
       "engines": {
@@ -2447,23 +2696,61 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
+    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
+      "dependencies": {
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/types": "2.3.1",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.2.0.tgz",
-      "integrity": "sha512-2h38B0tqlxgR2FZ9LpAkGrpDWVdXZ7vltfmTdX+4RsDs3A7khiNsmZB+x/x6sA4+G2V2CvrsPMlsYBy5X+cY1w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.3.1.tgz",
+      "integrity": "sha512-JdHaRqRuH1X++g5fEMLnq7OtULSGQdrs9AbhcWRQ428ZB8/HOiaN6mj3hzHvcD3DFgu7koIVtWPQnvnN7iwzHA==",
       "dependencies": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/plugin-content-docs": "2.2.0",
-        "@docusaurus/theme-common": "2.2.0",
-        "@docusaurus/theme-translations": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/plugin-content-docs": "2.3.1",
+        "@docusaurus/theme-common": "2.3.1",
+        "@docusaurus/theme-translations": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "fs-extra": "^10.1.0",
         "lodash": "^4.17.21",
         "tslib": "^2.4.0",
@@ -2478,9 +2765,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.2.0.tgz",
-      "integrity": "sha512-3T140AG11OjJrtKlY4pMZ5BzbGRDjNs2co5hJ6uYJG1bVWlhcaFGqkaZ5lCgKflaNHD7UHBHU9Ec5f69jTdd6w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.3.1.tgz",
+      "integrity": "sha512-BsBZzAewJabVhoGG1Ij2u4pMS3MPW6gZ6sS4pc+Y7czevRpzxoFNJXRtQDVGe7mOpv/MmRmqg4owDK+lcOTCVQ==",
       "dependencies": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
@@ -2493,6 +2780,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
       "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
+      "devOptional": true,
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -2509,12 +2797,13 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.2.0.tgz",
-      "integrity": "sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.3.1.tgz",
+      "integrity": "sha512-9WcQROCV0MmrpOQDXDGhtGMd52DHpSFbKLfkyaYumzbTstrbA5pPOtiGtxK1nqUHkiIv8UwexS54p0Vod2I1lg==",
       "dependencies": {
-        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/logger": "2.3.1",
         "@svgr/webpack": "^6.2.1",
+        "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "github-slugger": "^1.4.0",
@@ -2542,9 +2831,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.2.0.tgz",
-      "integrity": "sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.3.1.tgz",
+      "integrity": "sha512-pVlRpXkdNcxmKNxAaB1ya2hfCEvVsLDp2joeM6K6uv55Oc5nVIqgyYSgSNKZyMdw66NnvMfsu0RBylcwZQKo9A==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2561,12 +2850,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
-      "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.3.1.tgz",
+      "integrity": "sha512-7n0208IG3k1HVTByMHlZoIDjjOFC8sbViHVXJx0r3Q+3Ezrx+VQ1RZ/zjNn6lT+QBCRCXlnlaoJ8ug4HIVgQ3w==",
       "dependencies": {
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -4440,9 +4729,9 @@
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.2.tgz",
-      "integrity": "sha512-eKvSM5hz5w9RcUowu8LnQ5v0KRrFLCvF4K3KF/Ab3VwCT726rWgZUWUIQUPjr9qDENUMukQ/IHZ7bGUVYRGP0g==",
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.3.tgz",
+      "integrity": "sha512-TbaEvLwiuGygHQIB8y+OsJKQQ40+JKUua5B91X66tMUHyyhbNHvqyr0lqd3wCoyKx7WybyQrC0WJvzoIeh24Aw==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -6788,9 +7077,9 @@
       }
     },
     "node_modules/eta": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/eta/-/eta-1.12.3.tgz",
-      "integrity": "sha512-qHixwbDLtekO/d51Yr4glcaUJCIjGVJyTzuqV4GPlgZo1YpgOKG+avQynErZIYrfM6JIJdtiG2Kox8tbb+DoGg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-2.0.0.tgz",
+      "integrity": "sha512-NqE7S2VmVwgMS8yBxsH4VgNQjNjLq1gfGU0u9I6Cjh468nPRMoDfGdK9n1p/3Dvsw3ebklDkZsFAnKJ9sefjBA==",
       "engines": {
         "node": ">=6.0.0"
       },
@@ -14708,9 +14997,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.32",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
-      "integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==",
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==",
       "funding": [
         {
           "type": "opencollective",
@@ -15203,6 +15492,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util": {
@@ -17465,25 +17762,25 @@
       "optional": true
     },
     "@docsearch/css": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.2.tgz",
-      "integrity": "sha512-dctFYiwbvDZkksMlsmc7pj6W6By/EjnVXJq5TEPd05MwQe+dcdHJgaIn1c8wfsucxHpIsdrUcgSkACHCq6aIhw=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.3.tgz",
+      "integrity": "sha512-6SCwI7P8ao+se1TUsdZ7B4XzL+gqeQZnBc+2EONZlcVa0dVrk0NjETxozFKgMv0eEGH8QzP1fkN+A1rH61l4eg=="
     },
     "@docsearch/react": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.2.tgz",
-      "integrity": "sha512-ugILab2TYKSh6IEHf6Z9xZbOovsYbsdfo60PBj+Bw+oMJ1MHJ7pBt1TTcmPki1hSgg8mysgKy2hDiVdPm7XWSQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.3.tgz",
+      "integrity": "sha512-pLa0cxnl+G0FuIDuYlW+EBK6Rw2jwLw9B1RHIeS4N4s2VhsfJ/wzeCi3CWcs5yVfxLd5ZK50t//TMA5e79YT7Q==",
       "requires": {
         "@algolia/autocomplete-core": "1.7.4",
         "@algolia/autocomplete-preset-algolia": "1.7.4",
-        "@docsearch/css": "3.3.2",
+        "@docsearch/css": "3.3.3",
         "algoliasearch": "^4.0.0"
       }
     },
     "@docusaurus/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
+      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
       "requires": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -17495,13 +17792,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/cssnano-preset": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-common": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-common": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -17522,7 +17819,7 @@
         "del": "^6.1.1",
         "detect-port": "^1.3.0",
         "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "html-minifier-terser": "^6.1.0",
@@ -17559,9 +17856,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.2.0.tgz",
-      "integrity": "sha512-mAAwCo4n66TMWBH1kXnHVZsakW9VAXJzTO4yZukuL3ro4F+JtkMwKfh42EG75K/J/YIFQG5I/Bzy0UH/hFxaTg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
+      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -17570,23 +17867,23 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
-      "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.3.1.tgz",
+      "integrity": "sha512-2lAV/olKKVr9qJhfHFCaqBIl8FgYjbUFwgUnX76+cULwQYss+42ZQ3grHGFvI0ocN2X55WcYe64ellQXz7suqg==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.2.0.tgz",
-      "integrity": "sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.3.1.tgz",
+      "integrity": "sha512-Gzga7OsxQRpt3392K9lv/bW4jGppdLFJh3luKRknCKSAaZrmVkOQv2gvCn8LAOSZ3uRg5No7AgYs/vpL8K94lA==",
       "requires": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -17606,6 +17903,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz",
       "integrity": "sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==",
+      "dev": true,
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
         "@docusaurus/types": "2.2.0",
@@ -17618,17 +17916,17 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.2.0.tgz",
-      "integrity": "sha512-0mWBinEh0a5J2+8ZJXJXbrCk1tSTNf7Nm4tYAl5h2/xx+PvH/Bnu0V+7mMljYm/1QlDYALNIIaT/JcoZQFUN3w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.3.1.tgz",
+      "integrity": "sha512-f5LjqX+9WkiLyGiQ41x/KGSJ/9bOjSD8lsVhPvYeUYHCtYpuiDKfhZE07O4EqpHkBx4NQdtQDbp+aptgHSTuiw==",
       "requires": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-common": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-common": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -17638,20 +17936,37 @@
         "unist-util-visit": "^2.0.3",
         "utility-types": "^3.10.0",
         "webpack": "^5.73.0"
+      },
+      "dependencies": {
+        "@docusaurus/types": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+          "requires": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0",
+            "webpack-merge": "^5.8.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.2.0.tgz",
-      "integrity": "sha512-BOazBR0XjzsHE+2K1wpNxz5QZmrJgmm3+0Re0EVPYFGW8qndCWGNtXW/0lGKhecVPML8yyFeAmnUCIs7xM2wPw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.3.1.tgz",
+      "integrity": "sha512-DxztTOBEruv7qFxqUtbsqXeNcHqcVEIEe+NQoI1oi2DBmKBhW/o0MIal8lt+9gvmpx3oYtlwmLOOGepxZgJGkw==",
       "requires": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/module-type-aliases": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/module-type-aliases": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -17661,91 +17976,254 @@
         "tslib": "^2.4.0",
         "utility-types": "^3.10.0",
         "webpack": "^5.73.0"
+      },
+      "dependencies": {
+        "@docusaurus/module-type-aliases": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+          "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
+          "requires": {
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/types": "2.3.1",
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "@types/react-router-config": "*",
+            "@types/react-router-dom": "*",
+            "react-helmet-async": "*",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+          }
+        },
+        "@docusaurus/types": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+          "requires": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0",
+            "webpack-merge": "^5.8.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.2.0.tgz",
-      "integrity": "sha512-+OTK3FQHk5WMvdelz8v19PbEbx+CNT6VSpx7nVOvMNs5yJCKvmqBJBQ2ZSxROxhVDYn+CZOlmyrC56NSXzHf6g==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.3.1.tgz",
+      "integrity": "sha512-E80UL6hvKm5VVw8Ka8YaVDtO6kWWDVUK4fffGvkpQ/AJQDOg99LwOXKujPoICC22nUFTsZ2Hp70XvpezCsFQaA==",
       "requires": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
+      },
+      "dependencies": {
+        "@docusaurus/types": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+          "requires": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0",
+            "webpack-merge": "^5.8.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.2.0.tgz",
-      "integrity": "sha512-p9vOep8+7OVl6r/NREEYxf4HMAjV8JMYJ7Bos5fCFO0Wyi9AZEo0sCTliRd7R8+dlJXZEgcngSdxAUo/Q+CJow==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.3.1.tgz",
+      "integrity": "sha512-Ujpml1Ppg4geB/2hyu2diWnO49az9U2bxM9Shen7b6qVcyFisNJTkVG2ocvLC7wM1efTJcUhBO6zAku2vKJGMw==",
       "requires": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@docusaurus/types": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+          "requires": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0",
+            "webpack-merge": "^5.8.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.2.0.tgz",
-      "integrity": "sha512-+eZVVxVeEnV5nVQJdey9ZsfyEVMls6VyWTIj8SmX0k5EbqGvnIfET+J2pYEuKQnDIHxy+syRMoRM6AHXdHYGIg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.3.1.tgz",
+      "integrity": "sha512-OHip0GQxKOFU8n7gkt3TM4HOYTXPCFDjqKbMClDD3KaDnyTuMp/Zvd9HSr770lLEscgPWIvzhJByRAClqsUWiQ==",
       "requires": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@docusaurus/types": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+          "requires": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0",
+            "webpack-merge": "^5.8.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.2.0.tgz",
-      "integrity": "sha512-6SOgczP/dYdkqUMGTRqgxAS1eTp6MnJDAQMy8VCF1QKbWZmlkx4agHDexihqmYyCujTYHqDAhm1hV26EET54NQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.3.1.tgz",
+      "integrity": "sha512-uXtDhfu4+Hm+oqWUySr3DNI5cWC/rmP6XJyAk83Heor3dFjZqDwCbkX8yWPywkRiWev3Dk/rVF8lEn0vIGVocA==",
       "requires": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@docusaurus/types": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+          "requires": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0",
+            "webpack-merge": "^5.8.0"
+          }
+        }
+      }
+    },
+    "@docusaurus/plugin-google-tag-manager": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.3.1.tgz",
+      "integrity": "sha512-Ww2BPEYSqg8q8tJdLYPFFM3FMDBCVhEM4UUqKzJaiRMx3NEoly3qqDRAoRDGdIhlC//Rf0iJV9cWAoq2m6k3sw==",
+      "requires": {
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@docusaurus/types": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+          "requires": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0",
+            "webpack-merge": "^5.8.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.2.0.tgz",
-      "integrity": "sha512-0jAmyRDN/aI265CbWZNZuQpFqiZuo+5otk2MylU9iVrz/4J7gSc+ZJ9cy4EHrEsW7PV8s1w18hIEsmcA1YgkKg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.3.1.tgz",
+      "integrity": "sha512-8Yxile/v6QGYV9vgFiYL+8d2N4z4Er3pSHsrD08c5XI8bUXxTppMwjarDUTH/TRTfgAWotRbhJ6WZLyajLpozA==",
       "requires": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-common": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-common": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@docusaurus/types": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+          "requires": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0",
+            "webpack-merge": "^5.8.0"
+          }
+        }
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.2.0.tgz",
-      "integrity": "sha512-yKIWPGNx7BT8v2wjFIWvYrS+nvN04W+UameSFf8lEiJk6pss0kL6SG2MRvyULiI3BDxH+tj6qe02ncpSPGwumg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.3.1.tgz",
+      "integrity": "sha512-OQ5W0AHyfdUk0IldwJ3BlnZ1EqoJuu2L2BMhqLbqwNWdkmzmSUvlFLH1Pe7CZSQgB2YUUC/DnmjbPKk/qQD0lQ==",
       "requires": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/plugin-content-blog": "2.2.0",
-        "@docusaurus/plugin-content-docs": "2.2.0",
-        "@docusaurus/plugin-content-pages": "2.2.0",
-        "@docusaurus/plugin-debug": "2.2.0",
-        "@docusaurus/plugin-google-analytics": "2.2.0",
-        "@docusaurus/plugin-google-gtag": "2.2.0",
-        "@docusaurus/plugin-sitemap": "2.2.0",
-        "@docusaurus/theme-classic": "2.2.0",
-        "@docusaurus/theme-common": "2.2.0",
-        "@docusaurus/theme-search-algolia": "2.2.0",
-        "@docusaurus/types": "2.2.0"
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/plugin-content-blog": "2.3.1",
+        "@docusaurus/plugin-content-docs": "2.3.1",
+        "@docusaurus/plugin-content-pages": "2.3.1",
+        "@docusaurus/plugin-debug": "2.3.1",
+        "@docusaurus/plugin-google-analytics": "2.3.1",
+        "@docusaurus/plugin-google-gtag": "2.3.1",
+        "@docusaurus/plugin-google-tag-manager": "2.3.1",
+        "@docusaurus/plugin-sitemap": "2.3.1",
+        "@docusaurus/theme-classic": "2.3.1",
+        "@docusaurus/theme-common": "2.3.1",
+        "@docusaurus/theme-search-algolia": "2.3.1",
+        "@docusaurus/types": "2.3.1"
+      },
+      "dependencies": {
+        "@docusaurus/types": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+          "requires": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0",
+            "webpack-merge": "^5.8.0"
+          }
+        }
       }
     },
     "@docusaurus/react-loadable": {
@@ -17758,22 +18236,22 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.2.0.tgz",
-      "integrity": "sha512-kjbg/qJPwZ6H1CU/i9d4l/LcFgnuzeiGgMQlt6yPqKo0SOJIBMPuz7Rnu3r/WWbZFPi//o8acclacOzmXdUUEg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.3.1.tgz",
+      "integrity": "sha512-SelSIDvyttb7ZYHj8vEUhqykhAqfOPKk+uP0z85jH72IMC58e7O8DIlcAeBv+CWsLbNIl9/Hcg71X0jazuxJug==",
       "requires": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/module-type-aliases": "2.2.0",
-        "@docusaurus/plugin-content-blog": "2.2.0",
-        "@docusaurus/plugin-content-docs": "2.2.0",
-        "@docusaurus/plugin-content-pages": "2.2.0",
-        "@docusaurus/theme-common": "2.2.0",
-        "@docusaurus/theme-translations": "2.2.0",
-        "@docusaurus/types": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-common": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/module-type-aliases": "2.3.1",
+        "@docusaurus/plugin-content-blog": "2.3.1",
+        "@docusaurus/plugin-content-docs": "2.3.1",
+        "@docusaurus/plugin-content-pages": "2.3.1",
+        "@docusaurus/theme-common": "2.3.1",
+        "@docusaurus/theme-translations": "2.3.1",
+        "@docusaurus/types": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-common": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -17787,19 +18265,51 @@
         "rtlcss": "^3.5.0",
         "tslib": "^2.4.0",
         "utility-types": "^3.10.0"
+      },
+      "dependencies": {
+        "@docusaurus/module-type-aliases": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+          "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
+          "requires": {
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/types": "2.3.1",
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "@types/react-router-config": "*",
+            "@types/react-router-dom": "*",
+            "react-helmet-async": "*",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+          }
+        },
+        "@docusaurus/types": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+          "requires": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0",
+            "webpack-merge": "^5.8.0"
+          }
+        }
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.2.0.tgz",
-      "integrity": "sha512-R8BnDjYoN90DCL75gP7qYQfSjyitXuP9TdzgsKDmSFPNyrdE3twtPNa2dIN+h+p/pr+PagfxwWbd6dn722A1Dw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.3.1.tgz",
+      "integrity": "sha512-RYmYl2OR2biO+yhmW1aS5FyEvnrItPINa+0U2dMxcHpah8reSCjQ9eJGRmAgkZFchV1+aIQzXOI1K7LCW38O0g==",
       "requires": {
-        "@docusaurus/mdx-loader": "2.2.0",
-        "@docusaurus/module-type-aliases": "2.2.0",
-        "@docusaurus/plugin-content-blog": "2.2.0",
-        "@docusaurus/plugin-content-docs": "2.2.0",
-        "@docusaurus/plugin-content-pages": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/mdx-loader": "2.3.1",
+        "@docusaurus/module-type-aliases": "2.3.1",
+        "@docusaurus/plugin-content-blog": "2.3.1",
+        "@docusaurus/plugin-content-docs": "2.3.1",
+        "@docusaurus/plugin-content-pages": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -17807,26 +18317,59 @@
         "parse-numeric-range": "^1.3.0",
         "prism-react-renderer": "^1.3.5",
         "tslib": "^2.4.0",
+        "use-sync-external-store": "^1.2.0",
         "utility-types": "^3.10.0"
+      },
+      "dependencies": {
+        "@docusaurus/module-type-aliases": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+          "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
+          "requires": {
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/types": "2.3.1",
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "@types/react-router-config": "*",
+            "@types/react-router-dom": "*",
+            "react-helmet-async": "*",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+          }
+        },
+        "@docusaurus/types": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+          "requires": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0",
+            "webpack-merge": "^5.8.0"
+          }
+        }
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.2.0.tgz",
-      "integrity": "sha512-2h38B0tqlxgR2FZ9LpAkGrpDWVdXZ7vltfmTdX+4RsDs3A7khiNsmZB+x/x6sA4+G2V2CvrsPMlsYBy5X+cY1w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.3.1.tgz",
+      "integrity": "sha512-JdHaRqRuH1X++g5fEMLnq7OtULSGQdrs9AbhcWRQ428ZB8/HOiaN6mj3hzHvcD3DFgu7koIVtWPQnvnN7iwzHA==",
       "requires": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/plugin-content-docs": "2.2.0",
-        "@docusaurus/theme-common": "2.2.0",
-        "@docusaurus/theme-translations": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@docusaurus/utils-validation": "2.2.0",
+        "@docusaurus/core": "2.3.1",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/plugin-content-docs": "2.3.1",
+        "@docusaurus/theme-common": "2.3.1",
+        "@docusaurus/theme-translations": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/utils-validation": "2.3.1",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "fs-extra": "^10.1.0",
         "lodash": "^4.17.21",
         "tslib": "^2.4.0",
@@ -17834,9 +18377,9 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.2.0.tgz",
-      "integrity": "sha512-3T140AG11OjJrtKlY4pMZ5BzbGRDjNs2co5hJ6uYJG1bVWlhcaFGqkaZ5lCgKflaNHD7UHBHU9Ec5f69jTdd6w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.3.1.tgz",
+      "integrity": "sha512-BsBZzAewJabVhoGG1Ij2u4pMS3MPW6gZ6sS4pc+Y7czevRpzxoFNJXRtQDVGe7mOpv/MmRmqg4owDK+lcOTCVQ==",
       "requires": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
@@ -17846,6 +18389,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
       "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
+      "devOptional": true,
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -17858,12 +18402,13 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.2.0.tgz",
-      "integrity": "sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.3.1.tgz",
+      "integrity": "sha512-9WcQROCV0MmrpOQDXDGhtGMd52DHpSFbKLfkyaYumzbTstrbA5pPOtiGtxK1nqUHkiIv8UwexS54p0Vod2I1lg==",
       "requires": {
-        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/logger": "2.3.1",
         "@svgr/webpack": "^6.2.1",
+        "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "github-slugger": "^1.4.0",
@@ -17880,20 +18425,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.2.0.tgz",
-      "integrity": "sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.3.1.tgz",
+      "integrity": "sha512-pVlRpXkdNcxmKNxAaB1ya2hfCEvVsLDp2joeM6K6uv55Oc5nVIqgyYSgSNKZyMdw66NnvMfsu0RBylcwZQKo9A==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
-      "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.3.1.tgz",
+      "integrity": "sha512-7n0208IG3k1HVTByMHlZoIDjjOFC8sbViHVXJx0r3Q+3Ezrx+VQ1RZ/zjNn6lT+QBCRCXlnlaoJ8ug4HIVgQ3w==",
       "requires": {
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/utils": "2.3.1",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -19311,9 +19856,9 @@
       }
     },
     "algoliasearch-helper": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.2.tgz",
-      "integrity": "sha512-eKvSM5hz5w9RcUowu8LnQ5v0KRrFLCvF4K3KF/Ab3VwCT726rWgZUWUIQUPjr9qDENUMukQ/IHZ7bGUVYRGP0g==",
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.3.tgz",
+      "integrity": "sha512-TbaEvLwiuGygHQIB8y+OsJKQQ40+JKUua5B91X66tMUHyyhbNHvqyr0lqd3wCoyKx7WybyQrC0WJvzoIeh24Aw==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -21001,9 +21546,9 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "eta": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/eta/-/eta-1.12.3.tgz",
-      "integrity": "sha512-qHixwbDLtekO/d51Yr4glcaUJCIjGVJyTzuqV4GPlgZo1YpgOKG+avQynErZIYrfM6JIJdtiG2Kox8tbb+DoGg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-2.0.0.tgz",
+      "integrity": "sha512-NqE7S2VmVwgMS8yBxsH4VgNQjNjLq1gfGU0u9I6Cjh468nPRMoDfGdK9n1p/3Dvsw3ebklDkZsFAnKJ9sefjBA=="
     },
     "etag": {
       "version": "1.8.1",
@@ -26649,9 +27194,9 @@
       "peer": true
     },
     "ua-parser-js": {
-      "version": "0.7.32",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
-      "integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw=="
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw=="
     },
     "uc.micro": {
       "version": "1.0.6",
@@ -26964,6 +27509,12 @@
       "requires": {
         "use-isomorphic-layout-effect": "^1.1.1"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util": {
       "version": "0.10.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "slick-carousel": "^1.8.1"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.3.1",
         "husky": "^8.0.2",
         "markdownlint-cli2": "^0.5.1"
       },
@@ -2163,13 +2163,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz",
-      "integrity": "sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==",
-      "dev": true,
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.2.0",
+        "@docusaurus/types": "2.3.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2212,25 +2211,6 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-docs": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.3.1.tgz",
@@ -2261,44 +2241,6 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
-      "dependencies": {
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.3.1",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-pages": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.3.1.tgz",
@@ -2315,25 +2257,6 @@
       },
       "engines": {
         "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
       },
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
@@ -2360,25 +2283,6 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-google-analytics": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.3.1.tgz",
@@ -2391,25 +2295,6 @@
       },
       "engines": {
         "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
       },
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
@@ -2434,25 +2319,6 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.3.1.tgz",
@@ -2465,25 +2331,6 @@
       },
       "engines": {
         "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
       },
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
@@ -2513,25 +2360,6 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/preset-classic": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.3.1.tgz",
@@ -2553,25 +2381,6 @@
       },
       "engines": {
         "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
       },
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
@@ -2629,44 +2438,6 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
-      "dependencies": {
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.3.1",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/theme-common": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.3.1.tgz",
@@ -2690,44 +2461,6 @@
       },
       "engines": {
         "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
-      "dependencies": {
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.3.1",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
       },
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
@@ -2777,10 +2510,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
-      "devOptional": true,
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -17900,13 +17632,12 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz",
-      "integrity": "sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==",
-      "dev": true,
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.2.0",
+        "@docusaurus/types": "2.3.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -17936,23 +17667,6 @@
         "unist-util-visit": "^2.0.3",
         "utility-types": "^3.10.0",
         "webpack": "^5.73.0"
-      },
-      "dependencies": {
-        "@docusaurus/types": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-          "requires": {
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.6.0",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.73.0",
-            "webpack-merge": "^5.8.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-content-docs": {
@@ -17976,38 +17690,6 @@
         "tslib": "^2.4.0",
         "utility-types": "^3.10.0",
         "webpack": "^5.73.0"
-      },
-      "dependencies": {
-        "@docusaurus/module-type-aliases": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-          "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
-          "requires": {
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/types": "2.3.1",
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "@types/react-router-config": "*",
-            "@types/react-router-dom": "*",
-            "react-helmet-async": "*",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-          }
-        },
-        "@docusaurus/types": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-          "requires": {
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.6.0",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.73.0",
-            "webpack-merge": "^5.8.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-content-pages": {
@@ -18023,23 +17705,6 @@
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
-      },
-      "dependencies": {
-        "@docusaurus/types": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-          "requires": {
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.6.0",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.73.0",
-            "webpack-merge": "^5.8.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-debug": {
@@ -18053,23 +17718,6 @@
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@docusaurus/types": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-          "requires": {
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.6.0",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.73.0",
-            "webpack-merge": "^5.8.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-google-analytics": {
@@ -18081,23 +17729,6 @@
         "@docusaurus/types": "2.3.1",
         "@docusaurus/utils-validation": "2.3.1",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@docusaurus/types": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-          "requires": {
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.6.0",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.73.0",
-            "webpack-merge": "^5.8.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-google-gtag": {
@@ -18109,23 +17740,6 @@
         "@docusaurus/types": "2.3.1",
         "@docusaurus/utils-validation": "2.3.1",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@docusaurus/types": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-          "requires": {
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.6.0",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.73.0",
-            "webpack-merge": "^5.8.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-google-tag-manager": {
@@ -18137,23 +17751,6 @@
         "@docusaurus/types": "2.3.1",
         "@docusaurus/utils-validation": "2.3.1",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@docusaurus/types": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-          "requires": {
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.6.0",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.73.0",
-            "webpack-merge": "^5.8.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-sitemap": {
@@ -18170,23 +17767,6 @@
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@docusaurus/types": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-          "requires": {
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.6.0",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.73.0",
-            "webpack-merge": "^5.8.0"
-          }
-        }
       }
     },
     "@docusaurus/preset-classic": {
@@ -18207,23 +17787,6 @@
         "@docusaurus/theme-common": "2.3.1",
         "@docusaurus/theme-search-algolia": "2.3.1",
         "@docusaurus/types": "2.3.1"
-      },
-      "dependencies": {
-        "@docusaurus/types": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-          "requires": {
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.6.0",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.73.0",
-            "webpack-merge": "^5.8.0"
-          }
-        }
       }
     },
     "@docusaurus/react-loadable": {
@@ -18265,38 +17828,6 @@
         "rtlcss": "^3.5.0",
         "tslib": "^2.4.0",
         "utility-types": "^3.10.0"
-      },
-      "dependencies": {
-        "@docusaurus/module-type-aliases": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-          "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
-          "requires": {
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/types": "2.3.1",
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "@types/react-router-config": "*",
-            "@types/react-router-dom": "*",
-            "react-helmet-async": "*",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-          }
-        },
-        "@docusaurus/types": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-          "requires": {
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.6.0",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.73.0",
-            "webpack-merge": "^5.8.0"
-          }
-        }
       }
     },
     "@docusaurus/theme-common": {
@@ -18319,38 +17850,6 @@
         "tslib": "^2.4.0",
         "use-sync-external-store": "^1.2.0",
         "utility-types": "^3.10.0"
-      },
-      "dependencies": {
-        "@docusaurus/module-type-aliases": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-          "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
-          "requires": {
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/types": "2.3.1",
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "@types/react-router-config": "*",
-            "@types/react-router-dom": "*",
-            "react-helmet-async": "*",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-          }
-        },
-        "@docusaurus/types": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-          "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-          "requires": {
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.6.0",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.73.0",
-            "webpack-merge": "^5.8.0"
-          }
-        }
       }
     },
     "@docusaurus/theme-search-algolia": {
@@ -18386,10 +17885,9 @@
       }
     },
     "@docusaurus/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
-      "devOptional": true,
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
+      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@docusaurus/core": "2.2.0",
-    "@docusaurus/preset-classic": "2.2.0",
+    "@docusaurus/core": "2.3.1",
+    "@docusaurus/preset-classic": "^2.3.1",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@mdx-js/react": "^1.6.22",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "slick-carousel": "^1.8.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "2.2.0",
+    "@docusaurus/module-type-aliases": "2.3.1",
     "husky": "^8.0.2",
     "markdownlint-cli2": "^0.5.1"
   },


### PR DESCRIPTION
As described in #128 we we could use an new version from docusaurus.

- update npm packages in the package.json
"@docusaurus/core"
"@docusaurus/preset-classic"
"@docusaurus/module-type-aliases"

Forked the repo and let the `npm start` run locally as described in https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/blob/main/README.md

and seems up and running.

