### PR TITLE
docs: Create trg-7-01.md

### DIFF
--- a/docs/release/trg-0/trg-7-01.md
+++ b/docs/release/trg-0/trg-7-01.md
@@ -72,14 +72,20 @@ If different technologies / package managers (e.g. npm and maven) are used you a
 
 SECURITY.md example:
 
-```bash
+```md
 ## Reporting a Vulnerability
 
 Please do **not** report security vulnerabilities through public GitHub issues.
 
 Please report vulnerabilities to this repository via **GitHub security advisories** instead.
 
-How? Inside affected repository --> security tab --> Report a vulnerability
+How? Inside affected repository --> security tab
+
+for contributor:
+--> Report a vulnerability
+
+for committer:
+--> advisories --> New draft security advisory
 
 In severe cases, you can also report a found vulnerability via mail or eclipse issue here: https://www.eclipse.org/security/
 

--- a/docs/release/trg-0/trg-7-01.md
+++ b/docs/release/trg-0/trg-7-01.md
@@ -79,7 +79,7 @@ Please do **not** report security vulnerabilities through public GitHub issues.
 
 Please report vulnerabilities to this repository via **GitHub security advisories** instead.
 
-How? Inside affected repository --> security tab --> advisories --> New draft security advisory
+How? Inside affected repository --> security tab --> Report a vulnerability
 
 In severe cases, you can also report a found vulnerability here: https://www.eclipse.org/security/
 

--- a/docs/release/trg-0/trg-7-01.md
+++ b/docs/release/trg-0/trg-7-01.md
@@ -5,6 +5,7 @@ title: TRG 7.01 - Legal Documentation
 | Status | Created     | Post-History  |
 |--------|-------------|---------------|
 | Draft  | 13-Apr-2023 | Moved from OSS Development           |
+| Draft  | 18-Jul-2023 | Proposed new SECURITY.md file           |
 
 ## Why
 
