### PR TITLE
Add/kitsgallery filters

### DIFF
--- a/docs/website-guidelines/update-and-integrate-react-components.md
+++ b/docs/website-guidelines/update-and-integrate-react-components.md
@@ -21,7 +21,7 @@ This `index.js` is defined as a `React` component. Its content is being imported
 
 - #### AboutUsCard `./src/components/AboutUsCard/index.js`
 
-- #### KitsGallery `./src/components/KitsGallery/index.js`
+- #### KitsGalleryWithFilters `./src/components/KitsGalleryWithFilters/index.js`
 
 - #### FAQsComponent `./src/components/FAQsComponent/index.js`
 
@@ -48,6 +48,8 @@ This `index.js` is defined as a `React` component. Its content is imported from 
 - #### DeveloperHeader `./src/components/DeveloperHeader/index.js`
 
 - #### DeveloperContent `./src/components/DeveloperContent/index.js`
+
+- #### KitsGalleryWithFilters `./src/components/KitsGalleryWithFilters/index.js`
 
 - #### KitsGallery `./src/components/KitsGallery/index.js`
 
@@ -103,12 +105,12 @@ Make sure when adding a new `object` to the `faqsContent array`, to include the 
 
 ### `<KitsGallery />`
 
-This component's content is defined in the `./utils/galleryKits.js` file, and follows the next structure:
+This component's content is defined in the `./utils/resiliencyItems.js` file, and follows the next structure:
 
 ```javascript
   import Business_Kit from "@site/static/img/bpkit.png";
 
-  export const galleryKits = [
+  export const resiliencyItems = [
     {
       id: 1,
       img: Business_Kit,
@@ -117,7 +119,27 @@ This component's content is defined in the `./utils/galleryKits.js` file, and fo
   ]
 ```
 
-Make sure when adding a new `object` to the `galleryKits array`, to include the same properties: `id` as a `number`, `img` and `pageRoute` as a `string` with your needed definitions if you want this to be displayed as part of the UI. _**Important:**_ remember to increase the `id` property of your new object +1 the last `object.id` of the array. Note as well, that this components takes an image as a property, and thus this needs to be imported from the `./statics/img` folder at the beginning of the file using the `@site/static/img/your-image` declaration.
+Make sure when adding a new `object` to the `resiliencyItems array`, to include the same properties: `id` as a `number`, `img` and `pageRoute` as a `string` with your needed definitions if you want this to be displayed as part of the UI. _**Important:**_ remember to increase the `id` property of your new object +1 the last `object.id` of the array. Note as well, that this components takes an image as a property, and thus this needs to be imported from the `./statics/img` folder at the beginning of the file using the `@site/static/img/your-image` declaration.
+
+### `<KitsGalleryWithFilters />`
+
+This component's content is defined in the `./utils/kitsGallery.js` file, and follows the next structure:
+
+```javascript
+  import Business_Kit from "@site/static/img/bpkit.png";
+
+  export const kitsGallery = [
+    {
+      id: 1,
+      name: 'Business Partner Kit',
+      domain: 'Network & Core Services',
+      img: Business_Kit,
+      pageRoute: "docs-kits/kits/Business Partner Kit/Adoption View"
+    },
+  ]
+```
+
+Make sure when adding a new `object` to the `kitsGallery array`, to include the same properties: `id` as a `number`, `name` as a `string`, `domain` as a `string`, `img` as an imported declaration and `pageRoute` as a `string` with your needed definitions if you want this to be displayed as part of the UI. _**Important:**_ remember to increase the `id` property of your new object +1 the last `object.id` of the array. Note as well, that this components takes an image as a property, and thus this needs to be imported from the `./statics/img` folder at the beginning of the file using the `@site/static/img/your-image` declaration.
 
 ### `<ProductOverview />`
 

