### PR TITLE
feat: PURIS Kit Preview Refresh

### DIFF
--- a/docs-kits/kits/PURIS Kit/page_adoption-view.md
+++ b/docs-kits/kits/PURIS Kit/page_adoption-view.md
@@ -1,0 +1,35 @@
+---
+id: Adoption View PURIS Kit
+title: Adoption View
+description: 'PURIS Kit'
+sidebar_position: 2
+---
+
+### PURIS Kit
+
+## Vision & Mission
+
+### Vision
+
+Demand and capacity management (DCM) increases transparency in the supply chain and provides information on potential supply bottlenecks in the medium to long term by comparing a customer's material requirements and the supplier's capacities in the initial one-tier supply relationship (one-down, one-up). By linking the information, bottleneck situations that go beyond the one-tier supply relationship and arise at lower levels of the n-tier supply chain can also be identified. This early detection enables problems to be solved before they affect production and thus timely delivery. If bottleneck situations nevertheless occur in the short-term horizon, the data must be enriched with additional, up-to-date information and the current stock situation, material movements and inbound and outbound deliveries must also be taken into account.
+
+For those involved in the supply chain, the Catena-X application PURIS is a short-term tool for transparently mapping delivery situations.
+
+In contrast to DCM in the long term, PURIS presents the delivery situation with actual data, without aggregation and completely in real time, in order to enable the user to derive measures for the corresponding requirement (e.g. in bottleneck management) on this basis and to be able to make decisions more reliably.
+
+### Mission
+
+The Catena-X application PURIS is available to all participants in the automotive supply chain. It depicts the current situation based on actual data (as opposed to planned data) with the option of an operational preview of a maximum of 4 weeks.
+
+The application enables all participants in the supply chain to exchange information (type, quantity, time, etc.) with participants of their choice (one-up/one-down) and to use this for their own findings.
+
+Information objects are
+
+- Stock
+- transportation
+- demand
+- Supplier production (output)
+- Other influencing variables
+- This exchange should be possible automatically, autonomously and independently, with minimal manual effort. Applicable guidelines are adhered to.
+
+The application should be usable regardless of company size and degree of digitization. The financial outlay for using PURIS should be as low as possible. It is intended to serve as a basic building block for a future industry standard and serves as a supplier.

--- a/docs-kits/kits/PURIS Kit/page_changelog.md
+++ b/docs-kits/kits/PURIS Kit/page_changelog.md
@@ -1,0 +1,24 @@
+---
+id: PURIS Kit Changelog
+title: Changelog
+description: 'PURIS Kit'
+sidebar_position: 1
+---
+
+### PURIS Kit
+
+All notable changes to this Kit will be documented in this file.
+
+## [0.1.0] - 2023-11-29
+
+### Added
+
+- Initial version of the Kit including the adoption view
+
+### Changed
+
+- ./.
+
+### Removed
+
+- ./.

--- a/sidebarsDocsKits.js
+++ b/sidebarsDocsKits.js
@@ -489,7 +489,11 @@ const sidebars = {
             items: [
                 'kits/Resiliency/DCM Kit',
                 'kits/Resiliency/maas',
-                'kits/Resiliency/PURIS',
+                {
+                    type: 'doc',
+                    label: 'PURIS Kit',
+                    id: 'kits/PURIS Kit/Adoption View PURIS Kit',
+                },
                 'kits/Resiliency/mp kit',
             ]
         },

--- a/utils/resiliencyItems.js
+++ b/utils/resiliencyItems.js
@@ -23,7 +23,7 @@ export const resiliencyItems = [
 	{
 		id: 4,
 		img: PURIS_Kit,
-		pageRoute: "/docs-kits/kits/Resiliency/PURIS"
+		pageRoute: "/docs-kits/next/kits/PURIS%20Kit/Adoption%20View%20PURIS%20Kit"
 	},
 	{
 		id: 5,


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

The PURIS team wants to update the content of their current preview Kit in anticipation of a `24.05` release.

The goal of this Pull Request is to:

- Update content of the Kit
- Fix broken linking on "Upcoming Kits" page for the resiliency domain page to the PURIS Kit page
- Introduce current folder structure proposed by the wiki/tutorials

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
