### PR TITLE
chore: add .tractusx metafile

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,0 +1,6 @@
+product: "eclipse-tractusx.github.io"
+leadingRepository: "https://github.com/eclipse-tractusx/eclipse-tractusx.github.io"
+repositories:
+- name: "eclipse-tractusx.github.io"
+  usage: "Eclipse-tractusx website repository"
+  url: "https://github.com/eclipse-tractusx/eclipse-tractusx.github.io"


### PR DESCRIPTION
This PR adds an initial version of the `.tractusx` metadata file like described in [TRG 2.05](https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-5).
If there are any other repositories, that are connected to the Semantic Hub, that together form a product, please point that out or add the connected repos later on

Fixes #319 
