### PR TITLE
Fix/various doc-kits updates

### DIFF
--- a/docs-kits/kits/Business Partner Kit/Documentation BPDM/bpdm_arc42.md
+++ b/docs-kits/kits/Business Partner Kit/Documentation BPDM/bpdm_arc42.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 ![Business partner kit banner](@site/static/img/BPKitIcon.png)
 
-## Business Partner Kit
+## Business Partner KIT
 
 ## Business Partner Data Management Application for Golden Record (BPDM)
 

--- a/docs-kits/kits/Business Partner Kit/Software Development View/page_software-development-view.md
+++ b/docs-kits/kits/Business Partner Kit/Software Development View/page_software-development-view.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 ![Business partner kit banner](@site/static/img/BPKitIcon.png)
 
-### Business Partner Kit
+### Business Partner KIT
 
 ## API Reference
 

--- a/docs-kits/kits/Business Partner Kit/page_adoption-view.mdx
+++ b/docs-kits/kits/Business Partner Kit/page_adoption-view.mdx
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 ![Business partner kit banner](@site/static/img/BPKitIcon.png)
 
-### Business Partner Kit
+### Business Partner KIT
 
 # Unique business partner data sets for the whole data space.
 ### Basis for the integration of value-adding services in the area of business partner data management.

--- a/docs-kits/kits/Business Partner Kit/page_changelog.md
+++ b/docs-kits/kits/Business Partner Kit/page_changelog.md
@@ -13,12 +13,16 @@ All notable changes to this Kit will be documented in this file.
 
 ## [1.0.0] - 2023-03-01
 
-### Added
+<h3>Added</h3>
 
 - documentation of the software development view including the business partner data management POOL API
 - documentation of adoption view
 - documentation of the operations view with an installation guide for the POOL API
 
-### Changed
+<h3>Changed</h3>
 
-### Removed
+- ./.
+
+<h3>Removed</h3>
+
+- ./.

--- a/docs-kits/kits/Business Partner Kit/page_changelog.md
+++ b/docs-kits/kits/Business Partner Kit/page_changelog.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 ![Business partner kit banner](@site/static/img/BPKitIcon.png)
 
-### Business Partner Kit
+### Business Partner KIT
 
 All notable changes to this Kit will be documented in this file.
 

--- a/docs-kits/kits/Business Partner Kit/page_software-operation-view.md
+++ b/docs-kits/kits/Business Partner Kit/page_software-operation-view.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 ![Business partner kit banner](@site/static/img/BPKitIcon.png)
 
-### Business Partner Kit
+### Business Partner KIT
 
 ## Local Deployment
 

--- a/docs-kits/kits/Data Chain Kit/Documentation/admin_guide.md
+++ b/docs-kits/kits/Data Chain Kit/Documentation/admin_guide.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 ![Datachain kit banner](@site/static/img/DataChainKitIcon.png)
 
-### Data Chain Kit
+### Data Chain KIT
 
 ## System Overview
 

--- a/docs-kits/kits/Data Chain Kit/Documentation/arc42.md
+++ b/docs-kits/kits/Data Chain Kit/Documentation/arc42.md
@@ -9,7 +9,7 @@ sidebar_position: 3
 
 ![Datachain kit banner](@site/static/img/DataChainKitIcon.png)
 
-### Data Chain Kit
+### Data Chain KIT
 
 ## Introduction and goals
 

--- a/docs-kits/kits/Data Chain Kit/Software Development View/page_software-development-view.md
+++ b/docs-kits/kits/Data Chain Kit/Software Development View/page_software-development-view.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 ![Datachain kit banner](@site/static/img/DataChainKitIcon.png)
 
-### Data Chain Kit
+### Data Chain KIT
 
 ## IRS REST API
 

--- a/docs-kits/kits/Data Chain Kit/page_adoption-view.md
+++ b/docs-kits/kits/Data Chain Kit/page_adoption-view.md
@@ -7,13 +7,13 @@ sidebar_position: 1
 
 ![Datachain kit banner](@site/static/img/DataChainKitIcon.png)
 
