### PR TITLE
chore(trg5.09): update workflow example to always use latest stable version of helm

### DIFF
--- a/docs/release/trg-5/trg-5-09.md
+++ b/docs/release/trg-5/trg-5-09.md
@@ -96,8 +96,6 @@ jobs:
 
             - name: Set up Helm
               uses: azure/setup-helm@v3
-              with:
-                version: v3.9.3
 
             - uses: actions/setup-python@v4
               with:

--- a/docs/release/trg-5/trg-5-09.md
+++ b/docs/release/trg-5/trg-5-09.md
@@ -4,6 +4,7 @@ title: TRG 5.09 - Helm test
 
 | Status     | Created     | Post-History       |
 |------------|-------------|--------------------|
+| Update     | 04-Dec-2023 | Update example     |
 | Update     | 10-Nov-2023 | Bump kind version  |
 | Active     | 10-Nov-2023 |                    |
 | Prerelease | 7-Mar-2023  | Moved out of draft |
@@ -18,11 +19,11 @@ GitHub Actions simplifies the open source infrastructure requirements as otherwi
 
 This is the base for future e2e tests.
 
-This also allows to move the responsibility of verifing the helm chart functionality from the system team back to the development team.
+This also allows to move the responsibility of verifying the helm chart functionality from the system team back to the development team.
 
 ## Description
 
-Helm charts and their dependend images (the application to test) need to be validated by installing them and verifing that they are running successfully.
+Helm charts and their dependent images (the application to test) need to be validated by installing them and verifying that they are running successfully.
 
 Helm test is the technical solution helm provides to verify that a helm chart works as expected. It basically installs the helm chart (which installs and runs the application) and then allows an additional
 container to run. This test container can do everything, especially calling an api, executing tests etc.

--- a/docs/release/trg-5/trg-5-09.md
+++ b/docs/release/trg-5/trg-5-09.md
@@ -2,13 +2,13 @@
 title: TRG 5.09 - Helm test
 ---
 
-| Status     | Created     | Post-History       |
-|------------|-------------|--------------------|
-| Update     | 04-Dec-2023 | Update example     |
-| Update     | 10-Nov-2023 | Bump kind version  |
-| Active     | 10-Nov-2023 |                    |
-| Prerelease | 7-Mar-2023  | Moved out of draft |
-| Draft      | 23-Feb-2023 | Draft release      |
+| Status     | Created     | Post-History                                    |
+|------------|-------------|-------------------------------------------------|
+| Update     | 05-Dec-2023 | Updated example, with customizable helm version |
+| Update     | 10-Nov-2023 | Bump kind version                               |
+| Active     | 10-Nov-2023 |                                                 |
+| Prerelease | 7-Mar-2023  | Moved out of draft                              |
+| Draft      | 23-Feb-2023 | Draft release                                   |
 
 ## Why
 
@@ -70,6 +70,11 @@ on:
           default: 'x.x.x'
           required: false
           type: string
+        helm_version:
+          description: 'helm version to test (default = latest)'
+          default: 'latest'
+          required: false
+          type: string
 
 jobs:
     lint-test:
@@ -97,6 +102,8 @@ jobs:
 
             - name: Set up Helm
               uses: azure/setup-helm@v3
+              with:
+                version: ${{ github.event.inputs.helm_version || 'latest' }}
 
             - uses: actions/setup-python@v4
               with:


### PR DESCRIPTION
## Description 
This PR removes the explicit definition of the to be installed helm version by the setup-helm action: Since the Action installs the latest stable version of helm by default anyways.
