### PR TITLE
TRG 7.04: added eclipse dash tool usage example and pom config

### DIFF
--- a/docs/release/trg-7/trg-7-04.md
+++ b/docs/release/trg-7/trg-7-04.md
@@ -55,6 +55,51 @@ You can request the status of your used libraries via the [Dash Licence Tool](ht
 - Provide support if an issue is labeled with "Help wanted"
 - Add the summary as DEPENDENCY file to the according repository (root level)
 
+**Example usage**
+
+Make sure to also include test dependencies. For a maven-based java project you can configure the maven plugin as follows to include test-depenencies:
+
+``` xml
+      <pluginRepositories>
+        <pluginRepository>
+          <id>dash-licenses-snapshots</id>
+          <url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+      <!-- other stuff -->
+      <plugin>
+        <groupId>org.eclipse.dash</groupId>
+        <artifactId>license-tool-plugin</artifactId>
+        <!-- see https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/org/eclipse/dash/license-tool-plugin/ -->
+        <version>1.0.3-SNAPSHOT</version>
+        <configuration>
+          <projectId>automotive.tractusx</projectId>
+          <!-- name of dependencies file -->
+          <summary>DEPENDENCIES</summary>
+          <!-- include test dependencies -->
+          <includeScope>test</includeScope>
+        </configuration>
+        <executions>
+          <execution>
+            <id>license-check</id>
+            <goals>
+              <goal>license-check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+```
+
+You then can invoke the plugin from command line as follows:
+
+```sh 
+# same directory as you pom.xml
+mvn org.eclipse.dash:license-tool-plugin:license-check
+```
+
 **Important Notes:**
 
 - Get your API Token (see README of the Dash Tool), note that only committers can get an API Token


### PR DESCRIPTION
## Description
Based on the proposal of @SebastianBezold in [discussion ](https://github.com/eclipse-tractusx/sig-infra/discussions/234)I added the pom documentation for java based projects to TR.7.04.

It also mentions to include the test dependencies.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
