### PR TITLE
docs(trg): add a reference to the metadata docs in TRG 2.05

### DIFF
--- a/docs/release/trg-2/trg-2-5.md
+++ b/docs/release/trg-2/trg-2-5.md
@@ -10,32 +10,35 @@ title: TRG 2.05 - Repository metafile
 
 ## Why
 
-Due to many products having more than one repository, we need a way of identifying dependent repositories automatically. This allows us to programmatically parse and analyze repositories for quality checks and for generating documentation across repositories.
+Due to many products having more than one repository, we need a way of identifying dependent repositories automatically. This allows us to analyze repositories for quality checks and for generating documentation across repositories.
 
 ## Description
 
-Having a `.tractusx` metafile helps individuals, release management, test management and others to determine basic information about a repository in the scope of **Eclipse Tractus-X**.
+To enable automatic analyzing of repositories, all repositories **MUST** have a file named `.tractusx` present on root-level.
+This file needs to contain metadata about the repository and product in a YAML format.
+The mandatory declarations in the `.tractusx` metadata file do vary for leading- and non-leading repositories.
 
-The `yaml` format enables the opportunity to programmatically combine repositories to a single product, determine leading product repository, read data that can be processed for different cases.
+Documentation on the content of the `.tractusx` metadata file can be found [in the quality check docs](https://github.com/eclipse-tractusx/tractusx-quality-checks/blob/main/docs/metadata_file.md).
 
-The `.tractusx` dotfile **must** contain metadata about the repository and product in a `yaml` format that can be processed programmatically. The structure is the following:
-
-- In the root of the [TRG 2.04 - Leading product repository](docs/release/trg-2/trg-2-4.md) create a file called `.tractusx`:
+Example `.tractusx` file taken from the docs:
 
 ```yaml
-product: "PRODUCT_NAME"
-leadingRepository: "LEADING_PRODUCT_REPOSITORY_URL"
+# Will be used on release checks dashboard etc. to refer to your product; only mandatory in the leading repo
+product: "your-product-name"
+# mandatory info in every repo
+leadingRepository: "https://github.com/eclipse-tractusx/<your-leading-repo>"
+# default: product; available options: "special", "support", "product"
+repoCategory: "special"
+# optional section to refer to all of your teams repositories
 repositories:
-  - name: "REPOSITORY_1_NAME"
-    usage: "DESCRIPTION/PURPOSE"
-    url: "REPOSITORY_1_URL"
-  - name: "REPOSITORY_2_NAME"
-    usage: "DESCRIPTION/PURPOSE"
-    url: "REPOSITORY_2_URL"
-```
-
-In the root of a sub/non-leading repository create a file called `.tractusx`:
-
-```yaml
-leadingRepository: "LEADING_PRODUCT_REPOSITORY_URL"
+  - name: "your-product-repo"
+    usage: "Main documentation and release repo for <product>"
+    url: "https://github.com/eclipse-tractusx/<your-leading-repo>"
+  - name: "your-product-library"
+    usage: "A library supporting <product>, that is released separately"
+    url: "https://github.com/eclipse-tractusx/<your-product-lib>"
+# section to explicitly skip certain release guideline checks
+skipReleaseChecks:
+  alignedBaseImage:
+    - "/path/to/non-published/Dockerfile"
 ```

--- a/docs/release/trg-2/trg-2-5.md
+++ b/docs/release/trg-2/trg-2-5.md
@@ -14,7 +14,7 @@ Due to many products having more than one repository, we need a way of identifyi
 
 ## Description
 
-To enable automatic analyzing of repositories, all repositories **MUST** have a file named `.tractusx` present on root-level.
+To enable automatic analysis of repositories, all repositories **MUST** have a file named `.tractusx` present on root-level.
 This file needs to contain metadata about the repository and product in a YAML format.
 The mandatory declarations in the `.tractusx` metadata file do vary for leading- and non-leading repositories.
 
@@ -27,7 +27,7 @@ Example `.tractusx` file taken from the docs:
 product: "your-product-name"
 # mandatory info in every repo
 leadingRepository: "https://github.com/eclipse-tractusx/<your-leading-repo>"
-# default: product; available options: "special", "support", "product"
+# default: available options: "special", "support"; optional field. will be treated as regular product repo without entry
 repoCategory: "special"
 # optional section to refer to all of your teams repositories
 repositories:


### PR DESCRIPTION
## Description

This PR simplifies the descriptions for [TRG 2.05](https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-5) and 
adds a link to the `.tractusx` metadata file docs to always keep the description up-to-date.
Because this could lead to someone missing updates to the metadata structure, a complete and up-to-date example of a metadata file is also added at the end.

relevant to eclipse-tractusx/sig-infra#309

