### PR TITLE
chore: fix typos licence → license

### DIFF
--- a/docs/release/trg-5/trg-5-02.md
+++ b/docs/release/trg-5/trg-5-02.md
@@ -38,7 +38,7 @@ charts/
     ...
 AUTHORS.md
 DEPENDENCIES.md
-LICENCE
+LICENSE
 README.md
 ```
 
@@ -47,9 +47,9 @@ Structure](../trg-2/trg-2-3.md).
 
 ### Chart File Structure
 
-:::danger Licence Headers required
+:::danger License/Copyright Headers required
 
-It is **mandatory to add a valid licence header** to each file (except of rendered files, e.g. Markdown files) in the
+It is **mandatory to add a valid license/copyright header** to each file (except of rendered files, e.g. Markdown files) in the
 Git repository!
 
 For further details, please refer to [How to make your Catena-X product OSS
@@ -61,8 +61,9 @@ For Eclipse Tractus-X Helm charts we expect the following charts structure as a 
 
 ```text
 chartName/
+  .helmignore          # mandatory
   Chart.yaml           # mandatory
-  LICENCE              # mandatory
+  LICENSE              # mandatory
   README.md            # mandatory
   values.yaml          # mandatory
   crds/                # optional
@@ -98,9 +99,9 @@ maintainers: # Optional, could become mandatory in Eclipse repositories
 For further details about the `Chart.yaml` file please refer to [Helm
 documentation](https://helm.sh/docs/topics/charts/#the-chartyaml-file).
 
-#### The `LICENCE` File
+#### The `LICENSE` File
 
-The file **must** contain the [Apache 2.0 Licence](https://github.com/catenax-ng/foss-example/blob/main/general/LICENSE).
+The file **must** contain the [Apache 2.0 License](https://github.com/catenax-ng/foss-example/blob/main/general/LICENSE).
 
 #### The `README.md` File
 


### PR DESCRIPTION
Typo corrected, especially for file name. Also added `.helmignore` to example list and enhanced on license/copyright header.