-### Data Chain Kit
+### Data Chain KIT
 
 DataChainKit brings valuable data chain information to your use-cases and services through connected data that can help Business Owner and Catena-X participants to be up to date and prepared. It's easy to use the DataChainKit with an Open Source Software package, which can easily deployed via HELM or docker-compose. The DataChainKit enables to apply business logic along a distributed data chains, for example aggregation of certificates along the value chain. Also ad-hoc provisioning of continuous data chains across company boundaries for empowerment of use cases Circular Economy, Traceability, Quality and the European supply chain act.
 
 (#GreenIT#DataSovereignty#Interoperability#ConnectedData)
 
-## Why Data Chain Kit
+## Why Data Chain KIT
 
 What is in for you to use the Data Chain Kit. On what is it built on.
 

--- a/docs-kits/kits/Data Chain Kit/page_changelog.md
+++ b/docs-kits/kits/Data Chain Kit/page_changelog.md
@@ -13,7 +13,7 @@ All notable changes to this Kit will be documented in this file.
 
 ## [1.0.0] - 2023-03-01
 
-### Added
+<h3>Added</h3>
 
 - dokumentation of the IRS API
 - dokumentation of adoption view
@@ -21,6 +21,10 @@ All notable changes to this Kit will be documented in this file.
 - dokumentation of the IRS reference implementation
 - two successstories how this Kit is beeing used
 
-### Changed
+<h3>Changed</h3>
 
-### Removed
+- ./.
+
+<h3>Removed</h3>
+
+- ./.

--- a/docs-kits/kits/Data Chain Kit/page_changelog.md
+++ b/docs-kits/kits/Data Chain Kit/page_changelog.md
@@ -7,7 +7,7 @@ sidebar_position: 10
 
 ![Datachain kit banner](@site/static/img/DataChainKitIcon.png)
 
-### Data Chain Kit
+### Data Chain KIT
 
 All notable changes to this Kit will be documented in this file.
 

--- a/docs-kits/kits/Data Chain Kit/page_software-operation-view.md
+++ b/docs-kits/kits/Data Chain Kit/page_software-operation-view.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 ![Datachain kit banner](@site/static/img/DataChainKitIcon.png)
 
-### Data Chain Kit
+### Data Chain KIT
 
 ## Local Deployment
 

--- a/docs-kits/kits/Digital Twin Kit/Software Development View/page_software-development-view.md
+++ b/docs-kits/kits/Digital Twin Kit/Software Development View/page_software-development-view.md
@@ -1,7 +1,7 @@
 ---
-id: Specification Digital Twin Kit
-title: Developing with the DT Kit
-description: 'Digital Twin Kit'
+id: Specification Digital Twin KIT
+title: Developing with the DT KIT
+description: 'Digital Twin KIT'
 sidebar_position: 4
 ---
 
@@ -11,6 +11,8 @@ Development View of the Kit.
 -->
 
 ![DT Kit Pictotogram](../assets/img/DTKIT_pictogram_blue.png)
+
+### Digital Twin KIT
 
 <!-- !Mandatory! -->
 ## API Specifications

--- a/docs-kits/kits/Digital Twin Kit/page_adoption-view.md
+++ b/docs-kits/kits/Digital Twin Kit/page_adoption-view.md
@@ -11,6 +11,8 @@ Adoption View of the Kit.
 
 ![DT Kit Pictotogram](assets/img/DTKIT_pictogram_blue.png)
 
+### Digital Twin KIT
+
 <!-- !Mandatory! -->
 ## Vision & Mission
 

--- a/docs-kits/kits/Digital Twin Kit/page_changelog.md
+++ b/docs-kits/kits/Digital Twin Kit/page_changelog.md
@@ -11,34 +11,34 @@ All notable changes to this Kit will be documented in this file.
 
 ## [0.2.0] - 2023-08-08
 
-### Added
+<h3>Added</h3>
 
 - Additional graphic on terminology
 - section on entire discovery mechanism
 - pictograms
 
-### Changed
+<h3>Changed</h3>
 
 - Clarification on decentralization of registries
 - Minor improvements based on stakeholders' feedback
 - figures optimized for dark backgrounds
 - example data adjusted to standards for CX R3.2
 
-### Removed
+<h3>Removed</h3>
 
 - ./.
 
 
 ## [0.1.0] - 2023-07-12
 
-### Added
+<h3>Added</h3>
 
 - Initial version of the Kit including adoption, operation and development view incl. all relevant API specifications.
 
-### Changed
+<h3>Changed</h3>
 
 - ./.
 
-### Removed
+<h3>Removed</h3>
 
 - ./.

--- a/docs-kits/kits/Digital Twin Kit/page_changelog.md
+++ b/docs-kits/kits/Digital Twin Kit/page_changelog.md
@@ -7,6 +7,8 @@ sidebar_position: 1
 
 ![DT Kit Pictotogram](assets/img/DTKIT_pictogram_blue.png)
 
+### Digital Twin KIT
+
 All notable changes to this Kit will be documented in this file.
 
 ## [0.2.0] - 2023-08-08

--- a/docs-kits/kits/Digital Twin Kit/page_software-operation-view.md
+++ b/docs-kits/kits/Digital Twin Kit/page_software-operation-view.md
@@ -7,6 +7,8 @@ sidebar_position: 3
 
 ![DT Kit Pictotogram](assets/img/DTKIT_pictogram_blue.png)
 
+### Digital Twin KIT
+
 <!--
 Documentation of the kit.
 -->

--- a/docs-kits/kits/Traceability Kit/Software Development View/page_software-development-view.md
+++ b/docs-kits/kits/Traceability Kit/Software Development View/page_software-development-view.md
@@ -7,7 +7,7 @@ sidebar_position: 4
 
 ![Traceability kit banner](@site/static/img/doc-traceability_header-minified.png)
 
-### Traceability Kit
+### Traceability KIT
 
 <!--
 Development View of the Kit.

--- a/docs-kits/kits/Traceability Kit/page_adoption-view.md
+++ b/docs-kits/kits/Traceability Kit/page_adoption-view.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 ![Traceability kit banner](@site/static/img/doc-traceability_header-minified.png)
 
-### Traceability Kit
+### Traceability KIT
 <!--
 Adoption View of the Kit.
 -->

--- a/docs-kits/kits/Traceability Kit/page_changelog.md
+++ b/docs-kits/kits/Traceability Kit/page_changelog.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 ![Traceability kit banner](@site/static/img/doc-traceability_header-minified.png)
 
-### Traceability Kit
+### Traceability KIT
 
 All notable changes to this Kit will be documented in this file.
 

--- a/docs-kits/kits/Traceability Kit/page_changelog.md
+++ b/docs-kits/kits/Traceability Kit/page_changelog.md
@@ -13,29 +13,29 @@ All notable changes to this Kit will be documented in this file.
 
 ## [1.0.1] - 2023-04-14
 
-### Added
+<h3>Added</h3>
 
 - Adoption View: Traceability tutorial video
 - Adoption View: Customer journey
 
-### Changed
+<h3>Changed</h3>
 
 - ./.
 
-### Removed
+<h3>Removed</h3>
 
 - ./.
 
 ## [1.0.0] - 2023-04-12
 
-### Added
+<h3>Added</h3>
 
 - Initial version of the Kit including adoption, operation and development view + two API specifications (Notification API, Unique ID Push API)
 
-### Changed
+<h3>Changed</h3>
 
 - ./.
 
-### Removed
+<h3>Removed</h3>
 
 - ./.

--- a/docs-kits/kits/Traceability Kit/page_software-operation-view.md
+++ b/docs-kits/kits/Traceability Kit/page_software-operation-view.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 ![Traceability kit banner](@site/static/img/doc-traceability_header-minified.png)
 
-### Traceability Kit
+### Traceability KIT
 
 <!--
 Documentation of the Kit.

--- a/docs-kits/kits/tractusx-edc/CHANGELOG.md
+++ b/docs-kits/kits/tractusx-edc/CHANGELOG.md
@@ -8,13 +8,13 @@ All notable changes to this Kit will be documented in this file.
 
 ## [0.5.0] - 2023-08-09
 
-### Changed
+<h3>Changed</h3>
 
 - preparation for release Tractus-X EDC 0.5.0
 
 ## [0.4.0] - 2023-07-07
 
-### Added
+<h3>Added</h3>
 
 - documentation to deal with the new managament-api
 - documentation to deal with the new SSI
@@ -22,13 +22,13 @@ All notable changes to this Kit will be documented in this file.
 - legacy connector documentation which works with daps
 - migration guide to edc version 0.5.x
 
-### Changed
+<h3>Changed</h3>
 
 - helm charts reference now to the edc version 0.5.0-rc5
 - restructuring of the openAPI documentation
 - postmancollection contains the new management-api
 
-### Removed
+<h3>Removed</h3>
 
 - chart documentation for tractusx-connector-app
 - unused files like charts, values.yaml
@@ -36,22 +36,22 @@ All notable changes to this Kit will be documented in this file.
 
 ## [0.3.0] - 2023-05-16
 
-### Added
+<h3>Added</h3>
 
 - chart documentation for tractusx-connector-azure-vault
 
-### Changed
+<h3>Changed</h3>
 
 - helm chart documentation -> added needed properties and information about self-signed certificates for testing
 
-### Removed
+<h3>Removed</h3>
 
 - chart documentation for tractusx-connector-app
 - unused files like charts, values.yaml
 
 ## [0.2.0] - 2023-04-28
 
-### Added
+<h3>Added</h3>
 
 - documentation of the control-plane-adapter extension
 - openAPI documentation of the control-plane-adapter extension
@@ -59,23 +59,29 @@ All notable changes to this Kit will be documented in this file.
 - migration documentation
 - postman collection
 
-### Changed
+<h3>Changed</h3>
 
 - helm chart version for the edc components is now 0.3.3
 - switched the whole documentation structure from product-edc to tractusx-edc
 - switched build tool from maven to gradle
 - restructured the whole documentation structure and order
 
-### Removed
+<h3>Removed</h3>
+
+- ./.
 
 ## [0.1.0] - 2023-03-01
 
-### Added
+<h3>Added</h3>
 
 - documentation of the management-api
 - documentation of adoption view
 - documentation of software development view
 
-### Changed
+<h3>Changed</h3>
 
-### Removed
+- ./.
+
+<h3>Removed</h3>
+
+- ./.

--- a/docs-kits/kits/tractusx-edc/CHANGELOG.md
+++ b/docs-kits/kits/tractusx-edc/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ![Connector kit banner](@site/static/img/ConnectorKitIcon.png)
 
-## Connector Kit
+## Connector KIT
 
 All notable changes to this Kit will be documented in this file.
 

--- a/docs-kits/kits/tractusx-edc/docs/kit/adoption-view/page_adoption-view.md
+++ b/docs-kits/kits/tractusx-edc/docs/kit/adoption-view/page_adoption-view.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 ![Connector kit banner](@site/static/img/ConnectorKitIcon.png)
 
-## Connector Kit
+## Connector KIT
 
 The ConnectorKit provides a connector framework, based on the [Eclipse Dataspace Connector][edc-url] for sovereign, cross-enterprise data exchange.
 

--- a/docs-kits/kits/tractusx-edc/docs/kit/development-view/page00_development_view.md
+++ b/docs-kits/kits/tractusx-edc/docs/kit/development-view/page00_development_view.md
@@ -2,7 +2,7 @@
 
 ![Connector kit banner](@site/static/img/ConnectorKitIcon.png)
 
-## Connector Kit
+## Connector KIT
 
 ## Project Overview
 

--- a/docs-kits/kits/tractusx-edc/docs/kit/operation-view/page00_operation_view.md
+++ b/docs-kits/kits/tractusx-edc/docs/kit/operation-view/page00_operation_view.md
@@ -2,7 +2,7 @@
 
 ![Connector kit banner](@site/static/img/ConnectorKitIcon.png)
 
-## Connector Kit
+## Connector KIT
 
 ## Introduction
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/Documentation BPDM/page_api-reference.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/Documentation BPDM/page_api-reference.md
@@ -1,6 +1,6 @@
 ---
 id: API Reference
-title: Api Reference
+title: API Reference
 description: ''
 sidebar_position: 2
 ---

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/Documentation BPDM/page_documentation-bpdm.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/Documentation BPDM/page_documentation-bpdm.md
@@ -7,6 +7,8 @@ sidebar_position: 1
 
 ![Business partner kit banner](@site/static/img/BPKitIcon.png)
 
+### Business Partner KIT
+
 ## Introduction
 
 BPDM (Business Partner Data Management) is a core component of the Catena-X project, which aims to create a secure, trusted, and standardized ecosystem for the exchange of data among various stakeholders in the automotive industry. BPDM provides services for querying, adding, and managing business partner base information in the Catena-X landscape.

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/Software Development View/page_software-development-view.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/Software Development View/page_software-development-view.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 ![Business partner kit banner](@site/static/img/BPKitIcon.png)
 
-### Business Partner Kit
+### Business Partner KIT
 
 ## Specification
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/page_adoption-view.mdx
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/page_adoption-view.mdx
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 ![Business partner kit banner](@site/static/img/BPKitIcon.png)
 
-### Business Partner Kit
+### Business Partner KIT
 
 # Unique business partner data sets for the whole data space.
 ### Basis for the integration of value-adding services in the area of business partner data management.

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/page_changelog.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/page_changelog.md
@@ -13,12 +13,16 @@ All notable changes to this Kit will be documented in this file.
 
 ## [1.0.0] - 2023-03-01
 
-### Added
+<h3>Added</h3>
 
 - documentation of the software development view including the business partner data management POOL API
 - documentation of adoption view
 - documentation of the operations view with an installation guide for the POOL API
 
-### Changed
+<h3>Changed</h3>
 
-### Removed
+- ./.
+
+<h3>Removed</h3>
+
+- ./.

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/page_changelog.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/page_changelog.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 ![Business partner kit banner](@site/static/img/BPKitIcon.png)
 
-### Business Partner Kit
+### Business Partner KIT
 
 All notable changes to this Kit will be documented in this file.
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/page_software-operation-view.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/page_software-operation-view.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 ![Business partner kit banner](@site/static/img/BPKitIcon.png)
 
-### Business Partner Kit
+### Business Partner KIT
 
 ## Installation Instructions
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Data Chain Kit/Documentation/admin_guide.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Data Chain Kit/Documentation/admin_guide.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 ![Datachain kit banner](@site/static/img/DataChainKitIcon.png)
 
-### Data Chain Kit
+### Data Chain KIT
 
 ## System Overview
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Data Chain Kit/Documentation/arc42.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Data Chain Kit/Documentation/arc42.md
@@ -9,7 +9,7 @@ sidebar_position: 3
 
 ![Datachain kit banner](@site/static/img/DataChainKitIcon.png)
 
-### Data Chain Kit
+### Data Chain KIT
 
 ## Introduction and goals
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Data Chain Kit/Software Development View/page_software-development-view.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Data Chain Kit/Software Development View/page_software-development-view.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 ![Datachain kit banner](@site/static/img/DataChainKitIcon.png)
 
-### Data Chain Kit
+### Data Chain KIT
 
 ## IRS REST API
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Data Chain Kit/page_adoption-view.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Data Chain Kit/page_adoption-view.md
@@ -7,13 +7,13 @@ sidebar_position: 1
 
 ![Datachain kit banner](@site/static/img/DataChainKitIcon.png)
 
-### Data Chain Kit
+### Data Chain KIT
 
 DataChainKit brings valuable data chain information to your use-cases and services through connected data that can help Business Owner and Catena-X participants to be up to date and prepared. It's easy to use the DataChainKit with an Open Source Software package, which can easily deployed via HELM or docker-compose. The DataChainKit enables to apply business logic along a distributed data chains, for example aggregation of certificates along the value chain. Also ad-hoc provisioning of continuous data chains across company boundaries for empowerment of use cases Circular Economy, Traceability, Quality and the European supply chain act.
 
 (#GreenIT#DataSovereignty#Interoperability#ConnectedData)
 
-## Why Data Chain Kit
+## Why Data Chain KIT
 
 What is in for you to use the Data Chain Kit. On what is it built on.
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Data Chain Kit/page_changelog.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Data Chain Kit/page_changelog.md
@@ -13,7 +13,7 @@ All notable changes to this Kit will be documented in this file.
 
 ## [1.0.0] - 2023-03-01
 
-### Added
+<h3>Added</h3>
 
 - dokumentation of the IRS API
 - dokumentation of adoption view
@@ -21,6 +21,10 @@ All notable changes to this Kit will be documented in this file.
 - dokumentation of the IRS reference implementation
 - two successstories how this Kit is beeing used
 
-### Changed
+<h3>Changed</h3>
 
-### Removed
+- ./.
+
+<h3>Removed</h3>
+
+- ./.

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Data Chain Kit/page_changelog.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Data Chain Kit/page_changelog.md
@@ -7,7 +7,7 @@ sidebar_position: 10
 
 ![Datachain kit banner](@site/static/img/DataChainKitIcon.png)
 
-### Data Chain Kit
+### Data Chain KIT
 
 All notable changes to this Kit will be documented in this file.
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Data Chain Kit/page_software-operation-view.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Data Chain Kit/page_software-operation-view.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 ![Datachain kit banner](@site/static/img/DataChainKitIcon.png)
 
-### Data Chain Kit
+### Data Chain KIT
 
 ## Local Deployment
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Traceability Kit/Software Development View/page_software-development-view.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Traceability Kit/Software Development View/page_software-development-view.md
@@ -7,7 +7,7 @@ sidebar_position: 4
 
 ![Traceability kit banner](@site/static/img/doc-traceability_header-minified.png)
 
-### Traceability Kit
+### Traceability KIT
 
 <!--
 Development View of the Kit.

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Traceability Kit/page_adoption-view.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Traceability Kit/page_adoption-view.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 ![Traceability kit banner](@site/static/img/doc-traceability_header-minified.png)
 
-### Traceability Kit
+### Traceability KIT
 <!--
 Adoption View of the Kit.
 -->

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Traceability Kit/page_changelog.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Traceability Kit/page_changelog.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 ![Traceability kit banner](@site/static/img/doc-traceability_header-minified.png)
 
-### Traceability Kit
+### Traceability KIT
 
 All notable changes to this Kit will be documented in this file.
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Traceability Kit/page_changelog.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Traceability Kit/page_changelog.md
@@ -13,29 +13,29 @@ All notable changes to this Kit will be documented in this file.
 
 ## [1.0.1] - 2023-04-14
 
-### Added
+<h3>Added</h3>
 
 - Adoption View: Traceability tutorial video
 - Adoption View: Customer journey
 
-### Changed
+<h3>Changed</h3>
 
 - ./.
 
-### Removed
+<h3>Removed</h3>
 
 - ./.
 
 ## [1.0.0] - 2023-04-12
 
-### Added
+<h3>Added</h3>
 
 - Initial version of the Kit including adoption, operation and development view + two API specifications (Notification API, Unique ID Push API)
 
-### Changed
+<h3>Changed</h3>
 
 - ./.
 
-### Removed
+<h3>Removed</h3>
 
 - ./.

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Traceability Kit/page_software-operation-view.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Traceability Kit/page_software-operation-view.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 ![Traceability kit banner](@site/static/img/doc-traceability_header-minified.png)
 
-### Traceability Kit
+### Traceability KIT
 
 <!--
 Documentation of the Kit.

--- a/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/CHANGELOG.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/CHANGELOG.md
@@ -8,22 +8,22 @@ All notable changes to this Kit will be documented in this file.
 
 ## [1.2.0] - 2023-05-16
 
-### Added
+<h3>Added</h3>
 
 - chart documentation for tractusx-connector-azure-vault
 
-### Changed
+<h3>Changed</h3>
 
 - helm chart documentation -> added needed properties and information about self-signed certificates for testing
 
-### Removed
+<h3>Removed</h3>
 
 - chart documentation for tractusx-connector-app
 - unused files like charts, values.yaml
 
 ## [1.1.0] - 2023-04-28
 
-### Added
+<h3>Added</h3>
 
 - documentation of the control-plane-adapter extension
 - openAPI documentation of the control-plane-adapter extension
@@ -31,23 +31,29 @@ All notable changes to this Kit will be documented in this file.
 - migration documentation
 - postman collection
 
-### Changed
+<h3>Changed</h3>
 
 - helm chart version for the edc components is now 0.3.3
 - switched the whole documentation structure from product-edc to tractusx-edc
 - switched build tool from maven to gradle
 - restructured the whole documentation structure and order
 
-### Removed
+<h3>Removed</h3>
+
+- ./.
 
 ## [1.0.0] - 2023-03-01
 
-### Added
+<h3>Added</h3>
 
 - documentation of the management-api
 - documentation of adoption view
 - documentation of software development view
 
-### Changed
+<h3>Changed</h3>
 
-### Removed
+- ./.
+
+<h3>Removed</h3>
+
+- ./.

--- a/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/CHANGELOG.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ![Connector kit banner](@site/static/img/ConnectorKitIcon.png)
 
-## Connector Kit
+## Connector KIT
 
 All notable changes to this Kit will be documented in this file.
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/docs/kit/adoption-view/page_adoption-view.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/docs/kit/adoption-view/page_adoption-view.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 ![Connector kit banner](@site/static/img/ConnectorKitIcon.png)
 
-## Connector Kit
+## Connector KIT
 
 The ConnectorKit provides a connector framework, based on the [Eclipse Dataspace Connector][edc-url] for sovereign, cross-enterprise data exchange.
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/docs/kit/development-view/page00_development_view.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/docs/kit/development-view/page00_development_view.md
@@ -2,7 +2,7 @@
 
 ![Connector kit banner](@site/static/img/ConnectorKitIcon.png)
 
-## Connector Kit
+## Connector KIT
 
 ## Project Overview
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/docs/kit/operation-view/page00_operation_view.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/docs/kit/operation-view/page00_operation_view.md
@@ -2,7 +2,7 @@
 
 ![Connector kit banner](@site/static/img/ConnectorKitIcon.png)
 
-## Connector Kit
+## Connector KIT
 
 ## Introduction
 

--- a/docs-kits_versioned_sidebars/version-3.1.0-sidebars.json
+++ b/docs-kits_versioned_sidebars/version-3.1.0-sidebars.json
@@ -34,7 +34,7 @@
             "kits/Business Partner Kit/Software Development View/Specification",
             {
               "type": "category",
-              "label": "Gate Api",
+              "label": "Gate API",
               "link": {
                 "type": "generated-index"
               },
@@ -187,7 +187,7 @@
             },
             {
               "type": "category",
-              "label": "Pool Api",
+              "label": "Pool API",
               "link": {
                 "type": "generated-index"
               },

--- a/docs-kits_versioned_sidebars/version-3.1.0-sidebars.json
+++ b/docs-kits_versioned_sidebars/version-3.1.0-sidebars.json
@@ -2,7 +2,7 @@
   "kits": [
     {
       "type": "category",
-      "label": "Business Partner Kit",
+      "label": "Business Partner KIT",
       "link": {
         "type": "generated-index"
       },
@@ -615,7 +615,7 @@
     },
     {
       "type": "category",
-      "label": "Data Chain Kit",
+      "label": "Data Chain KIT",
       "link": {
         "type": "generated-index"
       },
@@ -660,7 +660,7 @@
     },
     {
       "type": "category",
-      "label": "Connector Kit",
+      "label": "Connector KIT",
       "link": {
         "type": "generated-index"
       },
@@ -805,7 +805,7 @@
     },
     {
       "type": "category",
-      "label": "Traceability Kit",
+      "label": "Traceability KIT",
       "link": {
         "type": "generated-index"
       },

--- a/docs/kit-process/artefacts.md
+++ b/docs/kit-process/artefacts.md
@@ -4,7 +4,7 @@ title: Artefacts
 
 - The documentation of a KIT can grow and change
 - Think about the customer perspective / who will be using this kit and needs to understand it
-- How to create the kit documentation in Github is explained [here](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/wiki/How-to-create-a-KIT-website%3F)
+- How to create the kit documentation in Github is explained [here](/docs/kit-process/processes/create_KIT_page)
 
 ## ADOPTION VIEW
 
@@ -139,7 +139,7 @@ Deliverable:
 
 `Example from DataChain KIT:` The API of the Item Relationship Service (IRS) for retrieving item graphs along the value chain of CATENA-X partners.
 
-[`Example for OpenAPI integration:`](https://eclipse-tractusx.github.io/docs/kits/Business%20Partner%20Kit/Software%20Development%20View/Pool%20Api/business-partner-data-management-pool)
+[`Example for OpenAPI integration:`](/docs-kits/kits/Business%20Partner%20Kit/Software%20Development%20View/Pool%20Api/business-partner-data-management-pool)
 
 ### Sample Data
 

--- a/docs/kit-process/processes/update-documentation.md
+++ b/docs/kit-process/processes/update-documentation.md
@@ -18,7 +18,7 @@ Currently the documentation has to be manually maintained by the process describ
 
 ### Overview
 
-1. Create a fork of the [Tractus-X website repository]("https://github.com/eclipse-tractusx/eclipse-tractusx.github.io") by clicking on the "fork" button on the top right
+1. Create a fork of the [Tractus-X website repository](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io) by clicking on the "fork" button on the top right
    ![IMG: how to create fork](resources/create-new-fork.png)
 
 2. Edit your documentation with regard to the schema. Note that you **only** apply changes to the content within the `docs-kits` directory! If you modify your or other content outside of this directory your changes will be rejected!
@@ -59,15 +59,13 @@ In order to have a uniform apperance we expect the documentation to be in a simi
         ├── page-adoption-view.md
         ├── page-software-development-view.md
         ├── page-documentation.md
-        ├── page-software-operation-view.md
-        └── sidebar.js
+        └── page-software-operation-view.md
 ```
 
-The sections within these files are the aligned with the artefacts described [here](https://eclipse-tractusx.github.io/docs/artefacts/).
+The sections within these files are the aligned with the artefacts described [here](/docs/kit-process/artefacts).
 
 Additionaly we apply linter for to the submitted code which will atomatically reject your pull request if these fail.
 
 ## Notes
 
 - The documentation is only a copy thus it will not be automatically updated!
-- you find our linters [here]("https://github.com/eclipse-tractusx/eclipse-tractusx.github.io")

--- a/sidebarsDocsKits.js
+++ b/sidebarsDocsKits.js
@@ -16,7 +16,7 @@ const sidebars = {
   kits: [
     {
       type: 'category',
-      label: 'Business Partner Kit',
+      label: 'Business Partner KIT',
       link: {
           type: 'generated-index',
       },
@@ -90,7 +90,7 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Data Chain Kit',
+      label: 'Data Chain KIT',
       link: {
         type: 'generated-index',
       },
@@ -135,7 +135,7 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Connector Kit',
+      label: 'Connector KIT',
       link: {
         type: 'generated-index',
       },
@@ -293,7 +293,7 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Traceability Kit',
+      label: 'Traceability KIT',
       link: {
         type: 'generated-index',
       },
@@ -307,7 +307,7 @@ const sidebars = {
     },
     {
           type: 'category',
-          label: 'Digital Twin Kit',
+          label: 'Digital Twin KIT',
           link: {
             type: 'generated-index',
           },

--- a/sidebarsDocsKits.js
+++ b/sidebarsDocsKits.js
@@ -35,7 +35,7 @@ const sidebars = {
             'kits/Business Partner Kit/Software Development View/Specification',
             {
               type: "category",
-              label: "Gate Api",
+              label: "Gate API",
               link: {
                 type: "generated-index",
               },
@@ -43,7 +43,7 @@ const sidebars = {
             },
             {
               type: "category",
-              label: "Pool Api",
+              label: "Pool API",
               link: {
                 type: "generated-index",
               },
@@ -51,7 +51,7 @@ const sidebars = {
             },
             {
               type: "category",
-              label: "Bridge Dummy Api",
+              label: "Bridge Dummy API",
               link: {
                   type: "generated-index",
               },


### PR DESCRIPTION
In this PR issues #333 and #335 are being handled

Other small content related issues are been updated, specifically in the `Capitalisation` of titles in the `latest` and `current` **sidebars** files. Modifying **KIT** and **API** words where needed.

All the KITs `CHANGELOG` -> subtitles inputs are declared in `HTML` tags to avoid been displayed in the right side navigation bar. The subtitles affected are **Added**, **Changed** and **Removed**.