### PR TITLE
docs(trg4.02/06): add alpine linux to list of container base images

### DIFF
--- a/docs/release/trg-0/trg-0.md
+++ b/docs/release/trg-0/trg-0.md
@@ -6,6 +6,7 @@ title: TRG 0 - Changelog & Drafts
 
 | Created      | Post-History                                                                                  |
 |--------------|-----------------------------------------------------------------------------------------------|
+| 29-Sep-2023  | TRG 4.02 / 06 add Alpine Linux to list of container base images                               |
 | 20-Sept-2023 | Adjust PostgreSQL version in TRG 5.07                                                         |
 | 24-Aug-2023  | Move updated TRG 7.01 to active                                                               |
 | 20-Jul-2023  | TRG 7.07 / 08 for OSS documentation improved, section added for documentation under CC-BY-4.0 |

--- a/docs/release/trg-4/trg-4-02.md
+++ b/docs/release/trg-4/trg-4-02.md
@@ -23,12 +23,13 @@ Since many of our Eclipse Tractus-X product use the same language, we are aligni
 per language.
 The following table lists container base images, that are already agreed on.
 
-| Language / Runtime        | Container base image                                                       | Notes                                                    |
+| Language / Runtime / OS       | Container base image                                                       | Notes                                                    |
 |---------------------------|----------------------------------------------------------------------------|----------------------------------------------------------|
 | Java / Kotlin / JVM based | [Eclipse Temurin](https://hub.docker.com/_/eclipse-temurin)                | prefer JRE over JDK and alpine tags for your JRE version |
 | JS frontends              | [nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged) | prefer :stable-alpine tag                                |
 | .NET runtime              | [.NET runtime](https://hub.docker.com/_/microsoft-dotnet-runtime)          | prefer :alpine tag                                       |
 | ASP.NET runtime           | [ASP.NET core runtime](https://hub.docker.com/_/microsoft-dotnet-aspnet)   | prefer :alpine tag                                       |
+| Linux                     | [Alpine Linux](https://hub.docker.com/_/alpine)                            |
 
 If the language or runtime environment of your product is not listed above, feel free to [start a discussion](https://github.com/eclipse-tractusx/sig-infra/discussions)
 and propose your preferred container images as base image.

--- a/docs/release/trg-4/trg-4-06.md
+++ b/docs/release/trg-4/trg-4-06.md
@@ -129,3 +129,10 @@ You have to adapt some of the provided links to match your used version.
 - Dockerfile (:6-alpine): [mcr.microsoft.com/dotnet/aspnet:6.0-alpine](https://github.com/dotnet/dotnet-docker/blob/e1984aaea51a796b68f6672749d280525c30e063/src/aspnet/6.0/alpine3.17/amd64/Dockerfile)
 - GitHub project: [https://github.com/dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker)
 - DockerHub: [https://hub.docker.com/_/microsoft-dotnet-aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet)
+
+### Linux
+
+- Base image reference (example): `alpine:3.17`
+- Dockerfile: [alpinelinux/docker-alpine:3.17](https://github.com/alpinelinux/docker-alpine/blob/681b8c677aaed66e48a5ce721509647bd4dcd017/x86_64/Dockerfile)
+- GitHub project: [https://github.com/alpinelinux/docker-alpine](https://github.com/alpinelinux/docker-alpine)
+- DockerHub: [https://hub.docker.com/_/alpine](https://hub.docker.com/_/alpine)


### PR DESCRIPTION
## Description

add alpine linux to list of container base images

## Why

base image for init container needed

fixes https://github.com/eclipse-tractusx/sig-infra/issues/259

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
