### PR TITLE
docs: TRG 5.09, 5.10, 5.11 title to lose PRERELEASE postfix and other content cleanup

### DIFF
--- a/docs/release/trg-5/trg-5-09.md
+++ b/docs/release/trg-5/trg-5-09.md
@@ -1,13 +1,11 @@
 ---
-title: TRG 5.09 - Helm test PRERELEASE
+title: TRG 5.09 - Helm test
 ---
-
-:::caution
-Proposed release date: "mandatory after": 19th of May 2023
-:::
 
 | Status     | Created     | Post-History       |
 |------------|-------------|--------------------|
+| Update     | 10-Nov-2023 | Bump kind version  |
+| Active     | 10-Nov-2023 |                    |
 | Prerelease | 7-Mar-2023  | Moved out of draft |
 | Draft      | 23-Feb-2023 | Draft release      |
 
@@ -38,6 +36,8 @@ Example Github Action Workflow:
 - Make the necessary container images available through the kind setup (see github action example, it uses the local kind registry)
 - Prepare and execute helm test
 - Fail on a failing helm test
+- The example also contains the upgradeability test as the last step which
+  is described in more detail in [TRG 5.11](trg-5-11.md)
 
 Technical requirements:
 
@@ -60,7 +60,7 @@ on:
         node_image:
           description: 'kindest/node image for k8s kind cluster'
           # k8s version from 3.1 release as default
-          default: 'kindest/node:v1.24.6'
+          default: 'kindest/node:v1.27.3'
           required: false
           type: string
         upgrade_from:
@@ -83,9 +83,9 @@ jobs:
               uses: container-tools/kind-action@v1
               with:
                 # upgrade version, default (v0.17.0) uses node image v1.21.1 and doesn't work with more recent node image versions
-                version: v0.19.0
+                version: v0.20.0
                 # default value for event_name != workflow_dispatch
-                node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.24.6' }}
+                node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.3' }}
 
             - name: Build image
               uses: docker/build-push-action@v3

--- a/docs/release/trg-5/trg-5-10.md
+++ b/docs/release/trg-5/trg-5-10.md
@@ -1,13 +1,10 @@
 ---
-title: TRG 5.10 - Kubernetes versions PRERELEASE
+title: TRG 5.10 - Kubernetes versions
 ---
-
-:::caution
-Proposed release date: "mandatory after": 19th of May 2023
-:::
 
 | Status     | Created     | Post-History       |
 |------------|-------------|--------------------|
+| Active     | 10-Nov-2023 |                    |
 | Prerelease | 7-Mar-2023  | Moved out of draft |
 | Draft      | 24-Feb-2022 | n/a                |
 

--- a/docs/release/trg-5/trg-5-11.md
+++ b/docs/release/trg-5/trg-5-11.md
@@ -1,13 +1,10 @@
 ---
-title: TRG 5.11 - Upgradeability PRERELEASE
+title: TRG 5.11 - Upgradeability
 ---
-
-:::caution
-Proposed release date: "mandatory after": 19th of May 2023
-:::
 
 | Status     | Created     | Post-History       |
 |------------|-------------|--------------------|
+| Active     | 10-Nov-2023 |                    |
 | Draft      | 17-Jul-2023 | 'handels' typo fix |
 | Prerelease | 7-Mar-2023  | Moved out of draft |
 | Draft      | 24-Feb-2022 | n/a                |


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Fixes #478

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
