### PR TITLE
Blog Post Update for Open Planning Days

### DIFF
--- a/blog/2023-10-26-open-planning.mdx
+++ b/blog/2023-10-26-open-planning.mdx
@@ -61,7 +61,7 @@ Our committers would highly appreciate contributions as a continuous stream of s
 - [Eclipse Tractus-X **GitHub** getting started](https://github.com/eclipse-tractusx/sig-release/wiki/Eclipse-Tractus-X-GitHub-getting-started)
 - [Planning](https://github.com/eclipse-tractusx/sig-release/blob/main/README.md) with the sig-release repositorry
 - Feature [planning board](https://github.com/orgs/eclipse-tractusx/projects/26) (without product filter)
-- Curren available [labels](https://github.com/eclipse-tractusx/sig-release/labels)
+- Current available [labels](https://github.com/eclipse-tractusx/sig-release/labels)
 - [Matrix Chat from Eclipse Tractus-X](https://chat.eclipse.org/#/room/#tools.tractus-x:matrix.eclipse.org) and [getting-started](https://chat.eclipse.org/docs/getting-started/)
 - [sig-release planning board](https://github.com/orgs/eclipse-tractusx/projects/26) and created features on [sig-release repository](https://github.com/eclipse-tractusx/sig-release/issues)
 
@@ -76,7 +76,7 @@ By participating, you'll not only contribute to a smoother development process b
 
 #### Introduction and Overview
 ⏰ **09:00 AM - 09:30 AM**
-- [Sessionlink]
+- [Sessionlink](https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZTRjNGYwOWEtNGFiOC00YTM3LWFmNmMtODA3MmQzYzM1ZWNk%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
 - Welcome note by the consortia PMs and Tractus-X Team Lead.
 - Brief overview of Tractus-X's mission and vision.
 
@@ -85,17 +85,17 @@ By participating, you'll not only contribute to a smoother development process b
 
 Team/Topic | Presenter | Consortium representative | Issues | Sessionlink
 --- | --- | --- | --- | ---
-Portal & Marketplaces | all contributer | Julia Jeroch | [Issues] | [Sessionlink]
-Tractus-X EDC | all contributer | Stefan Ettl | [Issues] | [Sessionlink]
-Managed Identity Wallet | all contributer | Oliver Schlienz | [Issues] | [Sessionlink]
-IRS | all contributer | Johannes Zahn | [Issues] | [Sessionlink]
-BPN & Discovery Finder| all contributer | Thomas Henn | [Issues] | [Sessionlink]
-Knowledge Agent | all contributer | Tom Buchert | [Issues] | [Sessionlink]
-BPDM and Country Risk | all contributer | Benjamin Renn / Philipp Butzmann | [Issues] | [Sessionlink]
+Portal & Marketplaces | all contributer | Julia Jeroch | [Issues] | [Sessionlink](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MDA0YWZiMDAtNGQyZS00NGI0LTkxNzAtNDcyNjlkYzYyMWFh%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+Tractus-X EDC | all contributer | Stefan Ettl | [Issues] | [Sessionlink](https://teams.microsoft.com/l/meetup-join/19%3ameeting_YzAyNTQ1NmYtZjU4ZC00YjhiLTljNTktOTJlODEwNTYxMTNm%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+Managed Identity Wallet | all contributer | Oliver Schlienz | [Issues] | [Sessionlink](https://teams.microsoft.com/l/meetup-join/19%3ameeting_YjIwY2EyMzYtODc1Ni00NzdhLTk5ZWQtNDhlN2VhMjM4MGUx%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+IRS | all contributer | Johannes Zahn | [Issues] | [Sessionlink](https://teams.microsoft.com/l/meetup-join/19%3ameeting_NDkwNjAyNDAtOGJiNy00ZDIxLThmMmItNTc1M2JmNmNhMGRk%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+BPN & Discovery Finder| all contributer | Thomas Henn | [Issues] | [Sessionlink](https://teams.microsoft.com/l/meetup-join/19%3ameeting_NWJlNThhZTgtOTA1OS00M2YxLTk2YzctMDNmNTAxYjA4ZmM5%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+Knowledge Agent | all contributer | Tom Buchert | [Issues] | [Sessionlink](https://teams.microsoft.com/l/meetup-join/19%3ameeting_YTUyOTZmMzgtZDExMy00YmFiLWE0MDgtZDAwOGY4OWRhMDA1%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+BPDM and Country Risk | all contributer | Benjamin Renn / Philipp Butzmann | [Issues] | [Sessionlink](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MDk5NGEzZTItMzhkMC00Zjk2LTg4OTktMTdmODg1M2RlYjhm%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
 
 #### Concluding Remarks and Open Floor
 ⏰ **12:30 PM - 01:00 PM**
-- [Sessionlink]
+- [Sessionlink](https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZTc3YmI1YjQtOGY5ZC00MDI3LWE0YzctNjc1NmNhNTM5ODNl%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
 - Recap of all products and key takeaways
 - Community Q&A
 - Closing note and the next steps for Tractus-X
@@ -111,13 +111,13 @@ Whether you're a core developer, a stakeholder, or someone passionate about our 
 
 #### Introduction and Vision
 ⏰ **9:30 AM - 10:30 AM**
-- [Sessionlink]
+- [Sessionlink](https://teams.microsoft.com/l/meetup-join/19%3ameeting_OTMwOWU4MzItY2NmNS00YzllLTkyMzctZGZjMzI5YmUzZTdl%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
 - Welcome note by the consortia PMs and Tractus-X Team Lead.
 - Brief overview of Tractus-X's mission and vision.
 
 #### Review/Planning Sessions
 ⏰ **10:30 AM - 05:15 PM**
-- [Sessionlink]
+- [Sessionlink](https://teams.microsoft.com/l/meetup-join/19%3ameeting_M2U1OGRhY2MtN2I4OC00ZjdmLTk5ZTgtYmNlNmEwZTFkMzk0%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
 
 Timeline | Team/Topic | Presenter | Consortium representative | Issues
 --- | --- | --- | --- | ---
@@ -134,7 +134,7 @@ Timeline | Team/Topic | Presenter | Consortium representative | Issues
 
 #### Concluding Remarks and Open Floor
 ⏰ **05:15 PM - 05:45 PM**
-- [Sessionlink]
+- [Sessionlink](https://teams.microsoft.com/l/meetup-join/19%3ameeting_YjMwNDRhMzctZjRkMC00ZWNlLTgzN2UtNTk0NmVmOTQzNDNj%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
 - Recap of all products and key takeaways
 - Community Q&A
 - Closing note and the next steps for Tractus-X


### PR DESCRIPTION
Update Blog Post as an invitation for the open source planning day(s) with detailed information and agenda and teamslinks