### PR TITLE
chore: TRG 4.01 - update example workflow

### DIFF
--- a/docs/release/trg-4/trg-4-01.md
+++ b/docs/release/trg-4/trg-4-01.md
@@ -2,10 +2,11 @@
 title: TRG 4.01 - Image tagging
 ---
 
-| Status | Created     | Post-History                     |
-|--------|-------------|----------------------------------|
-| Active | 24-Nov-2022 | more precise process description |
-|        | 10-Nov-2022 | Initial release                  |
+| Status | Created     | Post-History                              |
+|--------|-------------|-------------------------------------------|
+| Active | 11-May-2023 | update example workflow to match TRG 4.05 |
+|        | 24-Nov-2022 | more precise process description          |
+|        | 10-Nov-2022 | Initial release                           |
 
 ## Why
 
@@ -28,7 +29,7 @@ steps:
 
 1. Create/edit your `Dockerfile` and merge Changes via PullRequest to `main` branch, if changes where made in a feature
    branch, or similar.
-1. Create/push a Git tag to `main` branch, e.g.:
+2. Create/push a Git tag to `main` branch, e.g.:
 
    ```shell
    > git pull
@@ -53,8 +54,8 @@ steps:
    to [Git documentation](https://git-scm.com/book/en/v2/Git-Basics-Tagging#_creating_tags) about tags.
 
    :::
-1. Pushing the tag will trigger the GH workflow to build your Docker image
-1. After the finishing the build workflow, your repository will contain proper versioned Docker images, e.g.:
+3. Pushing the tag will trigger the GH workflow to build your Docker image
+4. After the finishing the build workflow, your repository will contain proper versioned Docker images, e.g.:
 
    ![SemVer Docker images](assets/trg4-1-semver-image.png)
 
@@ -78,10 +79,8 @@ on:
       - main
 
 env:
-  # Use GH Container Registry instead of docker
-  # github.repository equals to <account|org>/<repo>
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+   IMAGE_NAMESPACE: "tractusx"
+   IMAGE_NAME: "YourApplicationName"
 
 jobs:
   docker:
@@ -98,28 +97,43 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}
-            type=semver,pattern={{major}}.{{minor}}
+           images: |
+              ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+           # Automatically prepare image tags; See action docs for more examples. 
+           # semver patter will generate tags like these for example :1 :1.2 :1.2.3
+           tags: |
+              type=ref,event=branch
+              type=ref,event=pr
+              type=semver,pattern={{version}}
+              type=semver,pattern={{major}}
+              type=semver,pattern={{major}}.{{minor}}
 
-      - name: Log into registry ${{ env.REGISTRY }}
+      - name: DockerHub login
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+           # Use existing DockerHub credentials present as secrets
+           username: ${{ secrets.DOCKER_HUB_USER }}
+           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+           context: .
+           # Build image for verification purposes on every trigger event. Only push if event is not a PR
+           push: ${{ github.event_name != 'pull_request' }}
+           tags: ${{ steps.meta.outputs.tags }}
+           labels: ${{ steps.meta.outputs.labels }}
+
+       # https://github.com/peter-evans/dockerhub-description
+       # Important step to push image description to DockerHub 
+      - name: Update Docker Hub description
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+           # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'   
+           # readme-filepath: path/to/dedicated/notice-for-docker-image.md 
+           username: ${{ secrets.DOCKER_HUB_USER }}
+           password: ${{ secrets.DOCKER_HUB_TOKEN }}
+           repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
 ```


### PR DESCRIPTION
As _TRG 4.05 - Container registries_ got introduced, we had 2 different workflow examples in our TRGs for container image tagging. This is to align the workflows again.