### PR TITLE
adjust postgresql version in trg 5.07

### DIFF
--- a/docs/release/trg-0/trg-0.md
+++ b/docs/release/trg-0/trg-0.md
@@ -4,17 +4,19 @@ title: TRG 0 - Changelog & Drafts
 
 ## Index of Tractus-X Release Guidelines (TRGs)
 
-| Created      | Post-History                                                                                 |
-|--------------|----------------------------------------------------------------------------------------------|
-| 20-Jul-2023  | TRG 7.07 / 08 for OSS documentation improved, section added for documentation under CC-BY-4.0|
-| 6-June-2023  | Extend helm test example workflow (5.09) for k8s versions (5.10) and upgradeability (5.11)   |
-| 2-June-2023  | Add recommendation for implementing legal notice in frontend apps (7.06)                     |
-| 9-May-2023   | Make DockerHub registry mandatory (4.05), Describe mandatory notice for Docker images (4.06) |
-| 8-May-2023   | Move TRG 7.00-7.07 out of Draft to Final                                                     |
-| 7-Mar-2023   | Remove author column, reorder post-history latest first, cleanup formatting across all TRGs  |
-| 7-Mar-2023   | Move TRG 2.05, 5.09, 5.10 and 5.11 out of Draft to Prerelease                                |
-| 23-Feb-2023  | Add draft "Helm Action"                                                                      |
-| 13-Sept-2022 | Initial contribution                                                                         |
+| Created      | Post-History                                                                                  |
+|--------------|-----------------------------------------------------------------------------------------------|
+| 20-Sept-2023 | Adjust PostgreSQL version in TRG 5.07                                                         |
+| 24-Aug-2023  | Move updated TRG 7.01 to active                                                               |
+| 20-Jul-2023  | TRG 7.07 / 08 for OSS documentation improved, section added for documentation under CC-BY-4.0 |
+| 6-June-2023  | Extend helm test example workflow (5.09) for k8s versions (5.10) and upgradeability (5.11)    |
+| 2-June-2023  | Add recommendation for implementing legal notice in frontend apps (7.06)                      |
+| 9-May-2023   | Make DockerHub registry mandatory (4.05), Describe mandatory notice for Docker images (4.06)  |
+| 8-May-2023   | Move TRG 7.00-7.07 out of Draft to Final                                                      |
+| 7-Mar-2023   | Remove author column, reorder post-history latest first, cleanup formatting across all TRGs   |
+| 7-Mar-2023   | Move TRG 2.05, 5.09, 5.10 and 5.11 out of Draft to Prerelease                                 |
+| 23-Feb-2023  | Add draft "Helm Action"                                                                       |
+| 13-Sept-2022 | Initial contribution                                                                          |
 
 ## Index by Category
 

--- a/docs/release/trg-5/trg-5-07.md
+++ b/docs/release/trg-5/trg-5-07.md
@@ -2,10 +2,11 @@
 title: TRG 5.07 - Chart Dependencies
 ---
 
-| Status | Created     | Post-History |
-|--------|-------------|--------------|
-| Active | 07-Mar-2023 |              |
-| Draft  | 02-Dec-2022 | n/a          |
+| Status | Created     | Post-History              |
+|--------|-------------|---------------------------|
+| Update | 20-Sep-2023 | Adjust PostgreSQL version |
+| Active | 07-Mar-2023 |                           |
+| Draft  | 02-Dec-2022 | n/a                       |
 
 ## Why
 
@@ -45,8 +46,8 @@ Then the install can be done with `helm install [NAME] [CHART] [flags]`
 
 ## Aligning dependency versions
 
-The following table describes the required version of dependencies for all products.
+The following table describes the required version of dependencies for all products. As Minor versions change rapidly, this guidance is not pinning a specifc version. Alignment also has to be coordinated across Teams through other communication means.
 
-|Name |Repo URL |Chart version | App version|
-|--- | --- | ---| ---|
-|postgresql | [Bitnami](https://charts.bitnami.com/bitnami) | 11.x.x| 14.5.0|
+| Name       | Repo URL                                      | Chart version | App version |
+|------------|-----------------------------------------------|:-------------:|:-----------:|
+| postgresql | [Bitnami](https://charts.bitnami.com/bitnami) |    12.x.x     |   15.x.x    |


### PR DESCRIPTION
PostgreSQL is now at 16 while our TRG still referenced PostgreSQL 14.

Adjusted the TRG to use 15 and made it less specific as it doesn't make sense to keep one specific version documented