### PR TITLE
fix/released information links content

### DIFF
--- a/src/pages/release-information.md
+++ b/src/pages/release-information.md
@@ -2,11 +2,11 @@
 
 ## Introduction
 
-Catena-X Standards are the foundation for certifying any software component operating in the Catena-X data space. Those standards are the binding reference to obtain a valid certificate.
+[Catena-X Standards](https://catena-x.net/de/standard-library) are the foundation for certifying any software component operating in the Catena-X data space. Those standards are the binding reference to obtain a valid certificate.
 
-To make adopting the latest Catena-X standards easier, reference implementations are provided through the Elipse Tractus-X Project. Releases of these reference implementations happen four times a year using a calendar versioning scheme ([https://calver.org/](https://calver.org/)), and include the operating system consisting of core services, enablement services, and KITs.
+To make adopting the latest Catena-X standards easier, reference implementations are provided through the Elipse Tractus-X Project. Releases of these reference implementations happen four times a year using a [calendar versioning](https://calver.org/) scheme, and include the operating system consisting of core services, enablement services, and KITs.
 
-Please check the Change Log ([https://eclipse-tractusx.github.io/CHANGELOG](https://eclipse-tractusx.github.io/CHANGELOG)) for content, known knowns, and backward compatibility since the calendar versioning scheme readily shows the year and month of release.
+Please check the [Change Log](/CHANGELOG) for content, known knowns, and backward compatibility since the calendar versioning scheme readily shows the year and month of release.
 
 ![Release information cycles chart](@site/static/img/release-information-cycles.png)
 


### PR DESCRIPTION
Simple fix, redesigning links of released information page

Resultant UI:

<img width="1770" alt="Screenshot 2023-08-07 at 16 42 54" src="https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/68547995/c39bdd50-2d58-4095-8a40-7cf9dd1726bb">