@@ -74,7 +75,7 @@ See the [Handbook#vulnerability](https://www.eclipse.org/projects/handbook/#vuln
 
 See new SECURITY.md example:
 
-```
+```bash
 ## Reporting a Vulnerability
 
 Please do not report security vulnerabilities through public GitHub issues.

--- a/docs/release/trg-0/trg-7-01.md
+++ b/docs/release/trg-0/trg-7-01.md
@@ -81,7 +81,7 @@ Please report vulnerabilities to this repository via **GitHub security advisorie
 
 How? Inside affected repository --> security tab --> Report a vulnerability
 
-In severe cases, you can also report a found vulnerability here: https://www.eclipse.org/security/
+In severe cases, you can also report a found vulnerability via mail or eclipse issue here: https://www.eclipse.org/security/
 
 See [Eclipse Foundation Vulnerability Reporting Policy](https://www.eclipse.org/projects/handbook/#vulnerability)
 ```

--- a/docs/release/trg-0/trg-7-01.md
+++ b/docs/release/trg-0/trg-7-01.md
@@ -1,0 +1,113 @@
+---
+title: TRG 7.01 - Legal Documentation
+---
+
+| Status | Created     | Post-History  |
+|--------|-------------|---------------|
+| Draft  | 13-Apr-2023 | Moved from OSS Development           |
+
+## Why
+
+Eclipse Tractus-X is an open source project hosted by the Eclipse Foundation licensed under the [Apache License 2.0](https://spdx.org/licenses/Apache-2.0). The legal obligations of the content must be observed in all forms of which the content is available.
+
+This page contains information about legal documentation requirements in your repositories. The source of truth is always the [Eclipse Foundation Project Handbook](https://www.eclipse.org/projects/handbook/#legaldoc).
+
+:::info
+
+The requirements described here **must** be met for each contribution.
+
+:::
+
+## Description
+
+The following files must be part of your repository root folder:
+
+- LICENSE
+- NOTICE.md
+- DEPENDENCIES
+- SECURITY.md
+- CONTRIBUTING.md
+- CODE_OF_CONDUCT.md
+
+For examples look to the [Eclipse Tractus-X GitHub Organisation](https://github.com/eclipse-tractusx), e.g. the [APP Dashboard](https://github.com/eclipse-tractusx/app-dashboard).
+
+### LICENSE FILE
+
+In Eclipse Tractus-X the primary outbound license is Apache-2.0.
+
+- SPDX-License-Identifier: Apache-2.0
+- [License Text](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+See the [Handbook#legaldoc-license](https://www.eclipse.org/projects/handbook/#legaldoc-license).
+
+For documentation the Creative Commons Attribution 4.0 International (CC BY 4.0) is recommended, see [here](/docs/release/trg-7/trg-7-06#documentation).
+
+### NOTICE FILE
+
+- Add the link to your repository
+- Add the link(s) to your SBOM, e.g. the DEPENDENCY file (one or more)
+- Add information for third party content checks, if not covered by the Dash Tool (e.g. IP checks for icons, fonts, ...)
+
+[Further information](/docs/release/trg-7/trg-7-04#checking-other-content-fonts-images-) and see the [Handbook#legaldoc-notice](https://www.eclipse.org/projects/handbook/#legaldoc-notice).
+
+### DEPENDENCY FILE
+
+:::info
+
+Third-party dependencies need to be checked regularly to reflect your code changes. The DEPENDENCY file must be updated accordingly. This is recommended for every contribution (e.g. PR) whenever possible.
+
+:::
+
+- Create it with the [Eclipse Dash License Tool](https://www.eclipse.org/projects/handbook/#ip-license-tool)
+
+If different technologies / package managers (e.g. npm and maven) are used you are free to have several dependency files. Use the naming convention DEPENDENCY_XYZ, e.g. DEPENDENCY_FRONTEND and DEPENDENCY_BACKEND.
+
+[Further information](/docs/release/trg-7/trg-7-04)
+
+### SECURITY FILE
+
+- The security file should at least contain information, where/how to report a vulneriability issue
+- Add this [link](https://www.eclipse.org/security/)
+- **Will be updated** [Example](https://github.com/eclipse-tractusx/app-dashboard/blob/main/SECURITY.md)
+
+See the [Handbook#vulnerability](https://www.eclipse.org/projects/handbook/#vulnerability).
+
+See new SECURITY.md example:
+
+```
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+Please report vulnerabilities to this repository via GitHub security advisories instead.
+
+How? Inside affected repository --> security tab --> advisories --> New draft security advisory
+
+In severe cases, you can also report a found vulnerability here: https://www.eclipse.org/security/
+```
+
+### CONTRIBUTOR GUIDE
+
+See the [Handbook#legaldoc-contributor](https://www.eclipse.org/projects/handbook/#legaldoc-contributor)
+
+### CODE OF CONDUCT
+
+:::info
+
+The Version 2.0  of the Eclipse Foundation Community Code of Conduct was released on Jan 01, 2023.
+Update the file in your repositories.
+
+:::
+
+See the [CODE OF CONDUCT](https://www.eclipse.org/org/documents/Community_Code_of_Conduct.php)
+and here in [md format](https://raw.githubusercontent.com/eclipse/.github/master/CODE_OF_CONDUCT.md).
+
+### AUTHORS FILE (optional)
+
+- Add the authors and further contact information
+- [Example](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/blob/main/AUTHORS.md)
+
+## Existing checks for the legal documentation
+
+- [EF - Legal Documentation Generator](https://www.eclipse.org/projects/tools/documentation.php?id=automotive.tractusx)
+- [TractusX - Central Github Checks](https://eclipse-tractusx.github.io/docs/github-checks)

--- a/docs/release/trg-0/trg-7-01.md
+++ b/docs/release/trg-0/trg-7-01.md
@@ -69,22 +69,21 @@ If different technologies / package managers (e.g. npm and maven) are used you a
 
 - The security file should at least contain information, where/how to report a vulneriability issue
 - Add this [link](https://www.eclipse.org/security/)
-- **Will be updated** [Example](https://github.com/eclipse-tractusx/app-dashboard/blob/main/SECURITY.md)
 
-See the [Handbook#vulnerability](https://www.eclipse.org/projects/handbook/#vulnerability).
-
-See new SECURITY.md example:
+SECURITY.md example:
 
 ```bash
 ## Reporting a Vulnerability
 
-Please do not report security vulnerabilities through public GitHub issues.
+Please do **not** report security vulnerabilities through public GitHub issues.
 
-Please report vulnerabilities to this repository via GitHub security advisories instead.
+Please report vulnerabilities to this repository via **GitHub security advisories** instead.
 
 How? Inside affected repository --> security tab --> advisories --> New draft security advisory
 
 In severe cases, you can also report a found vulnerability here: https://www.eclipse.org/security/
+
+See [Eclipse Foundation Vulnerability Reporting Policy](https://www.eclipse.org/projects/handbook/#vulnerability)
 ```
 
 ### CONTRIBUTOR GUIDE


### PR DESCRIPTION
New SECURITY.md vulnerability "policy".
First report vulnerabilities via a GitHub security advisory and then to the Eclipse security dashboard. This is agreed with the Eclipse security team.

The new SECURITY.md is shown in code below.