### PR TITLE
chore: reference Keep A Changelog and make it mandatory

### DIFF
--- a/docs/release/trg-1/trg-1-3.md
+++ b/docs/release/trg-1/trg-1-3.md
@@ -9,15 +9,17 @@ title: TRG 1.03 - CHANGELOG.md
 
 ## Description
 
-Repositories must contain a `CHANGELOG.md` file and content must
+Repositories must contain a `CHANGELOG.md` file and content should
 follow [Keep A Changelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## Why
 
-To track changes of releases a `CHANGELOG.md` must be added to repositories. The format must follow the format explained at [Keep A Changelog](https://keepachangelog.com/en/1.0.0/).
+To track changes of releases a `CHANGELOG.md` must be added to repositories. The format should follow the format
+explained at [Keep A Changelog](https://keepachangelog.com/en/1.0.0/).
 
 The versioning of releases must
 follows [semantic versioning](https://semver.org/). For easy changelog
 creation [conventional committing](https://www.conventionalcommits.org/en/v1.0.0/#summary) is strongly recommended.
 
-An example of a `CHANGELOG.md` file following _Keep A Changelog_ can be found [here](https://github.com/eclipse-tractusx/tractus-x-release/blob/main/CHANGELOG.md).
+An example of a `CHANGELOG.md` file following _Keep A Changelog_ can be
+found [here](https://github.com/eclipse-tractusx/tractus-x-release/blob/main/CHANGELOG.md).

--- a/docs/release/trg-1/trg-1-3.md
+++ b/docs/release/trg-1/trg-1-3.md
@@ -2,17 +2,22 @@
 title: TRG 1.03 - CHANGELOG.md
 ---
 
-| Author               | Status | Created      | Post-History |
-|----------------------|--------|--------------|--------------|
-| Catena-X System Team | Draft  | 14-Sept-2022 | n/a          |
+| Author               | Status | Created      | Post-History                         |
+|----------------------|--------|--------------|--------------------------------------|
+| Catena-X System Team | Draft  | 14-Sept-2022 | n/a                                  |
+| Catena-X System Team | Active | 20-Feb-2023  | reference keep a changelog as format |
 
 ## Description
 
-Repositories must contain a appropriate `CHANGELOG.md` file.
+Repositories must contain a `CHANGELOG.md` file and content must
+follow [Keep A Changelog](https://keepachangelog.com/en/1.0.0/) format.
 
 ## Why
 
-To track changes of releases a `CHANGELOG.md` must be added to repositories. The versioning itself
-follows [semantic versioning](https://semver.org/). For easy changelog creation [conventional committing](https://www.conventionalcommits.org/en/v1.0.0/#summary) is strongly recommended.
+To track changes of releases a `CHANGELOG.md` must be added to repositories. The format must follow the format explained at [Keep A Changelog](https://keepachangelog.com/en/1.0.0/).
 
-Recommendations for changelog format can be found [here](https://github.com/eclipse-tractusx/tractus-x-release/blob/main/CHANGELOG.md).
+The versioning of releases must
+follows [semantic versioning](https://semver.org/). For easy changelog
+creation [conventional committing](https://www.conventionalcommits.org/en/v1.0.0/#summary) is strongly recommended.
+
+An example of a `CHANGELOG.md` file following _Keep A Changelog_ can be found [here](https://github.com/eclipse-tractusx/tractus-x-release/blob/main/CHANGELOG.md).

--- a/docs/release/trg-1/trg-1-3.md
+++ b/docs/release/trg-1/trg-1-3.md
@@ -18,7 +18,7 @@ To track changes of releases a `CHANGELOG.md` must be added to repositories. The
 explained at [Keep A Changelog](https://keepachangelog.com/en/1.0.0/).
 
 The versioning of releases must
-follows [semantic versioning](https://semver.org/). For easy changelog
+follow [semantic versioning](https://semver.org/). For easy changelog
 creation [conventional committing](https://www.conventionalcommits.org/en/v1.0.0/#summary) is strongly recommended.
 
 An example of a `CHANGELOG.md` file following _Keep A Changelog_ can be


### PR DESCRIPTION
Be more precise that keep a changelog is mandatory for `CHANGELOG.md` file content.