### PR TITLE
added new standard links to the bp kit

### DIFF
--- a/docs/kits/Business Partner Kit/page_adoption-view.mdx
+++ b/docs/kits/Business Partner Kit/page_adoption-view.mdx
@@ -62,8 +62,8 @@ Solution Provider:
 - Potential to scale customer group and access new market potentials via marketplace and shared service network.
 
 ## Standards
-- [Business Partner Number](https://catena-x.net/fileadmin/user_upload/Standard-Bibliothek/Update_PDF_Feb._2023/5_BPDM_v1.0/CX_-_0010_BUSINESS_PARTNER_NUMBER_PlatformCapabilityBPDM_v_1.0.0.pdf)
+- [Business Partner Number](https://catena-x.net/fileadmin/user_upload/Standard-Bibliothek/Update_PDF_Maerz/5_BPDM/CX_-_0010_BUSINESS_PARTNER_NUMBER_PlatformCapabilityBPDM_v_1.0.1.pdf)
 
-- [Business Partner Pool API](https://catena-x.net/fileadmin/user_upload/Standard-Bibliothek/Update_PDF_Feb._2023/5_BPDM_v1.0/CX_-_0012_BUSINESS_PARTNER_POOL_API_PlatformCapabilityBPDM_v_1.0.0.pdf)
+- [Business Partner Pool API](https://catena-x.net/fileadmin/user_upload/Standard-Bibliothek/Update_PDF_Maerz/5_BPDM/CX_-_0012_Business_Partner_Pool_API_v_1.1.1.pdf)
 
-- [Business Partner Issuing Agency](https://catena-x.net/fileadmin/user_upload/Standard-Bibliothek/Update_PDF_Feb._2023/5_BPDM_v1.0/CX_-_0011_ISSUING_AGENCY_PlatformCapabilityBPDM_v_1.0.0.pdf)
+- [Business Partner Issuing Agency](https://catena-x.net/fileadmin/user_upload/Standard-Bibliothek/Update_PDF_Maerz/5_BPDM/CX_-_0011_ISSUING_AGENCY_PlatformCapabilityBPDM_v_1.0.1.pdf)


### PR DESCRIPTION
In the BP KIT, adoption view are links to standards of the Catena-X homepage (standard library) available - they were outdated. Updated three links.