### PR TITLE
Docs/security reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,5 +2,10 @@
 
 ## Reporting a Vulnerability
 
-Please report a found vulnerability here:
-[https://www.eclipse.org/security/](https://www.eclipse.org/security/)
+Please do not report security vulnerabilities through public GitHub issues.
+
+Please report vulnerabilities to this repository via GitHub security advisories instead.
+
+How? Inside affected repository --> security tab --> advisories --> New draft security advisory
+
+In severe cases, you can also report a found vulnerability here: https://www.eclipse.org/security/

--- a/docs/release/trg-7/trg-7-01.md
+++ b/docs/release/trg-7/trg-7-01.md
@@ -67,6 +67,7 @@ If different technologies / package managers (e.g. npm and maven) are used you a
 ### SECURITY FILE
 
 - The security file should at least contain information, where/how to report a vulneriability issue
+- Please report vulnerabilities as GitHub security advisories
 - Add this [link](https://www.eclipse.org/security/)
 - [Example](https://github.com/eclipse-tractusx/app-dashboard/blob/main/SECURITY.md)
 


### PR DESCRIPTION
New SECURITY.md vulnerability "policy".
First report vulnerabilities via a GitHub security advisory and then to the Eclipse security dashboard.
This is agreed with the Eclipse security team.