### PR TITLE
fix broken image references

### DIFF
--- a/docs-kits/kits/Behaviour Twin MDP Kit/page_adoption-view.md
+++ b/docs-kits/kits/Behaviour Twin MDP Kit/page_adoption-view.md
@@ -5,7 +5,9 @@ description: 'Model Based Development and Data Processing Kit'
 sidebar_position: 2
 ---
 
-![Model Based Development and Data Processing Kit banner](@site/static/img/doc-mdp_header-minified.png)
+<!--
+TODO: Img reference is broken
+![Model Based Development and Data Processing Kit banner](@site/static/img/doc-mdp_header-minified.png)-->
 
 ### Model Based Development and Data Processing Kit
 <!--

--- a/docs-kits/kits/Behaviour Twin MDP Kit/page_changelog.md
+++ b/docs-kits/kits/Behaviour Twin MDP Kit/page_changelog.md
@@ -5,7 +5,10 @@ description: 'Model Based Development and Data Processing Kit'
 sidebar_position: 1
 ---
 
+<!--
+TODO: Img reference is broken
 ![Model Based Development and Data Processing Kit banner](@site/static/img/doc-mdp_header-minified.png)
+-->
 
 ### Model Based Development and Data Processing Kit
 


### PR DESCRIPTION
Github action missed the broken image links. This broke the build.

Quick fix by removing the reference.