### PR TITLE
align trg 2.02 with eclipse workflow

### DIFF
--- a/docs/release/trg-2/trg-2-2.md
+++ b/docs/release/trg-2/trg-2-2.md
@@ -2,21 +2,20 @@
 title: TRG 2.02 - Repo permissions
 ---
 
-| Status | Created      | Post-History    |
-|--------|--------------|-----------------|
-| Active | 10-Nov-2022  | Initial release |
-
-## Description
-
-No admin privileges will be granted to GitHub teams for repositories.
+| Status | Created      | Post-History                 |
+|--------|--------------|------------------------------|
+| Update | 24-May-2023  | Adjust for Eclipse Tractus-X |
+| Active | 10-Nov-2022  | Initial release              |
 
 ## Why
 
 The GitHub organization is managed by the Eclipse Foundation.
 
-__In case you want to change configuration that needs administrative privileges__:  
-Get in touch with System Team and explain what you need to change and why. You can create
-a [support request](https://jira.catena-x.net/secure/CreateIssueDetails!init.jspa?pid=10212&issuetype=10401&components=10401&priority=3&summary=blank%20template%20for%20any%20requirement&description=%0AGitHub%20user%3A%20_your_user_%0Ablank_template&labels=requirement-dependent)
-, or use
-the [CoP channel](https://teams.microsoft.com/l/channel/19%3a9a3c4a05a3514d07b973c13e7b468709%40thread.tacv2/CX%2520-%2520CoP%2520DevSecOps?groupId=17b1a2dc-67fb-4a49-a2ed-dd1344321439&tenantId=1ad22c6d-2f08-4f05-a0ba-e17f6ce88380)
-. We will then address the requested changes.
+## Description
+
+No admin privileges will be granted to GitHub teams for repositories.
+
+**In case you want to change configuration that needs administrative privileges**:
+
+- If you are unsure about a change you like to have, please ask on the [tractusx-dev mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev)
+- Create a ticket on the Eclipse Foundation Helpdesk (see our [issues page](../../oss/issues))


### PR DESCRIPTION
We still had the workflow for catena-x written which is wrong.

Small hint on using the dev mailing list and the help desk