### PR TITLE
Fix/Home-Page-Header BG dimensions

### DIFF
--- a/src/components/HomePageHeader/styles.module.css
+++ b/src/components/HomePageHeader/styles.module.css
@@ -47,6 +47,10 @@
 }
 
 @media screen and (max-width: 996px) {
+  .container {
+    background-position: center right;
+  }
+
   .title {
     font-size: 10vw;
     line-height: 10vw;
@@ -63,6 +67,11 @@
 }
 
 @media screen and (max-width: 600px) {
+  .container {
+    justify-content: flex-start;
+    padding-top: 30%;
+  }
+
   .title {
     font-size: 44px;
     line-height: 40px;

--- a/src/components/NewsTicker/styles.module.css
+++ b/src/components/NewsTicker/styles.module.css
@@ -120,6 +120,10 @@
     gap: 0.5rem;
   }
 
+  .arrow_container {
+    display: none;
+  }
+
   .slider_item {
     flex-direction: column;
   }


### PR DESCRIPTION
---
name: Fix/Home-Page-Header BG dimensions
about: 'background position adjusted at 600px width and padding-top decrease, both changes occurred in the home page header component'
title: 'fix|Home-Page-Header BG dimensions'
---

## Description

This simple PR improves the UI of the `HomePageHeader` component when it displayed in small screen devices, it contains 2 minor changes that affects the position of the BG and the padding-top of the banner when displayed in devices =< 600px.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files

### Additional information

N/A

