### PR TITLE
chore: add drawing as code trg as draft

### DIFF
--- a/docs/release/trg-0/trg-1-4.md
+++ b/docs/release/trg-0/trg-1-4.md
@@ -19,6 +19,7 @@ Also updating the static files will be easier and faster to do for every committ
 All static files **must** be created with code and also stored as `.svg` file within your product repository.
 After a committers [decision](https://github.com/eclipse-tractusx/sig-infra/discussions/19) there are 2 languages accepted, either [PUML](https://plantuml.com/en/) or [Mermaid](https://mermaid.js.org/).
 These code files (`.puml`,`.mmd`,`mermaid`) and static `.svg` files **must** be stored within the `docs/static` folder.
+In addition to this you can integrate mermaid diagrams also directly into your markdown files as code snippets.
 
 This includes:
 
@@ -29,11 +30,11 @@ This includes:
 - gantt charts
 - etc.
 
-## PlantUML / Mermaid snippets
+## PlantUML / Mermaid / Markdown snippets
 
 ### PlantUML example
 
-```bash
+```plantuml
 @startuml
 (First usecase)
 (Another usecase) as (UC2)
@@ -42,11 +43,11 @@ usecase (Last\nusecase) as UC4
 @enduml
 ```
 
-![example](https://www.plantuml.com/plantuml/svg/SoWkIImgAStDuT9moomgBb4eBKvDJYnErUJISCpBByb8BOABA2GMAsY4EXjfSa5554ATZU5i3P_4ufAOF2J5G6aJBeVKl1IWwG00)
+![example-as-image](https://www.plantuml.com/plantuml/svg/SoWkIImgAStDuT9moomgBb4eBKvDJYnErUJISCpBByb8BOABA2GMAsY4EXjfSa5554ATZU5i3P_4ufAOF2J5G6aJBeVKl1IWwG00)
 
 ### Mermaid example
 
-``` bash
+```markdown
 flowchart TD
     A[Committer] -->|Get money| B(Go shopping)
     B --> C{Let me think}
@@ -55,7 +56,29 @@ flowchart TD
     C -->|Three| F[fa:fa-car Car]
 ```
 
-[![example2](https://mermaid.ink/img/pako:eNpVkEFug0AMRa9iedVK4QIsKiXQZpOokZodsHDBMKMwYzQxiiLg7h3KpvXK8n_fX_aEtTSMKba9PGpDQeGalx5i7YtMnLOqHCpIkrf5yApOPD9nOLwcBe5GhsH67nXjDysE2XRaMQY11t-WTcp-_Z-eZ8iLEw0qQ_VXuT5khvfiLN-2Z7iYGPJfN4Gj96NoKW0pqSlARqHCHToOjmwTD5hWQ4lq2HGJaWwbCrcSS79EjkaVr6evMdUw8g7HoSHl3FIXyGFc2t_jlBurEs7bR2rxre1w-QHjzV4u?type=png)](https://mermaid.live/edit#pako:eNpVkEFug0AMRa9iedVK4QIsKiXQZpOokZodsHDBMKMwYzQxiiLg7h3KpvXK8n_fX_aEtTSMKba9PGpDQeGalx5i7YtMnLOqHCpIkrf5yApOPD9nOLwcBe5GhsH67nXjDysE2XRaMQY11t-WTcp-_Z-eZ8iLEw0qQ_VXuT5khvfiLN-2Z7iYGPJfN4Gj96NoKW0pqSlARqHCHToOjmwTD5hWQ4lq2HGJaWwbCrcSS79EjkaVr6evMdUw8g7HoSHl3FIXyGFc2t_jlBurEs7bR2rxre1w-QHjzV4u)
+[![example2-as-image](https://mermaid.ink/img/pako:eNpVkEFug0AMRa9iedVK4QIsKiXQZpOokZodsHDBMKMwYzQxiiLg7h3KpvXK8n_fX_aEtTSMKba9PGpDQeGalx5i7YtMnLOqHCpIkrf5yApOPD9nOLwcBe5GhsH67nXjDysE2XRaMQY11t-WTcp-_Z-eZ8iLEw0qQ_VXuT5khvfiLN-2Z7iYGPJfN4Gj96NoKW0pqSlARqHCHToOjmwTD5hWQ4lq2HGJaWwbCrcSS79EjkaVr6evMdUw8g7HoSHl3FIXyGFc2t_jlBurEs7bR2rxre1w-QHjzV4u?type=png)](https://mermaid.live/edit#pako:eNpVkEFug0AMRa9iedVK4QIsKiXQZpOokZodsHDBMKMwYzQxiiLg7h3KpvXK8n_fX_aEtTSMKba9PGpDQeGalx5i7YtMnLOqHCpIkrf5yApOPD9nOLwcBe5GhsH67nXjDysE2XRaMQY11t-WTcp-_Z-eZ8iLEw0qQ_VXuT5khvfiLN-2Z7iYGPJfN4Gj96NoKW0pqSlARqHCHToOjmwTD5hWQ4lq2HGJaWwbCrcSS79EjkaVr6evMdUw8g7HoSHl3FIXyGFc2t_jlBurEs7bR2rxre1w-QHjzV4u)
+
+### Example Mermaid into Markdown
+
+````markdown
+```mermaid
+flowchart TD
+    A[Committer] -->|Get money| B(Go shopping)
+    B --> C{Let me think}
+    C -->|One| D[Laptop]
+    C -->|Two| E[Mobile Phone]
+    C -->|Three| F[fa:fa-car Car]
+```
+````
+
+```mermaid
+flowchart TD
+    A[Committer] -->|Get money| B(Go shopping)
+    B --> C{Let me think}
+    C -->|One| D[Laptop]
+    C -->|Two| E[Mobile Phone]
+    C -->|Three| F[fa:fa-car Car]
+```
 
 ## Technical requirements
 

--- a/docs/release/trg-0/trg-1-4.md
+++ b/docs/release/trg-0/trg-1-4.md
@@ -33,7 +33,7 @@ This includes:
 
 ### PlantUML example
 
-``` bash
+```bash
 @startuml
 (First usecase)
 (Another usecase) as (UC2)

--- a/docs/release/trg-0/trg-1-4.md
+++ b/docs/release/trg-0/trg-1-4.md
@@ -9,16 +9,16 @@ title: TRG 1.04 - Diagrams as Code
 
 ## Why
 
-To have an easier approach to update current static files and have a better overview of the changes within the product pictures.
+To have an easier approach to update current diagram files and have a better overview of the changes within the diagrams.
 
 This helps people to understand our workflows within our products and make it easier to understand the product itself.
 Also updating the static files will be easier and faster to do for every committer or maintainer of our repositories.
 
 ## Description
 
-All static files **must** be created with code and also stored as `.svg` file within your product repository.
+All diagram files **must** be created with code and either stored as `.svg` file within our repositories or implemented in your documentation.
 After a committers [decision](https://github.com/eclipse-tractusx/sig-infra/discussions/19) there are 2 languages accepted, either [PUML](https://plantuml.com/en/) or [Mermaid](https://mermaid.js.org/).
-These code files (`.puml`,`.mmd`,`mermaid`) and static `.svg` files **must** be stored within the `docs/static` folder.
+These diagram code files (`.puml`,`.mmd`,`.mermaid`) and / or static diagram `.svg` files **must** be stored within the `docs/` folder as described in [TRG 2.03](https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-3#docs).
 In addition to this you can integrate mermaid diagrams also directly into your markdown files as code snippets.
 
 This includes:

--- a/docs/release/trg-0/trg-1-4.md
+++ b/docs/release/trg-0/trg-1-4.md
@@ -1,0 +1,71 @@
+---
+title: TRG 1.04 - Diagrams as Code
+---
+
+| Status | Created       | Post-History          |
+|--------|---------------|-----------------------|
+| Draft  | 20-Sept-2023  | created initial Draft |
+|        |               |                       |
+
+## Why
+
+To have an easier approach to update current static files and have a better overview of the changes within the product pictures.
+
+This helps people to understand our workflows within our products and make it easier to understand the product itself.
+Also updating the static files will be easier and faster to do for every committer or maintainer of our repositories.
+
+## Description
+
+All static files **must** be created with code and also stored as `.svg` file within your product repository.
+After a committers [decision](https://github.com/eclipse-tractusx/sig-infra/discussions/19) there are 2 languages accepted, either [PUML](https://plantuml.com/en/) or [Mermaid](https://mermaid.js.org/).
+These code files (`.puml`,`.mmd`,`mermaid`) and static `.svg` files **must** be stored within the `docs/static` folder.
+
+This includes:
+
+- diagrams
+- flowcharts
+- sequence diagrams
+- state diagrams
+- gantt charts
+- etc.
+
+## PlantUML / Mermaid snippets
+
+### PlantUML example
+
+``` bash
+@startuml
+(First usecase)
+(Another usecase) as (UC2)
+usecase UC3
+usecase (Last\nusecase) as UC4
+@enduml
+```
+
+![example](https://www.plantuml.com/plantuml/svg/SoWkIImgAStDuT9moomgBb4eBKvDJYnErUJISCpBByb8BOABA2GMAsY4EXjfSa5554ATZU5i3P_4ufAOF2J5G6aJBeVKl1IWwG00)
+
+### Mermaid example
+
+``` bash
+flowchart TD
+    A[Committer] -->|Get money| B(Go shopping)
+    B --> C{Let me think}
+    C -->|One| D[Laptop]
+    C -->|Two| E[Mobile Phone]
+    C -->|Three| F[fa:fa-car Car]
+```
+
+[![example2](https://mermaid.ink/img/pako:eNpVkEFug0AMRa9iedVK4QIsKiXQZpOokZodsHDBMKMwYzQxiiLg7h3KpvXK8n_fX_aEtTSMKba9PGpDQeGalx5i7YtMnLOqHCpIkrf5yApOPD9nOLwcBe5GhsH67nXjDysE2XRaMQY11t-WTcp-_Z-eZ8iLEw0qQ_VXuT5khvfiLN-2Z7iYGPJfN4Gj96NoKW0pqSlARqHCHToOjmwTD5hWQ4lq2HGJaWwbCrcSS79EjkaVr6evMdUw8g7HoSHl3FIXyGFc2t_jlBurEs7bR2rxre1w-QHjzV4u?type=png)](https://mermaid.live/edit#pako:eNpVkEFug0AMRa9iedVK4QIsKiXQZpOokZodsHDBMKMwYzQxiiLg7h3KpvXK8n_fX_aEtTSMKba9PGpDQeGalx5i7YtMnLOqHCpIkrf5yApOPD9nOLwcBe5GhsH67nXjDysE2XRaMQY11t-WTcp-_Z-eZ8iLEw0qQ_VXuT5khvfiLN-2Z7iYGPJfN4Gj96NoKW0pqSlARqHCHToOjmwTD5hWQ4lq2HGJaWwbCrcSS79EjkaVr6evMdUw8g7HoSHl3FIXyGFc2t_jlBurEs7bR2rxre1w-QHjzV4u)
+
+## Technical requirements
+
+- [PlantUML](https://plantuml.com/en/) or [Mermaid](https://mermaid.js.org/) must be used to create the static files.
+- Live Mermaid Editor: [Mermaid Live Editor](https://mermaid.live/edit)
+- Live PlantUML Editor: [PlantUML Live Editor](https://www.planttext.com/)
+
+## GitHub workflows
+
+Reusable workflows for each language can be found here:
+
+- [Generate static Mermaid Files](https://github.com/eclipse-tractusx/sig-infra#generate-static-mermaid-files)
+- [Generate static PlantUML Files](https://github.com/eclipse-tractusx/sig-infra#generate-static-plantuml-files)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
- add new trg as draft to alignment on diagrams as code
- enhancing required documentation for our product repositories

updates https://github.com/eclipse-tractusx/sig-infra/issues/87

## Preview

![image](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/121097161/038a7cf4-28ac-44fb-ae98-fca1b6734fec)

## Testing 
- checkout pr branch
- npm install (optional)
- npm start 
- verfiy changes
