### PR TITLE
updates(header component): reduce the height

### DIFF
--- a/src/components/HomePageHeader/styles.module.css
+++ b/src/components/HomePageHeader/styles.module.css
@@ -7,7 +7,7 @@
   text-align: center;
   position: relative;
   overflow: hidden;
-  height: 94vh;
+  height: 71vh;
 }
     
 .container {


### PR DESCRIPTION
## Description

reduce the height of the landing/header component which is currently occupying whole screen.

Ticket - https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/issues/347

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