--- a/src/components/KitsGalleryWithFilters/index.js
+++ b/src/components/KitsGalleryWithFilters/index.js
@@ -1,0 +1,162 @@
+/********************************************************************************* 
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Mercedes Benz AG 
+* Copyright (c) 2023 Contributors to the Eclipse Foundation
+* 
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+* 
+* This program and the accompanying materials are made available under the
+* terms of the Apache License, Version 2.0 which is available at
+* https://www.apache.org/licenses/LICENSE-2.0.
+* 
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+* 
+* SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+import React, { useState, useEffect } from "react";
+import Link from "@docusaurus/Link";
+import Box from '@mui/material/Box';
+// import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Select from '@mui/material/Select';
+import styles from "./styles.module.css";
+
+export default function KitsGalleryWithFilters({itemsArray, title, description}) {
+  const [selectedDomain, setSelectedDomain] = useState('All Domains');
+  const [filteredAndSortedKits, setFilteredAndSortedKits] = useState(itemsArray);
+  const [sortOrder, setSortOrder] = useState('asc');
+
+  useEffect(() => {
+    const sortedArray = [...itemsArray].sort((a, b) => a.name.localeCompare(b.name));
+    setFilteredAndSortedKits(sortedArray);
+  }, []);
+
+  const handleDomainChange = (event) => {
+    const selectedDomain = event.target.value;
+    setSelectedDomain(selectedDomain);
+  
+    let filteredKits = itemsArray;
+    if (selectedDomain !== 'All Domains') {
+      filteredKits = itemsArray.filter((kit) => kit.domain === selectedDomain);
+    }
+  
+    let sortedKits = filteredKits;
+    if (sortOrder === 'asc') {
+      sortedKits.sort((a, b) => a.name.localeCompare(b.name));
+    } else {
+      sortedKits.sort((a, b) => b.name.localeCompare(a.name));
+    }
+  
+    setFilteredAndSortedKits(sortedKits);
+  };
+
+  const handleSort = () => {
+    const sortedKits = [...filteredAndSortedKits];
+  
+    if (sortOrder === 'asc') {
+      sortedKits.sort((a, b) => b.name.localeCompare(a.name));
+      setSortOrder('desc');
+    } else {
+      sortedKits.sort((a, b) => a.name.localeCompare(b.name));
+      setSortOrder('asc');
+    }
+  
+    setFilteredAndSortedKits(sortedKits);
+  };
+  
+
+  return (
+    <section className={styles.kits_gallery}>
+      <div className={styles.container}>
+
+        <div className={styles.title_container}>
+          <h2 className="title-h2">{title}</h2>
+          <p className="subtitle-h3">{description}</p>
+        </div>
+
+        <div className={styles.filters_container}>
+          <Box>
+            <FormControl
+              size="small"
+            >
+              {/* <InputLabel 
+                sx={
+                  {
+                    color: '#FFF',
+                    '&.Mui-focused': {
+                      color: '#faa023'
+                    }
+                  }
+                }
+                id="domain-label"
+              >
+                Select Domain
+              </InputLabel> */}
+              <Select
+                labelId="domain-label"
+                id="domain-options"
+                value={selectedDomain}
+                // label="Select Domain"
+                onChange={handleDomainChange}
+                // variant="outlined"
+                sx={
+                  {
+                    color: '#fff',
+                    padding: '0 0.5rem',
+                    '& .MuiSvgIcon-root': {
+                      color: '#faa023',
+                    },
+                    '& .MuiOutlinedInput-notchedOutline': {
+                      borderColor: '#faa023'
+                    },
+                    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                      borderColor: '#c37304',
+                    },
+                    '&:hover .MuiOutlinedInput-notchedOutline': {
+                      borderColor: '#ed8c05',
+                    },
+                  }
+                }
+              >
+                <MenuItem value={'All Domains'}>All Domains</MenuItem>
+                <MenuItem value={'Network & Core Services'}>Network & Core Services</MenuItem>
+                <MenuItem value={'PLM / Quality'}>PLM / Quality</MenuItem>
+                <MenuItem value={'Sustainability'}>Sustainability</MenuItem>
+                <MenuItem value={'Resiliency'}>Resiliency</MenuItem>
+              </Select>
+            </FormControl>
+          </Box>
+
+          <div className={styles.button_container}>
+            {
+              sortOrder === 'asc' ?
+              <button className={styles.button} onClick={handleSort}>A-Z &darr;</button> :
+              <button className={styles.button} onClick={handleSort}>Z-A &uarr;</button>
+            }
+          </div>
+        </div>
+
+        <div className={styles.gallery_container}>
+          {
+            filteredAndSortedKits.map((kit, index)=> {
+              return(
+                <div key={index} className={styles.gallery_item}>
+                  <Link to={kit.pageRoute} className={styles.gallery_link}>
+                    <img src={kit.img} className={styles.item_img}/>
+                  </Link>
+                </div>
+              )      
+            })
+          }
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/KitsGalleryWithFilters/index.js
+++ b/src/components/KitsGalleryWithFilters/index.js
@@ -145,6 +145,8 @@ export default function KitsGalleryWithFilters({itemsArray, title, description})
 
         <div className={styles.gallery_container}>
           {
+            filteredAndSortedKits.length === 0 ?
+            <p className={styles.no_match}>NO MATCH FOUND...</p> :
             filteredAndSortedKits.map((kit, index)=> {
               return(
                 <div key={index} className={styles.gallery_item}>

--- a/src/components/KitsGalleryWithFilters/index.js
+++ b/src/components/KitsGalleryWithFilters/index.js
@@ -33,11 +33,13 @@ export default function KitsGalleryWithFilters({itemsArray, title, description})
   const [filteredAndSortedKits, setFilteredAndSortedKits] = useState(itemsArray);
   const [sortOrder, setSortOrder] = useState('asc');
 
+  // In charge of sort the cards by name alphabetically when the component mount
   useEffect(() => {
     const sortedArray = [...itemsArray].sort((a, b) => a.name.localeCompare(b.name));
     setFilteredAndSortedKits(sortedArray);
   }, []);
 
+  // In charge of filter the cards by domain, keeping the selected sorted order
   const handleDomainChange = (event) => {
     const selectedDomain = event.target.value;
     setSelectedDomain(selectedDomain);
@@ -57,6 +59,7 @@ export default function KitsGalleryWithFilters({itemsArray, title, description})
     setFilteredAndSortedKits(sortedKits);
   };
 
+  // In charge of switch the sorted order by name from "asc" to "des" and vice versa
   const handleSort = () => {
     const sortedKits = [...filteredAndSortedKits];
   
@@ -105,7 +108,8 @@ export default function KitsGalleryWithFilters({itemsArray, title, description})
                 value={selectedDomain}
                 // label="Select Domain"
                 onChange={handleDomainChange}
-                // variant="outlined"
+
+                //styles for the input box
                 sx={
                   {
                     color: '#fff',
@@ -121,9 +125,21 @@ export default function KitsGalleryWithFilters({itemsArray, title, description})
                     },
                     '&:hover .MuiOutlinedInput-notchedOutline': {
                       borderColor: '#ed8c05',
-                    },
+                    }
                   }
                 }
+
+                //styles for the dropdown paper
+                inputProps={{
+                  MenuProps: {
+                    MenuListProps: {
+                      sx: {
+                        backgroundColor: '#1f1f1f',
+                        color: '#fff',
+                      }
+                    },
+                  }
+                }}
               >
                 <MenuItem value={'All Domains'}>All Domains</MenuItem>
                 <MenuItem value={'Network & Core Services'}>Network & Core Services</MenuItem>

--- a/src/components/KitsGalleryWithFilters/styles.module.css
+++ b/src/components/KitsGalleryWithFilters/styles.module.css
@@ -74,6 +74,10 @@
   opacity: 0.5;
 }
 
+.no_match {
+  font-size: 1.3rem;
+}
+
 @media screen and (max-width: 1270px) {
   .gallery_container {
     grid-template-columns: repeat(3, 1fr);

--- a/src/components/KitsGalleryWithFilters/styles.module.css
+++ b/src/components/KitsGalleryWithFilters/styles.module.css
@@ -1,0 +1,109 @@
+/**
+* CSS files with the .module.css suffix will be treated as CSS modules
+* and scoped locally.
+*/
+
+.kits_gallery {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background-color: var(--ifm-background-color);
+  padding: 4rem 0 6rem;
+}
+
+.container {
+  width: 70vw;
+  height: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  gap: 2rem;
+}
+
+.title_container {
+  width: 100%;
+  height: auto;
+  margin-top: 0;
+}
+
+.filters_container {
+  width: 100%;
+  height: auto;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2rem;
+  /* background-color: white; */
+}
+
+.button_container {}
+
+.button {
+  font-size: 1.1rem;
+  background-color: var(--ifm-background-color);
+  border: none;
+}
+
+.button:hover {
+  cursor: pointer;
+  color: var(--ifm-color-primary);
+}
+
+.gallery_container {
+  width: 100%;
+  display: grid; 
+  grid-template-columns: repeat(4, 1fr);
+  justify-content: center;
+  align-items: center;
+  gap: 2.5rem;
+}
+
+.gallery_item {
+  width: 100%;
+}
+
+.item_img {
+  border-radius: 10px;
+  width: 100%;
+  object-fit: cover;
+}
+
+.gallery_item:hover {
+  opacity: 0.5;
+}
+
+@media screen and (max-width: 1270px) {
+  .gallery_container {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media screen and (max-width: 996px) {
+  .kits_gallery {
+    padding: 2rem 0 2rem;
+  }
+
+  .title_container {
+    margin-top: 2rem;
+  }
+
+  .container {
+    width: 80vw;
+    height: auto;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .gallery_container {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .gallery_container {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/KitsGalleryWithFilters/styles.module.css
+++ b/src/components/KitsGalleryWithFilters/styles.module.css
@@ -38,8 +38,6 @@
   /* background-color: white; */
 }
 
-.button_container {}
-
 .button {
   font-size: 1.1rem;
   background-color: var(--ifm-background-color);

--- a/src/pages/Developer/index.js
+++ b/src/pages/Developer/index.js
@@ -1,33 +1,34 @@
 /********************************************************************************* 
  * Copyright (c) 2023 BMW Group AG
  * Copyright (c) 2023 Mercedes Benz AG 
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
- * 
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- * 
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- * 
- * SPDX-License-Identifier: Apache-2.0
- ********************************************************************************/
+* Copyright (c) 2023 Contributors to the Eclipse Foundation
+* 
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+* 
+* This program and the accompanying materials are made available under the
+* terms of the Apache License, Version 2.0 which is available at
+* https://www.apache.org/licenses/LICENSE-2.0.
+* 
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+* 
+* SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
 
 import React from "react";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import DeveloperHeader from "../../components/DeveloperHeader";
 import DeveloperContent from "../../components/DeveloperContent";
+import KitsGalleryWithFilters from "../../components/KitsGalleryWithFilters";
 import KitsGallery from "../../components/KitsGallery";
 import KitsCard from "../../components/KitsCard";
-import { galleryKits } from "@site/utils/galleryKits";
-import {previewKits} from '@site/utils/previewKits.js'
+import { kitsGallery } from "@site/utils/kitsGallery";
+import { previewKits } from '@site/utils/previewKits.js'
 
 import IconsCard from "@site/static/img/icons-card.png"
 
@@ -41,8 +42,8 @@ export default function DeveloperPage() {
       <DeveloperHeader />
       <main>
         <DeveloperContent />
-        <KitsGallery 
-          itemsArray={galleryKits}
+        <KitsGalleryWithFilters 
+          itemsArray={kitsGallery}
           title={"Our Kits"}
           description={"Unlock the power of kits. Browse the latest kits, their documentation, including tutorials,sample code, articles, and API reference."}
         />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,11 +16,10 @@ import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 
 import HomePageHeader from "../components/HomePageHeader/index";
-import CarouselComponent from "../components/CarouselComponent";
 import AboutUsCard from "../components/AboutUsCard";
 import FAQsComponent from "../components/FAQsComponent";
-import KitsGallery from "../components/KitsGallery";
-import { galleryKits } from "@site/utils/galleryKits";
+import KitsGalleryWithFilters from "../components/KitsGalleryWithFilters";
+import { kitsGallery } from "@site/utils/kitsGallery";
 
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
@@ -32,8 +31,8 @@ export default function Home() {
       <HomePageHeader />
       <main>
         <AboutUsCard />
-        <KitsGallery 
-          itemsArray={galleryKits}
+        <KitsGalleryWithFilters 
+          itemsArray={kitsGallery}
           title={"Our Kits"}
           description={"Unlock the power of kits. Browse the latest kits, their documentation, including tutorials,sample code, articles, and API reference."}
         />

--- a/utils/kitsGallery.js
+++ b/utils/kitsGallery.js
@@ -4,6 +4,16 @@ import Connector_Kit from "@site/static/img/connectorkit-min.png";
 import Traceability_Kit from "@site/static/img/traceabilitykit.png";
 // import MoreToCome from "@site/static/img/gallery-more_coming-minified.png";
 
+//************************** IMPORTANT **************************** */
+
+// WHEN DEFINING A "DOMAIN" IN THE kitsGallery ARRAY, MAKE SURE TO SELECT/TYPE EXACTLY AS BELOW:
+// * Network & Core Services
+// * PLM / Quality
+// * Sustainability
+// * Resiliency
+
+//**************************************************************** */
+
 export const kitsGallery = [
   {
     id: 1,
@@ -15,21 +25,21 @@ export const kitsGallery = [
   {
     id: 2,
     name: 'Data Chain Kit',
-    domain: 'PLM / Quality',
+    domain: 'Network & Core Services',
     img: DataChain_Kit,
     pageRoute: "docs-kits/kits/Data Chain Kit/Adoption View"
   },
   {
     id: 3,
     name: 'Connector Kit',
-    domain: 'Sustainability',
+    domain: 'Network & Core Services',
     img: Connector_Kit,
     pageRoute: "docs-kits/kits/tractusx-edc/docs/kit/adoption-view/Adoption%20View"
   },
   {
     id: 4,
     name: 'Traceability Kit',
-    domain: 'Sustainability',
+    domain: 'PLM / Quality',
     img: Traceability_Kit,
     pageRoute: "docs-kits/kits/Traceability%20Kit/Adoption%20View%20Traceability%20Kit"
   },

--- a/utils/kitsGallery.js
+++ b/utils/kitsGallery.js
@@ -4,27 +4,35 @@ import Connector_Kit from "@site/static/img/connectorkit-min.png";
 import Traceability_Kit from "@site/static/img/traceabilitykit.png";
 // import MoreToCome from "@site/static/img/gallery-more_coming-minified.png";
 
-export const galleryKits = [
+export const kitsGallery = [
   {
     id: 1,
+    name: 'Business Partner Kit',
+    domain: 'Network & Core Services',
     img: Business_Kit,
     pageRoute: "docs-kits/kits/Business Partner Kit/Adoption View"
   },
   {
     id: 2,
+    name: 'Data Chain Kit',
+    domain: 'PLM / Quality',
     img: DataChain_Kit,
     pageRoute: "docs-kits/kits/Data Chain Kit/Adoption View"
   },
   {
     id: 3,
+    name: 'Connector Kit',
+    domain: 'Sustainability',
     img: Connector_Kit,
     pageRoute: "docs-kits/kits/tractusx-edc/docs/kit/adoption-view/Adoption%20View"
   },
   {
     id: 4,
+    name: 'Traceability Kit',
+    domain: 'Sustainability',
     img: Traceability_Kit,
     pageRoute: "docs-kits/kits/Traceability%20Kit/Adoption%20View%20Traceability%20Kit"
-  }
+  },
   // {
   //   id: 4,
   //   img: MoreToCome


### PR DESCRIPTION
In this PR a filter functionality has been included in the `KitsGallery` component, for this and for now a new **react** component is been defined: `KitsGalleryWithFilters` in the `src/components` folder. The content of this new component is defined in the `utils/kitsGallery.js` file

The documentation has been updated, including this component.

The resulting UI looks as follow:

<img width="1784" alt="Screenshot 2023-08-15 at 13 13 13" src="https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/68547995/65c0b82c-6644-4546-9de2-558c657db2d2">
