### PR TITLE
fix(agents-kit): do not use @static reference to images

### DIFF
--- a/docs-kits/kits/knowledge-agents/adoption-view/intro.md
+++ b/docs-kits/kits/knowledge-agents/adoption-view/intro.md
@@ -28,7 +28,7 @@ title: Adoption View
  * SPDX-License-Identifier: CC-BY-4.0
 -->
 
-![Agents Kit Banner](@site/static/img/knowledge-agents/AgentsKit-icon.png)
+![Agents Kit Banner](/img/knowledge-agents/AgentsKit-icon.png)
 
 This document describes the foundations of the (Knowledge) Agents KIT (=Keep It Together).
 

--- a/docs-kits/kits/knowledge-agents/development-view/Arc42.md
+++ b/docs-kits/kits/knowledge-agents/development-view/Arc42.md
@@ -28,7 +28,7 @@ title: Detailed Architecture
 
 ### Agents KIT
 
-![Agents Kit Banner](@site/static/img/knowledge-agents/AgentsKit-icon.png)
+![Agents Kit Banner](/img/knowledge-agents/AgentsKit-icon.png)
 
 This document describes the detailed Architecture of the (Knowledge) Agents KIT (=Keep It Together) based on ARC42 recommendations.
 

--- a/docs-kits/kits/knowledge-agents/development-view/architecture.md
+++ b/docs-kits/kits/knowledge-agents/development-view/architecture.md
@@ -28,7 +28,7 @@ title: High-Level Architecture
 
 ### Agents KIT
 
-![Agents Kit Banner](@site/static/img/knowledge-agents/AgentsKit-icon.png)
+![Agents Kit Banner](/img/knowledge-agents/AgentsKit-icon.png)
 
 This document describes the High-Level Architecture of the (Knowledge) Agents KIT (=Keep It Together).
 

--- a/docs-kits/kits/knowledge-agents/development-view/modules.md
+++ b/docs-kits/kits/knowledge-agents/development-view/modules.md
@@ -303,6 +303,4 @@ technological APIs in specific, transaction-oriented formats.
 As a special case of backend systems, we also regard existing AAS servers and databases as valid data sources
 to form a semantic dataspace.
 
-See [AAS Bridge](aas/bridge.md) for a more detailed explanation.
-
 <sub><sup>(C) 2021,2023 Contributors to the Eclipse Foundation. SPDX-License-Identifier: CC-BY-4.0</sup></sub>

--- a/docs-kits/kits/knowledge-agents/operation-view/deployment.md
+++ b/docs-kits/kits/knowledge-agents/operation-view/deployment.md
@@ -28,7 +28,7 @@ title: Deployment
 
 ### Agents KIT
 
-![Agents Kit Banner](@site/static/img/knowledge-agents/AgentsKit-icon.png)
+![Agents Kit Banner](/img/knowledge-agents/AgentsKit-icon.png)
 
 This document describes the deployment of the (Knowledge) Agents KIT (=Keep It Together) depending on the role that the respective tenant/business partner has.
 

--- a/docs-kits/kits/knowledge-agents/page_changelog.md
+++ b/docs-kits/kits/knowledge-agents/page_changelog.md
@@ -29,7 +29,7 @@ sidebar_position: 1
 -->
 ### Agents KIT
 
-![Agents Kit Banner](@site/static/img/knowledge-agents/AgentsKit-icon.png)
+![Agents Kit Banner](/img/knowledge-agents/AgentsKit-icon.png)
 
 All notable changes to the (Knowledge) Agents KIT (=Keep It Together) will be documented in this file.
 


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

The used @static links to the Kit Icon works in docusaurus start but not docusaurus build.

see https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/actions/runs/6354301937/job/17260541967


