### PR TITLE
feat: add auto documentation update

### DIFF
--- a/.github/workflows/build-and-deploy-gh-pages.yaml
+++ b/.github/workflows/build-and-deploy-gh-pages.yaml
@@ -31,24 +31,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      
+        with:
+          path: main-repo
+      # - name: check out kit repo
+      #   uses: actions/checkout@v3
+      #   with: 
+      #     # add the kit repository
+      #     repository: "<repo-owner>/<repo name>"
+      #     path: <repo name>
+      # - name: copy docs
+      #   run: |
+      #     # create path for the KIT Repository
+      #     mkdir -p main-repo/docs/test-kit &&
+      #     # copy documentation to website
+      #     cp -r <repo name>/path/to/documentation main-repo/docs/<repo name>
+        
       - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: npm
-
+          cache-dependency-path: 'main-repo/package-lock.json'
       - name: Install dependencies
-        run: npm ci
+        run: cd main-repo && npm ci
 
       - name: Build website
-        run: npm run build
+        run: cd main-repo && npm run build
 
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
+          publish_dir: ./main-repo/build
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212


### PR DESCRIPTION
with this PR we extend the gh-pages workflow to copy a kits documentation during the build process. An explanation will be added in the GitHub wiki.

[Link to Wiki](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/wiki/Automate-KIT-documentation-update)