### PR TITLE
docs(trg-7.06): update shared ui components

### DIFF
--- a/docs/release/trg-0/trg-0.md
+++ b/docs/release/trg-0/trg-0.md
@@ -6,6 +6,7 @@ title: TRG 0 - Changelog & Drafts
 
 | Created      | Post-History                                                                                  |
 |--------------|-----------------------------------------------------------------------------------------------|
+| 04-Dec-2023  | TRG 7.06 update Shared UI Components / NPM library                                            |
 | 09-Oct-2023  | TRG 4.06 add base image for hashicorp vault                                                   |
 | 29-Sep-2023  | TRG 4.02 / 06 add Alpine Linux to list of container base images                               |
 | 20-Sept-2023 | Adjust PostgreSQL version in TRG 5.07                                                         |

--- a/docs/release/trg-7/trg-7-06.md
+++ b/docs/release/trg-7/trg-7-06.md
@@ -2,9 +2,10 @@
 title: TRG 7.06 - Legal notice for end user content
 ---
 
-| Status | Created     | Post-History |
-|--------|-------------|--------------|
-| Active | 13-Apr-2023 | New          |
+| Status | Created     | Post-History                               |
+|--------|-------------|--------------------------------------------|
+| Active | 04-Dec-2023 | Update Shared UI Components / NPM library  |
+| Active | 13-Apr-2023 | New                                        |
 
 ## Why
 
@@ -44,7 +45,7 @@ Example:
     * Source URL: <URL to the your repository (*)>
     * Commit ID: <the commit id the component delivery has been created / build from>
 
-In order to align with the overall style guide, it's recommended to use the About card provided in the [Shared UI Components](https://www.npmjs.com/package/cx-portal-shared-components) npm library maintained by the portal product. Please note that the About card is only available in this library from version 1.5.0-RC1 onwards. As reference for the placement of this card in frontend apps: in the portal it has been integrated in an About page which is reachable from the footer.
+In order to align with the overall style guide, it's recommended to use the About card provided in the [Shared UI Components](https://eclipse-tractusx.github.io/portal-shared-components) via the respective [NPM library](https://www.npmjs.com/package/@catena-x/portal-shared-components) maintained by the portal product. As reference for the placement of this card in frontend apps: in the portal it has been integrated in an About page which is reachable from the footer.
 
 Regarding usage of this About card, it's recommended to add a json file to your frontend project to be imported for the real content. As some of the content can only be determined in the build pipeline, you could add a json file as reference containing placeholder values. Those placeholder values could then be replaced, by script, just before the build within the build pipeline.
 


### PR DESCRIPTION
## Description

update shared ui components and the [respective NPM library ](https://www.npmjs.com/package/@catena-x/portal-shared-components) for TRG 7.06

## Why

previous NPM library is deprecated https://www.npmjs.com/package/cx-portal-shared-components

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
