### PR TITLE
feature(issues.md): Adding a reference ticket for sonar project reque…

### DIFF
--- a/docs/oss/issues.md
+++ b/docs/oss/issues.md
@@ -16,7 +16,8 @@ Here all requests for Eclipse infrastructure  go in.
 
 - Start the summary with "tractus-x" prefix
 - If you are not a committer, create the ticket and add a committer to request a "thumbs up" for approval
-- [Example](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2273) for requesting a new repository
+- [Example new Repository](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2273) for requesting a new repository
+- [Example new Sonar Project](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2843) for requesting a sonar project for a repository
 
 ## [Eclipse GitLab IP Issue Tracker](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/?search=automotive.tractusx&sort=created_date&state=opened&first_page_size=20)
 


### PR DESCRIPTION
### Adding Request Template for Sonar Projects in Eclipse

Hello I would like to suggest adding a reference ticket for creating sonar projects in Eclipse to the Issue Tracker Section within the Issues.md.

Kind regards

Maximilian Wesener
eclipse-tractusx/contributor