### PR TITLE
Add/kits dropdown menu

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -284,16 +284,29 @@ const config = {
             label: "About Us",
           },
           {
-            to: "/developer",
-            position: "left",
-            label: "KITs",
+            type: 'dropdown',
+            label: 'KITs',
+            position: 'left',
+            to: '/developer',
+            items: [
+              {
+                to: '/docs/kits/Business%20Partner%20Kit/Adoption%20View',
+                label: 'Business Partner',
+              },
+              {
+                to: '/docs/kits/Data%20Chain%20Kit/Adoption%20View',
+                label: 'Data Chain',
+              },
+              {
+                to: '/docs/kits/tractusx-edc/docs/kit/adoption-view/Adoption%20View',
+                label: 'Connector',
+              },
+              {
+                to: '/docs/kits/Traceability%20Kit/Adoption%20View%20Traceability%20Kit',
+                label: 'Traceability',
+              },
+            ],
           },
-          // {
-          //   type: 'doc',
-          //   docId: 'introduction',
-          //   position: 'left',
-          //   label: 'Documentation',
-          // },
           {
             type: 'doc',
             docId: 'developer',
@@ -310,7 +323,6 @@ const config = {
             position: "left",
             label: "Versions",
           },
-          /* {to: '/blog', label: 'Blog', position: 'left'}, */
           {
             href: 'https://github.com/eclipse-tractusx/eclipse-tractusx.github.io',
             label: 'GitHub',

--- a/src/components/ProductAccordionCard/styles.module.css
+++ b/src/components/ProductAccordionCard/styles.module.css
@@ -77,7 +77,7 @@
 
 .description {
   font-weight: 400;
-  font-size: 16px;
+  font-size: 14px;
   line-height: 27px;
 }
 


### PR DESCRIPTION
This PR adds a `dropdown` functionality to the KITs item in the `Navbar`, the items of the menu are links that navigates to each Kits `Adoption View` page.

The resultant UI is:

<img width="1758" alt="Screenshot 2023-05-26 at 15 50 52" src="https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/68547995/77bd31e3-035e-470d-b281-de41b0893446">

A small change in the `font-size` of the description section from the `ProductAccordionCard` component is been included, from 16px to 14px