### PR TITLE
docs: update TRG 2.5 - draft version of new metadata option repoCategory

### DIFF
--- a/docs/release/trg-0/trg-2-5.md
+++ b/docs/release/trg-0/trg-2-5.md
@@ -1,0 +1,51 @@
+---
+title: TRG 2.05 - Repository metafile
+---
+
+| Status     | Created     | Post-History            |
+|------------|-------------|-------------------------|
+| Draft	     | 24-10-2023  | new option repoCategory |
+| Active     | 24-Apr-2023 |                         |
+| Prerelease | 7-Mar-2023  | Moved out of draft      |
+| Draft      | 24-Feb-2023 | Draft release           |
+
+## Why
+
+Due to many products having more than one repository, we need a way of identifying dependent repositories automatically. This allows us to programmatically parse and analyze repositories for quality checks and for generating documentation across repositories.
+
+## Description
+
+Having a `.tractusx` metafile helps individuals, release management, test management and others to determine basic information about a repository in the scope of **Eclipse Tractus-X**.
+
+The `yaml` format enables the opportunity to programmatically combine repositories to a single product, determine leading product repository, read data that can be processed for different cases.
+
+The `.tractusx` dotfile **must** contain metadata about the repository and product in a `yaml` format that can be processed programmatically. The structure is the following:
+
+- In the root of the [TRG 2.04 - Leading product repository](docs/release/trg-2/trg-2-4.md) create a file called `.tractusx`:
+
+```yaml
+product: "PRODUCT_NAME"
+leadingRepository: "LEADING_PRODUCT_REPOSITORY_URL"
+repositories:
+  - name: "REPOSITORY_1_NAME"
+    usage: "DESCRIPTION/PURPOSE"
+    url: "REPOSITORY_1_URL"
+  - name: "REPOSITORY_2_NAME"
+    usage: "DESCRIPTION/PURPOSE"
+    url: "REPOSITORY_2_URL"
+```
+
+In the root of a sub/non-leading repository create a file called `.tractusx`:
+
+```yaml
+leadingRepository: "LEADING_PRODUCT_REPOSITORY_URL"
+```
+
+There is an option to specify repository category, it decides which quality checks dashboard section will be used to present repository.
+The field is optional and there are currently two options supported "special" and "support".
+"Special" is dedicated mostly to repositories described as Special Interest Group (repo name begins with "sig-").
+"Support" used for repositories which are neither products nor SIG but play vital role in overall ecosystem.
+
+```yaml
+repoCategory: "SPECIFIED_CATEGORY"
+```


### PR DESCRIPTION
PR to crate TRG 2.5  draft version with an update of new metadata repoCategory option in .tractusx.

Updates https://github.com/eclipse-tractusx/sig-infra/issues/317