### PR TITLE
docs(trg): enhance description for base image alignment

### DIFF
--- a/docs/release/trg-4/trg-4-02.md
+++ b/docs/release/trg-4/trg-4-02.md
@@ -44,4 +44,7 @@ and propose your preferred container images as base image.
 As stated in the description above, base image usage is particularly aligned for container images, that we distribute by publishing them on DockerHub.
 In case you are using Docker images for build or testing purposes (for example pandoc or cypress, etc.), you can use other publicly available image,
 as long as the tools are open source license compliant.
+
+For automated TRG checks, you can skip base image checks on Dockerfiles by declaring it in the `.tractusx` metadata files.
+Details can be found in the [metadata file documentation](https://github.com/eclipse-tractusx/tractusx-quality-checks/blob/main/docs/metadata_file.md)
 :::

--- a/docs/release/trg-4/trg-4-02.md
+++ b/docs/release/trg-4/trg-4-02.md
@@ -13,17 +13,23 @@ Proposed release date: "mandatory after": 19th of May 2023
 
 ## Why
 
-Due to legal constrains we need to annotate the released container images to make it clear that we do our best to provide good images for demo purposes,
-but we do not provide any legal guarantee. To make that process easy, we are aligning on agreed base images for specific
-languages and use an aligned section to describe the base image.
+As part of our legal due diligence, we need to provide the best information possible about our distributed (published) Docker images.
+Similar to our 3rd-party dependency scans and the `DEPENDENCIES` file, Docker images also have to be scanned and the results published.
+Even though we do not provide any legal guarantees, we want to help you keep a high standard process, by defining guidelines, described in this TRG.
 
 ## Description
 
-Since many of our Eclipse Tractus-X product use the same language, we are aligning on a dedicated container base image
-per language.
+As Eclipse Tractus-X project, we cannot provide proper Docker image scans. This is why we use information that is already gathered for us.
+DockerHub is running container scans for all [official images](https://docs.docker.com/trusted-content/official-images/)
+and is publishing the scans result in the [docker-library/repo-info repository](https://github.com/docker-library/repo-info).
+
+We are leveraging this information by restricting the base images we use for our published container images to a minimal set.
+Aligning on specific base images also gives us the opportunity to provide you with templates for the legal notice,
+like described in [TRG 4.06 -  Notice for docker images](./trg-4-06.md)
+
 The following table lists container base images, that are already agreed on.
 
-| Language / Runtime / OS       | Container base image                                                       | Notes                                                    |
+| Language / Runtime / OS   | Container base image                                                       | Notes                                                    |
 |---------------------------|----------------------------------------------------------------------------|----------------------------------------------------------|
 | Java / Kotlin / JVM based | [Eclipse Temurin](https://hub.docker.com/_/eclipse-temurin)                | prefer JRE over JDK and alpine tags for your JRE version |
 | JS frontends              | [nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged) | prefer :stable-alpine tag                                |
@@ -35,5 +41,7 @@ If the language or runtime environment of your product is not listed above, feel
 and propose your preferred container images as base image.
 
 :::info
-Also be aware of the necessary references to the used base image and your products Dockerfile(s) described in [TRG 4.06](./trg-4-06.md)
+As stated in the description above, base image usage is particularly aligned for container images, that we distribute by publishing them on DockerHub.
+In case you are using Docker images for build or testing purposes (for example pandoc or cypress, etc.), you can use other publicly available image,
+as long as the tools are open source license compliant.
 :::

--- a/docs/release/trg-4/trg-4-02.md
+++ b/docs/release/trg-4/trg-4-02.md
@@ -15,11 +15,11 @@ Proposed release date: "mandatory after": 19th of May 2023
 
 As part of our legal due diligence, we need to provide the best information possible about our distributed (published) Docker images.
 Similar to our 3rd-party dependency scans and the `DEPENDENCIES` file, Docker images also have to be scanned and the results published.
-Even though we do not provide any legal guarantees, we want to help you keep a high standard process, by defining guidelines, described in this TRG.
+We want to help you to keep a high standard process, by defining guidelines, described in this TRG.
 
 ## Description
 
-As Eclipse Tractus-X project, we cannot provide proper Docker image scans. This is why we use information that is already gathered for us.
+As Eclipse Tractus-X project, we don't have automated processes for publishing container scan results (yet). This is why we use information that is already gathered for us.
 DockerHub is running container scans for all [official images](https://docs.docker.com/trusted-content/official-images/)
 and is publishing the scans result in the [docker-library/repo-info repository](https://github.com/docker-library/repo-info).
 
@@ -42,8 +42,8 @@ and propose your preferred container images as base image.
 
 :::info
 As stated in the description above, base image usage is particularly aligned for container images, that we distribute by publishing them on DockerHub.
-In case you are using Docker images for build or testing purposes (for example pandoc or cypress, etc.), you can use other publicly available image,
-as long as the tools are open source license compliant.
+In case you are using Docker images for build or testing purposes (for example pandoc or cypress, etc.) and you do not publish the images,
+you can use other publicly available image, as long as the tools are open source license compliant.
 
 For automated TRG checks, you can skip base image checks on Dockerfiles by declaring it in the `.tractusx` metadata files.
 Details can be found in the [metadata file documentation](https://github.com/eclipse-tractusx/tractusx-quality-checks/blob/main/docs/metadata_file.md)


### PR DESCRIPTION
This PR tries to add more background info on the base image alignment process.
It should make the prerequisites for being added to the aligned base image list clearer.
There is also a hint about non-published images and how to skip the automated base image check

relevant to eclipse-tractusx/sig-infra#309
