### PR TITLE
doc(irs): correct documentation concerning local deployment

### DIFF
--- a/docs-kits/kits/Data Chain Kit/page_changelog.md
+++ b/docs-kits/kits/Data Chain Kit/page_changelog.md
@@ -11,6 +11,12 @@ sidebar_position: 10
 
 All notable changes to this Kit will be documented in this file.
 
+## Unreleased
+
+<h3>Fixed</h3>
+
+- Update documentation: Local deployment currently requires IRS version 2.4.0. See https://github.com/eclipse-tractusx/item-relationship-service/issues/247.
+
 
 ## [1.1.0] - 2023-08-25
 

--- a/docs-kits/kits/Data Chain Kit/page_software-operation-view.md
+++ b/docs-kits/kits/Data Chain Kit/page_software-operation-view.md
@@ -11,6 +11,8 @@ sidebar_position: 2
 
 ## Local Deployment
 
+> **Please note that this demo is currently based on IRS version 2.4.0.**
+
 Run a working demo scenario of the Item Relationship Service with a mocked Catena-X network to retrieve data chains with the following components:
 
 * Item Relationship Service
@@ -56,6 +58,12 @@ This local deployment is an easy installation with helm. This setup is built to 
 ### Step 2: Check out the code
 
 Check out the project [Item Relationship Service](https://github.com/eclipse-tractusx/item-relationship-service) or download a [released version](https://github.com/eclipse-tractusx/item-relationship-service/releases) of the Item Relationship Service
+
+> 👉 **Please use [tag 2.6.0](https://github.com/eclipse-tractusx/item-relationship-service/releases/tag/2.6.0) instead
+of the latest version currently (this is the version compatible with IRS 2.4.0).**
+>
+> ```git clone -b 2.6.0 https://github.com/catenax-ng/tx-item-relationship-service```
+
 
 ### Step 3: Installing the services
 


### PR DESCRIPTION
## Description

Updates documentation concerning local deployment with testdata (requires to use IRs 2.4.0 currently). 
See https://github.com/eclipse-tractusx/item-relationship-service/issues/247

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs. - no deps changed
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files - no source code file changed, just documentation
