### PR TITLE
Added generic tutorial description

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -2,12 +2,6 @@
 title: Tutorials
 ---
 
-## What are tutorials?
+Tractus-X tutorials are descriptions and explanations on how to **run** the components in the Catena-X network. They are targeted towards software engineers that are getting started with Catena-x and want to familiarize themselves with the IT stack.
 
-- Descriptions and explanations how to **run** exiting components in the Catena-X network
-- Not meant to explain how to further develop components.
-- Can be run stand-alone, no need to integrate into an operating company network environment.
-
-## What are the customer groups?
-
-- IT Departments of operating companies.
+More information about the content and type of each tutorial can be found inside the respective tutorial.


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Generic introduction to tutorials - the page somehow needs to be there, because it's where you land when you click on "tutorials" on the top bar. A detailled description of the e2e tutorial is given, so I think we don't need to elaborate extensively on what generic tutorials are - every developer knows that. And Catena-X isn't really special here. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
#449 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
