### PR TITLE
Add/news ticker rotation carousel

### DIFF
--- a/src/components/CarouselComponent/index.js
+++ b/src/components/CarouselComponent/index.js
@@ -35,7 +35,7 @@ import ArrowCircleLeftOutlinedIcon from '@mui/icons-material/ArrowCircleLeftOutl
 import styles from "./styles.module.css";
 
 export default function CarouselComponent() {
-    var settings = {
+    let settings = {
       dots: true,
       infinite: true,
       speed: 500,

--- a/src/components/NewsTicker/index.js
+++ b/src/components/NewsTicker/index.js
@@ -21,6 +21,7 @@
 
 import React from "react";
 import Link from "@docusaurus/Link";
+
 import { newsTitles } from "../../../utils/newsTitles";
 
 import Slider from "react-slick";
@@ -61,7 +62,6 @@ export default function NewsTicker() {
     )
   }
 
-
   return (
     <section className={styles.news_ticker}>
       <div className={styles.container}>
@@ -82,7 +82,6 @@ export default function NewsTicker() {
             }
           </Slider>
         </div>
-        
       </div>
     </section>
   );

--- a/src/components/NewsTicker/index.js
+++ b/src/components/NewsTicker/index.js
@@ -21,6 +21,7 @@
 
 import React from "react";
 import Link from "@docusaurus/Link";
+import { newsTitles } from "../../../utils/newsTitles";
 
 import Slider from "react-slick";
 import "slick-carousel/slick/slick.css";
@@ -36,29 +37,11 @@ export default function NewsTicker() {
     slidesToScroll: 1,
     arrows: false,
     autoplay: true,
-    speed: 4000,
+    speed: 3000,
     autoplaySpeed: 6000,
   };
 
-  const news = [
-    {
-      date: "10.02.2023",
-      title: "Eclipse Tractus-X Developer Portal is LIVE!",
-      blogLink: "/blog/portal-is-live"
-    },
-    {
-      date: "00.00.0000",
-      title: "TESTING SECOND ITEM",
-      blogLink: "/blog/portal-is-live"
-    },
-    {
-      date: "01.001.00001",
-      title: "TESTING THE THIRD ITEM",
-      blogLink: "/blog/portal-is-live"
-    },
-  ]
-
-  const NewsCard = ({date, title, blogLink}) => {
+  const NewsTickerCard = ({date, title, blogLink}) => {
     return (
       <div className={styles.slider_item}>
         <div className={styles.date}>
@@ -91,9 +74,9 @@ export default function NewsTicker() {
         <div className={styles.carousel_container}>
           <Slider {...settings} className={styles.slider}>
             {
-              news.map((newPost, index)=> {
+              newsTitles.map((newPost, index)=> {
                 return (
-                  <NewsCard key={index} {...newPost}/>
+                  <NewsTickerCard key={index} {...newPost}/>
                 )
               })
             }

--- a/src/components/NewsTicker/index.js
+++ b/src/components/NewsTicker/index.js
@@ -21,9 +21,64 @@
 
 import React from "react";
 import Link from "@docusaurus/Link";
+
+import Slider from "react-slick";
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
+
 import styles from "./styles.module.css";
 
 export default function NewsTicker() {
+  let settings = {
+    dots: false,
+    infinite: true,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+    arrows: false,
+    autoplay: true,
+    speed: 4000,
+    autoplaySpeed: 6000,
+  };
+
+  const news = [
+    {
+      date: "10.02.2023",
+      title: "Eclipse Tractus-X Developer Portal is LIVE!",
+      blogLink: "/blog/portal-is-live"
+    },
+    {
+      date: "00.00.0000",
+      title: "TESTING SECOND ITEM",
+      blogLink: "/blog/portal-is-live"
+    },
+    {
+      date: "01.001.00001",
+      title: "TESTING THE THIRD ITEM",
+      blogLink: "/blog/portal-is-live"
+    },
+  ]
+
+  const NewsCard = ({date, title, blogLink}) => {
+    return (
+      <div className={styles.slider_item}>
+        <div className={styles.date}>
+          {date}
+        </div>
+
+        <div className={styles.introduction}>
+          <strong>{title}</strong>
+        </div>
+
+        <div className={styles.link_to_blog}>
+          <Link to={blogLink}>
+            Read more &gt;
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+
   return (
     <section className={styles.news_ticker}>
       <div className={styles.container}>
@@ -33,16 +88,16 @@ export default function NewsTicker() {
           </Link>
         </div>
 
-        <div className={styles.date}>10.02.2023</div>
-
-        <div className={styles.introduction}>
-          <strong>Eclipse Tractus-X Developer Portal is LIVE!</strong>
-        </div>
-
-        <div className={styles.link_to_blog}>
-          <Link to="/blog/portal-is-live">
-            Read more &gt;
-          </Link>
+        <div className={styles.carousel_container}>
+          <Slider {...settings} className={styles.slider}>
+            {
+              news.map((newPost, index)=> {
+                return (
+                  <NewsCard key={index} {...newPost}/>
+                )
+              })
+            }
+          </Slider>
         </div>
         
       </div>

--- a/src/components/NewsTicker/styles.module.css
+++ b/src/components/NewsTicker/styles.module.css
@@ -49,20 +49,12 @@
 
 .carousel_container {
   width: 60vw;
-  /* height: 100%; */
-  border: 1px solid red;
-}
-
-.slider {
-  border: 1px solid white;
 }
 
 .slider_item {
   display: flex;
   justify-content: space-around;
   align-items: center;
-
-  border: 1px solid blue;
 }
 
 .date {
@@ -90,9 +82,8 @@
   }
 
   .button {
-    padding: 0.2rem 0.8rem;
-    font-size: x-small;
-    font-size: 1vw;
+    padding: 0 0.8rem;
+    font-size: 1.3vw;
   }
 
   .date {

--- a/src/components/NewsTicker/styles.module.css
+++ b/src/components/NewsTicker/styles.module.css
@@ -29,6 +29,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  width: 10vw;
 }
 
 .button {
@@ -44,6 +45,24 @@
   background-color: #1e1e1e;
   color: #faa023;
   text-decoration: none;
+}
+
+.carousel_container {
+  width: 60vw;
+  /* height: 100%; */
+  border: 1px solid red;
+}
+
+.slider {
+  border: 1px solid white;
+}
+
+.slider_item {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+
+  border: 1px solid blue;
 }
 
 .date {

--- a/utils/newsTitles.js
+++ b/utils/newsTitles.js
@@ -4,14 +4,4 @@ export const newsTitles = [
     title: "Eclipse Tractus-X Developer Portal is LIVE!",
     blogLink: "/blog/portal-is-live"
   },
-  {
-    date: "00.00.0000",
-    title: "TESTING SECOND ITEM",
-    blogLink: "/blog/portal-is-live"
-  },
-  {
-    date: "01.01.0001",
-    title: "TESTING THE THIRD ITEM",
-    blogLink: "/blog/portal-is-live"
-  },
 ]

--- a/utils/newsTitles.js
+++ b/utils/newsTitles.js
@@ -1,0 +1,17 @@
+export const newsTitles = [
+  {
+    date: "10.02.2023",
+    title: "Eclipse Tractus-X Developer Portal is LIVE!",
+    blogLink: "/blog/portal-is-live"
+  },
+  {
+    date: "00.00.0000",
+    title: "TESTING SECOND ITEM",
+    blogLink: "/blog/portal-is-live"
+  },
+  {
+    date: "01.01.0001",
+    title: "TESTING THE THIRD ITEM",
+    blogLink: "/blog/portal-is-live"
+  },
+]


### PR DESCRIPTION
This PR modify the `src/components/NewsTicker` component in the Home page.

The modifications included an instance of the `slick-carousel` that is been used already in the `CarouselComponent`. Now been included in the `NewsTicker` rotate its content (date, title and read more link).

Another update in this PR is the creation of the `utils/newsTitles.js` file, where the content for the generation of the rotating cards are defined, currently just one post is been created, so only one title is been defined here. Thus the carousel is not rotating. 