### PR TITLE
Simplify copy and pasting commands.

### DIFF
--- a/docs/tutorials/e2e/connect/deployComponents.md
+++ b/docs/tutorials/e2e/connect/deployComponents.md
@@ -46,7 +46,7 @@ kind create cluster -n mxd --config kind.config.yaml
 # 
 # Now we activate ingress for the later port forwarding ?
 # the next step is specific to KinD and will be different for other Kubernetes runtimes!
-kubectl apply -f  \ 
+kubectl apply -f  \
 https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
 # wait until the ingress controller is ready
 kubectl wait --namespace ingress-nginx \


### PR DESCRIPTION

## Description
Removing the whitespace after the backslash allows the user to copy and paste the command to the console without the further modifications.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
