### PR TITLE
docs: move active TRG 1-4 into correct folder

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -160,7 +160,7 @@ npm/npmjs/-/cssnano-preset-default/5.2.13, MIT, approved, clearlydefined
 npm/npmjs/-/cssnano-utils/3.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/cssnano/5.1.14, MIT, approved, clearlydefined
 npm/npmjs/-/csso/4.2.0, MIT, approved, clearlydefined
-npm/npmjs/-/csstype/3.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/csstype/3.1.1, MIT, approved, #11847
 npm/npmjs/-/cytoscape-cose-bilkent/4.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/cytoscape-fcose/2.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/cytoscape/3.26.0, MIT, approved, clearlydefined
@@ -606,7 +606,7 @@ npm/npmjs/-/on-headers/1.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/once/1.4.0, ISC, approved, clearlydefined
 npm/npmjs/-/onetime/5.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/open/8.4.0, MIT, approved, #7102
-npm/npmjs/-/opener/1.5.2, MIT OR WTFPL OR (MIT AND WTFPL), approved, clearlydefined
+npm/npmjs/-/opener/1.5.2, MIT AND WTFPL AND WTFPL, approved, #11619
 npm/npmjs/-/p-cancelable/1.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/p-limit/2.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/p-limit/3.1.0, MIT, approved, clearlydefined
@@ -728,7 +728,6 @@ npm/npmjs/-/react-json-view/1.21.3, MIT, approved, clearlydefined
 npm/npmjs/-/react-lifecycles-compat/3.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/react-live/3.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/react-loadable-ssr-addon-v5-slorber/1.0.1, MIT, approved, clearlydefined
-npm/npmjs/-/react-loadable/5.5.2, MIT, approved, #6650
 npm/npmjs/-/react-magic-dropzone/1.0.1, MIT, approved, #6622
 npm/npmjs/-/react-markdown/8.0.5, MIT, approved, #6635
 npm/npmjs/-/react-modal/3.16.1, MIT, approved, clearlydefined

--- a/docs/release/trg-1/trg-1-4.md
+++ b/docs/release/trg-1/trg-1-4.md
@@ -4,6 +4,7 @@ title: TRG 1.04 - Diagrams as code / Editable static files
 
 | Status | Created      | Post-History                                             |
 |--------|--------------|----------------------------------------------------------|
+| Active | 12-Dez-2023  | move from Draft section to Active TRG's                  |
 | Draft  | 20-Sept-2023 | created initial Draft                                    |
 | Edited | 24-Okt-2023  | add draw.io as possible solution for static `.svg`-files |
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Please describe your PR: 
- moved Draft TRG into correct folder
- switch the TRG into active state for next release

updates https://github.com/eclipse-tractusx/sig-infra/issues/87

## Preview

![image](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/121097161/cd399d43-8e5a-4758-a6b3-c55a4a6e4c31)


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
