### PR TITLE
docs(trg): combine notice example to one in TRG 4.06

### DIFF
--- a/docs/release/trg-4/trg-4-06.md
+++ b/docs/release/trg-4/trg-4-06.md
@@ -35,19 +35,14 @@ notice Markdown file, that you then reference from your toplevel `README.md`.
 A dedicated notice file can be necessary, if you built multiple container image from a single repository.
 Multiple notice files ensure, that you can directly link the specific `Dockerfile`, that is used and include it in the description, that is pushed to `DockerHub`.
 
-The notice **must** always start with the following headline and the reference to your image on `DockerHub`
-(example taken from [app-dashboard](https://github.com/eclipse-tractusx/app-dashboard#notice-for-docker-image):
+The notice **must** follow a specific structure, starting with a specific headline, a reference to your image on `DockerHub` and information about your product.
+You can use the following example as a starting point. Remember to update the placeholders indicated by `<>` brackets.
 
 ```markdown
 ## Notice for Docker image
 
-DockerHub: [https://hub.docker.com/r/tractusx/app-dashboard](https://hub.docker.com/r/tractusx/app-dashboard)
-```
+DockerHub: [https://hub.docker.com/r/tractusx/<your-image>](https://hub.docker.com/r/tractusx/<your-image>)
 
-Following this, you **must** provide additional information on your product:
-(example taken from [app-dashboard](https://github.com/eclipse-tractusx/app-dashboard#notice-for-docker-image):
-
-```markdown
 Eclipse Tractus-X product(s) installed within the image:
 
 __<your product name>__
@@ -91,7 +86,10 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 The following examples are shown as reference, to see already existing and complete versions of a 'Notice for docker images'.
 They **can not** be used for your product without modifications.
 
-Good example for notice integrated in toplevel `README.md`: [IRS](https://github.com/eclipse-tractusx/item-relationship-service#notice-for-docker-image)
+Good example for notice integrated in toplevel `README.md`:
+
+- [IRS](https://github.com/eclipse-tractusx/item-relationship-service#notice-for-docker-image) or
+- [app-dashboard](https://github.com/eclipse-tractusx/app-dashboard#notice-for-docker-image)
 
 Good example for a dedicated notice file: [edc-controlplane-memory-hashicorp-vault](https://github.com/eclipse-tractusx/tractusx-edc/edit/main/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md)
 


### PR DESCRIPTION
This PR combines a split example of the notice for docker images section of the README.
This should make it easier to use and follow
