### PR TITLE
docs: Traceability-Kit Operation View - fix link to trace-x backend

### DIFF
--- a/docs-kits/kits/Traceability Kit/page_software-operation-view.md
+++ b/docs-kits/kits/Traceability Kit/page_software-operation-view.md
@@ -19,7 +19,7 @@ Data Exchanger (SDE)** for data provisioning. For further information regarding
 their usage, configuration and deployment, follow these resources:
 
 - [Trace-X Frontend GitHub Repository](https://github.com/eclipse-tractusx/traceability-foss)
-- [Trace-X Backend GitHub Repository](https://github.com/eclipse-tractusx/traceability-foss-backend)
+- [Trace-X Backend GitHub Repository](https://github.com/eclipse-tractusx/traceability-foss)
 - [Trace-X Installation Guide](https://github.com/eclipse-tractusx/traceability-foss/blob/main/frontend/INSTALL.md)
 - [SDE Frontend GitHub Repository](https://github.com/eclipse-tractusx/dft-frontend)
 - [SDE Backend GitHub Repository](https://github.com/eclipse-tractusx/dft-backend)


### PR DESCRIPTION

## Description
Fix wrong link to traceability-foss backend.


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
