### PR TITLE
Add/search bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -146,6 +146,11 @@ const config = {
         disableSwitch: true,
         respectPrefersColorScheme: false,
       },
+      algolia: {
+        apiKey: 'a97c5de3a563a32884153d3a84568be1',
+        indexName: 'eclipse-tractusxio',
+        appId: '5EEK7E23IM',
+      },
       navbar: {
         title: 'Eclipse Tractus-X',
         logo: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -88,6 +88,11 @@
   fill: #a4a4a4;
 }
 
+.DocSearch-Button .DocSearch-Button-Keys,
+.DocSearch-Button .DocSearch-Button-Container .DocSearch-Button-Placeholder {
+  display: none;
+}
+
 /* Docusaurus NavBar */
 .navbar {
   height: 74px;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -47,6 +47,48 @@
   --ifm-navbar-link-color: #fff;
 }
 
+/* Algolia DocSearch Component */
+[data-theme='dark'] .DocSearch {
+  --docsearch-text-color: var(--ifm-navbar-link-color);
+  --docsearch-muted-color: var(--ifm-navbar-link-color);
+  --docsearch-container-background: rgba(47, 55, 69, 0.7);
+  /* Modal */
+  --docsearch-modal-background: var(--ifm-background-color);
+  --docsearch-highlight-color: var(--ifm-color-primary-darker);
+  --docsearch-modal-width: 50vw;
+  /* Search box */
+  --docsearch-searchbox-background: var(--ifm-background-color);
+  --docsearch-searchbox-focus-background: var(--ifm-color-black);
+  /* Hit */
+  --docsearch-hit-color: var(--ifm-font-color-base);
+  --docsearch-hit-active-color: var(--ifm-color-white);
+  --docsearch-hit-background: var(--ifm-color-emphasis-100);
+  /* Footer */
+  --docsearch-footer-background: var(--ifm-background-color);
+  --docsearch-key-gradient: linear-gradient(
+    -26.5deg,
+    var(--ifm-color-emphasis-200) 0%,
+    var(--ifm-color-emphasis-100) 100%
+  );
+  --docsearch-searchbox-shadow: none;
+  --docsearch-key-shadow: none;
+  --docsearch-key-gradient: none;
+}
+
+.DocSearch-Form {
+  border-bottom: 1px solid var(--ifm-color-primary-darker);
+}
+
+.DocSearch-Footer {
+  border-top: 0.5px solid var(--ifm-color-primary-darker);
+}
+
+.DocSearch-Logo svg path,
+.DocSearch-Logo svg rect {
+  fill: #a4a4a4;
+}
+
+/* Docusaurus NavBar */
 .navbar {
   height: 74px;
 }
@@ -70,19 +112,6 @@
   font-weight: bold;
 }
 
-.footer__links {
-  border-top: 0.5px solid #aaa;
-  padding-top: 2rem;
-}
-
-.footer .container .footer__bottom {
-  margin-top: 60px;
-}
-
-.footer--dark {
-  --ifm-footer-background-color: #000;
-}
-
 @media screen and (max-width: 1250px) {
   .navbar__items {
     margin: 0 8px;
@@ -100,6 +129,20 @@
     margin: 0 10px;
     font-size: 12px;
   }
+}
+
+/* Docusaurus Footer */
+.footer__links {
+  border-top: 0.5px solid #aaa;
+  padding-top: 2rem;
+}
+
+.footer .container .footer__bottom {
+  margin-top: 60px;
+}
+
+.footer--dark {
+  --ifm-footer-background-color: #000;
 }
 
 @media screen and (max-width: 996px) {


### PR DESCRIPTION
This PR solves issue #149

It makes use of the [Algolia Official](https://docusaurus.io/docs/2.2.0/search#using-algolia-docsearch) search engine, which is implemented by adding public `apiKey`, `indexName` and `appId` to our `docusaurus.config.js`. Those fields were obtainer after apply to the official [DocSearch Program](https://docsearch.algolia.com/apply/). 

The customisation of the `DocSearch` component is done by targeting `css` classes in our `src/css/custom.css` file