### PR TITLE
fix: TRG update

### DIFF
--- a/docs/release/trg-0/trg-3-2.md
+++ b/docs/release/trg-0/trg-3-2.md
@@ -2,12 +2,12 @@
 title: TRG 3.02 - Persist Data
 ---
 
-| Status | Created     | Post-History  |
-|--------|-------------|---------------|
-| Draft  | 17-Jul-2023 | typo fix      |
-| Active | 07-Mar-2023 |               |
-| Draft  | 02-Jan-2023 | n/a           |
-| Moved  | 02-Jan-2023 | content moved |
+| Status | Created     | Post-History    |
+|--------|-------------|-----------------|
+| Draft  | 17-Jul-2023 | 'loos' typo fix |
+| Active | 07-Mar-2023 |                 |
+| Draft  | 02-Jan-2023 | n/a             |
+| Moved  | 02-Jan-2023 | content moved   |
 
 ## Why
 

--- a/docs/release/trg-0/trg-3-2.md
+++ b/docs/release/trg-0/trg-3-2.md
@@ -1,0 +1,74 @@
+---
+title: TRG 3.02 - Persist Data
+---
+
+| Status | Created     | Post-History  |
+|--------|-------------|---------------|
+| Draft  | 17-Jul-2023 | typo fix      |
+| Active | 07-Mar-2023 |               |
+| Draft  | 02-Jan-2023 | n/a           |
+| Moved  | 02-Jan-2023 | content moved |
+
+## Why
+
+In cases where data has to be persisted (database, uploaded files etc.), Kubernetes **must** be configured to create Persistent Volume that is attached to an underlying disk where data remains even after the deletion of the application. Otherwise, an incidental deletion will delete all state.
+
+## Description
+
+Using stateful data requires additional caution to not lose data by accident. Therefore, when a pod/deployment/statefulset resource is removed, data will still be available on the StorageClass's disk that was used.
+
+## How
+
+Example PersistentVolumeClaim:
+
+```yaml
+# pvc.yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-persistent-tmp-demo
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Mi
+```
+
+This can be referenced in the volumes section of a Pod/Deployment/StatefulSet resource:
+
+```yaml
+# deployment.yaml
+#...
+      volumes:
+        - name: pv-tmp-demo
+          persistentVolumeClaim:
+            claimName: pvc-persistent-tmp-demo
+#...
+```
+
+:::tip
+
+It is not recommended to directly request the claim in a StatefulSet! Rather create the PVC separately and reference that as an existing claim. See the example in [Bitnami's Postgresql chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) where an existing claim can be referenced for the primary database at the [primary.persistence.existingClaim property](https://github.com/bitnami/charts/tree/main/bitnami/postgresql#postgresql-primary-parameters).
+
+:::
+
+### How to expand volume in Kubernetes with ArgoCD
+
+1. Open **ArgoCD** in the desired environment and find the application
+1. Delete all Pod's that are attached to the volume. This also can be achieved by **scaling a StatefulSet to 0 replicas**
+1. Find the desired PersistenceVolumeClaim resource, click on it and press **Edit**
+1. Change the **spec.resource.requests.storage** property's value to the desired size
+1. Save the changes and wait for them to take effect.
+   This can be found in the PVC's status section:
+
+   ```yaml
+   status:
+     accessModes:
+       - ReadWriteOnce
+     capacity:
+       storage: 16Gi # DESIRED SIZE
+     phase: Bound
+   ```
+
+1. Scale back the StatefulSet to the original replica count

--- a/docs/release/trg-0/trg-5-02.md
+++ b/docs/release/trg-0/trg-5-02.md
@@ -4,7 +4,7 @@ title: TRG 5.02 - Chart structure
 
 | Status | Created     | Post-History                                           |
 |--------|-------------|--------------------------------------------------------|
-| Draft  | 17-Jul-2023 | templates/NOTES.txt made optional
+| Draft  | 17-Jul-2023 | templates/NOTES.txt made optional                      |
 | Active | 10-Jan-2023 | add prerequisite and TL;DR as requirement in README.md |
 | Active | 10-Nov-2022 | Initial release                                        |
 

--- a/docs/release/trg-0/trg-5-02.md
+++ b/docs/release/trg-0/trg-5-02.md
@@ -1,0 +1,171 @@
+---
+title: TRG 5.02 - Chart structure
+---
+
+| Status | Created     | Post-History                                           |
+|--------|-------------|--------------------------------------------------------|
+| Draft  | 17-Jul-2023 | templates/NOTES.txt made optional
+| Active | 10-Jan-2023 | add prerequisite and TL;DR as requirement in README.md |
+| Active | 10-Nov-2022 | Initial release                                        |
+
+## Why
+
+Following best practices when creating the chart helps everyone better understand, deploy and test the product. Having
+similar structure for every Helm chart enables easy understand, simple implementation of testing and deployment workflows.
+
+Having the helm chart in the same directory than everyone else allows for easy finding the right helm chart.
+
+## Description
+
+Each Helm chart **should** follow a specific structure. Helm
+provides [recommendations for creating charts](https://helm.sh/docs/chart_template_guide/getting_started/).
+
+For Eclipse Tractus-X Helm charts the following requirements **must** be met:
+
+- Helm chart location inside Git repository
+- Helm chart file structure defined below
+
+### Chart Location
+
+Helm charts **must** be located inside the `/charts` directory of the Git repository.
+
+```text
+charts/
+  chartNameA/
+    Chart.yaml
+    ...
+  chartNameB/
+    Chart.yaml
+    ...
+AUTHORS.md
+DEPENDENCIES.md
+LICENSE
+README.md
+```
+
+For further details about the Git repository structure, please refer to [TRG 2.03 - Repo
+Structure](../trg-2/trg-2-3.md).
+
+### Chart File Structure
+
+:::danger License/Copyright Headers required
+
+It is **mandatory to add a valid license/copyright header** to each file (except of rendered files, e.g. Markdown files) in the
+Git repository!
+
+For further details, please refer to [How to make your Catena-X product OSS
+ready](https://github.com/catenax-ng/foss-example#how-to-make-your-catenax-product-oss-ready).
+
+:::
+
+For Eclipse Tractus-X Helm charts we expect the following charts structure as a minimal set (except of optional parts):
+
+```text
+chartName/
+  .helmignore          # mandatory
+  Chart.yaml           # mandatory
+  LICENSE              # mandatory
+  README.md            # mandatory
+  values.yaml          # mandatory
+  crds/                # optional
+  templates/           # mandatory, except of umbrella Helm charts
+  templates/NOTES.txt  # optional 
+```
+
+For further details on Helm chart basics, please refer to [Helm documentation](https://helm.sh/docs/topics/charts/).
+
+#### The `Chart.yaml` File
+
+The following represents the minimum set of expected fields in `Chart.yaml` file:
+
+```yaml
+apiVersion: The chart API Version
+name: The name of the chart
+appVersion: The application version the chart will install
+version: A SemVer 2 version of the chart
+description: A brief description of the chart
+home: The URL of the product home page
+sources:
+  - A list of URLs to source code of this project
+dependencies: # A list of the chart requirements (if any)
+  - name: The name of the chart
+    version: The version of the chart
+    repository: The repository URL
+maintainers: # Optional, could become mandatory in Eclipse repositories
+  - name: Maintainers name
+    email: optional
+    url: A URL for the maintainer, optional
+```
+
+For further details about the `Chart.yaml` file please refer to [Helm
+documentation](https://helm.sh/docs/topics/charts/#the-chartyaml-file).
+
+#### The `LICENSE` File
+
+The file **must** contain the [Apache 2.0 License](https://github.com/catenax-ng/foss-example/blob/main/general/LICENSE).
+
+#### The `README.md` File
+
+The README.md file **must** contain:
+
+- a brief explanation of what the Helm chart will install
+- a section of "Prerequisites" includes the required kubernetes version, helm version and other necessary prerequisites and their versions. Example:
+
+  ```markdown
+  - Kubernetes 1.19+
+  - Helm 3.2.0+
+  - PV provisioner support in the underlying infrastructure
+  ```
+  
+- a section of "TL;DR" that includes the helm commands to add and install the helm chart, Example:
+
+  ```shell
+  helm repo add my-repo https://charts.bitnami.com/bitnami
+  helm install my-release my-repo/postgresql
+  ```
+  
+- documentation of default values for this Helm chart ([_helm-docs_](https://github.com/norwoodj/helm-docs#helm-docs)
+  may help).
+
+#### The `values.yaml` File
+
+The `values.yaml` file contains all necessary variables the Helm chart requires for successful installation. At the same
+time this enables users to override the default values.
+
+For best practices on `values.yaml` files, please refer to [TRG 5.05 - Chart Values](trg-5-05.md) or [Helm
+documentation](https://helm.sh/docs/chart_template_guide/values_files/).
+
+:::caution multiple values files not allowed
+
+All default values **must** be introduced with `values.yaml` file to successfully install the Helm chart.
+
+There **must** be no additional `values-xyz.yaml` files, e.g. to specify environment specific values. Only `values.yaml` file
+is allowed!
+:::
+
+#### The `crds` Directory
+
+If the Helm chart installs custom resource definitions, this directory is the place to locate the manifest files in.
+
+For further details, refer to [Helm
+documentation](https://helm.sh/docs/topics/charts/#custom-resource-definitions-crds).
+
+#### The `templates` Directory
+
+The `templates` directory contains manifest files, which will be deployed during Helm chart installation. For further
+details, refer to [Helm documentation](https://helm.sh/docs/topics/charts/#template-files).
+
+#### The `templates/NOTES.txt` File
+
+The content of `templates/NOTES.txt` will be printed after Helm chart installation. The file is evaluated as a template
+file with all possibilities of templating.
+
+#### `.helmignore`
+
+The `.helmignore` file should contain as a minimal set the following entries:
+
+```gitignore
+# Accept only values.yaml
+values?*.yaml
+values?*.yml
+```

--- a/docs/release/trg-0/trg-5-11.md
+++ b/docs/release/trg-0/trg-5-11.md
@@ -1,0 +1,25 @@
+---
+title: TRG 5.11 - Upgradeability PRERELEASE
+---
+
+:::caution
+Proposed release date: "mandatory after": 19th of May 2023
+:::
+
+| Status     | Created     | Post-History       |
+|------------|-------------|--------------------|
+| Draft      | 17-Jul-2023 | typo fix           |
+| Prerelease | 7-Mar-2023  | Moved out of draft |
+| Draft      | 24-Feb-2022 | n/a                |
+
+## Why
+
+With using helm charts, the upgrade of an application also happens through an upgrade of the helm chart. The application handles the upgrade itself like executing a database upgrade. The upgrade of the helm chart itself also needs to be tested and by testing the helm upgrade, you automatically verify that the application upgrade works too.
+
+## Description
+
+Based on the [Helm test](trg-5-09.md) workflow, you **must** provide a GitHub action which takes the latest released helm chart, does an installation of it and then execute the upgrade to the current / new version.
+
+To do so you **must** provide a GitHub action which runs helm install of the last released version and than a helm upgrade of the version to be released and than execute a helm test.
+
+The **GitHub Action** needs to be able to be **triggered manually**.

--- a/docs/release/trg-0/trg-5-11.md
+++ b/docs/release/trg-0/trg-5-11.md
@@ -8,7 +8,7 @@ Proposed release date: "mandatory after": 19th of May 2023
 
 | Status     | Created     | Post-History       |
 |------------|-------------|--------------------|
-| Draft      | 17-Jul-2023 | typo fix           |
+| Draft      | 17-Jul-2023 | 'handels' typo fix |
 | Prerelease | 7-Mar-2023  | Moved out of draft |
 | Draft      | 24-Feb-2022 | n/a                |
 


### PR DESCRIPTION
## Description

Consolidated update of 3 TRGs:

- TRG 5.02 - made templates/NOTES.txt file as optional for the Helm Chart structure, aligning with [Helm documentation](https://helm.sh/docs/topics/charts/)
- TRG-3.2 & TRG 5.11 typo fixes

Updates https://github.com/eclipse-tractusx/sig-infra/issues/93

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] Copyright and license header are present on all affected files

### Additional information

- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)
