### PR TITLE
docs(trg-helm): improve helm test workflow

### DIFF
--- a/docs/release/trg-0/trg-0.md
+++ b/docs/release/trg-0/trg-0.md
@@ -6,6 +6,7 @@ title: TRG 0 - Changelog & Drafts
 
 | Created      | Post-History                                                                                 |
 |--------------|----------------------------------------------------------------------------------------------|
+| 6-June-2023  | Extend helm test example workflow (5.09) for k8s versions (5.10) and upgradeability (5.11)   |
 | 2-June-2023  | Add recommendation for implementing legal notice in frontend apps (7.06)                     |
 | 9-May-2023   | Make DockerHub registry mandatory (4.05), Describe mandatory notice for Docker images (4.06) |
 | 8-May-2023   | Move TRG 7.00-7.07 out of Draft to Final                                                     |

--- a/docs/release/trg-5/trg-5-09.md
+++ b/docs/release/trg-5/trg-5-09.md
@@ -56,6 +56,19 @@ name: Lint and Test Charts
 on:
     pull_request:
     workflow_dispatch:
+      inputs:
+        node_image:
+          description: 'kindest/node image for k8s kind cluster'
+          # k8s version from 3.1 release as default
+          default: 'kindest/node:v1.24.6'
+          required: false
+          type: string
+        upgrade_from:
+          description: 'chart version to upgrade from'
+          # chart version from 3.1 release as default
+          default: 'x.x.x'
+          required: false
+          type: string
 
 jobs:
     lint-test:
@@ -68,38 +81,53 @@ jobs:
 
             - name: Kubernetes KinD Cluster
               uses: container-tools/kind-action@v1
-        
+              with:
+                # upgrade version, default (v0.17.0) uses node image v1.21.1 and doesn't    rk with more recent node image versions
+                version: v0.19.0
+                # default value for event_name != workflow_dispatch
+                node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.24.6' }}
+
             - name: Build image
               uses: docker/build-push-action@v3
               with:
                 context: .
                 push: true
                 tags: kind-registry:5000/app-dashboard:testing
-        
+
             - name: Set up Helm
               uses: azure/setup-helm@v3
               with:
                 version: v3.9.3
-        
+
             - uses: actions/setup-python@v4
               with:
                 python-version: '3.9'
                 check-latest: true
-        
             - name: Set up chart-testing
               uses: helm/chart-testing-action@v2.3.1
-        
+
             - name: Run chart-testing (list-changed)
               id: list-changed
               run: |
                 changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
                 if [[ -n "$changed" ]]; then
-                   echo "::set-output name=changed::true"
+                  echo "changed=true" >> $GITHUB_OUTPUT
                 fi
+
             - name: Run chart-testing (lint)
               run: ct lint --validate-maintainers=false --target-branch ${{ github.event.repository.default_branch }}
-        
             - name: Run chart-testing (install)
               run: ct install --charts charts/app-dashboard
-              if: steps.list-changed.outputs.changed == 'true'
+              if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
+
+              # Upgrade the released chart version with the locally available chart
+              # default value for event_name != workflow_dispatch
+            - name: Run helm upgrade
+              run: |
+                helm repo add bitnami https://charts.bitnami.com/bitnami
+                helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
+                helm install [CHART] tractusx-dev/[CHART] --version ${{ github.event.inputs.upgrade_from || 'x.x.x' }}
+                helm dependency update charts/[CHART]
+                helm upgrade portal charts/[CHART]
+              if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
 ```

--- a/docs/release/trg-5/trg-5-09.md
+++ b/docs/release/trg-5/trg-5-09.md
@@ -82,7 +82,7 @@ jobs:
             - name: Kubernetes KinD Cluster
               uses: container-tools/kind-action@v1
               with:
-                # upgrade version, default (v0.17.0) uses node image v1.21.1 and doesn't    rk with more recent node image versions
+                # upgrade version, default (v0.17.0) uses node image v1.21.1 and doesn't work with more recent node image versions
                 version: v0.19.0
                 # default value for event_name != workflow_dispatch
                 node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.24.6' }}


### PR DESCRIPTION
- provide example to enable workflow for testing of different k8s versions and helm upgrade via workflow dispatch
- enable chart-testing (install) and helm upgrade steps to not be skipped on workflow dispatch (adjusted if statement)
- upgrade container-tools/kind-action as default version (v0.17.0) uses node image v1.21.1 and doesn't work with more recent node image versions
- replace deprecated set-output command
- update changelog