### PR TITLE
fix: copyright clarification for modular production KIT

### DIFF
--- a/docs-kits/kits/Modular Production Kit/page_adoption-view.md
+++ b/docs-kits/kits/Modular Production Kit/page_adoption-view.md
@@ -85,4 +85,4 @@ This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses
 
 - SPDX-License-Identifier: CC-BY-4.0
 - SPDX-FileCopyrightText: 2023;Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IWU & Fraunhofer IOSB & Fraunhofer IPA)
-- SPDX-FileCopyrightText: 2023,Siemens AG
+- SPDX-FileCopyrightText: 2023 Siemens AG

--- a/docs-kits/kits/Modular Production Kit/page_adoption-view.md
+++ b/docs-kits/kits/Modular Production Kit/page_adoption-view.md
@@ -84,5 +84,5 @@ The standards for release 3.2 will be published soon. Our relevant standards can
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: 2023,Fraunhofer Institute of Optronics, System Technology and Image Exploitation (IOSB)
+- SPDX-FileCopyrightText: 2023,Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IWU & Fraunhofer IOSB)
 - SPDX-FileCopyrightText: 2023,Siemens AG

--- a/docs-kits/kits/Modular Production Kit/page_adoption-view.md
+++ b/docs-kits/kits/Modular Production Kit/page_adoption-view.md
@@ -84,5 +84,5 @@ The standards for release 3.2 will be published soon. Our relevant standards can
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: 2023;Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IWU & Fraunhofer IOSB & Fraunhofer IPA)
+- SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IWU & Fraunhofer IOSB & Fraunhofer IPA)
 - SPDX-FileCopyrightText: 2023 Siemens AG

--- a/docs-kits/kits/Modular Production Kit/page_adoption-view.md
+++ b/docs-kits/kits/Modular Production Kit/page_adoption-view.md
@@ -84,5 +84,5 @@ The standards for release 3.2 will be published soon. Our relevant standards can
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: 2023,Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IWU & Fraunhofer IOSB)
+- SPDX-FileCopyrightText: 2023;Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IWU & Fraunhofer IOSB & Fraunhofer IPA)
 - SPDX-FileCopyrightText: 2023,Siemens AG

--- a/docs-kits_versioned_docs/version-23.12/kits/Modular Production Kit/page_adoption-view.md
+++ b/docs-kits_versioned_docs/version-23.12/kits/Modular Production Kit/page_adoption-view.md
@@ -84,5 +84,5 @@ The standards for release 3.2 will be published soon. Our relevant standards can
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: 2023;Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IWU & Fraunhofer IOSB & Fraunhofer IPA)
+- SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IWU & Fraunhofer IOSB & Fraunhofer IPA)
 - SPDX-FileCopyrightText: 2023,Siemens AG

--- a/docs-kits_versioned_docs/version-23.12/kits/Modular Production Kit/page_adoption-view.md
+++ b/docs-kits_versioned_docs/version-23.12/kits/Modular Production Kit/page_adoption-view.md
@@ -84,5 +84,5 @@ The standards for release 3.2 will be published soon. Our relevant standards can
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: 2023,Fraunhofer Institute of Optronics, System Technology and Image Exploitation (IOSB)
+- SPDX-FileCopyrightText: 2023,Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IWU & Fraunhofer IOSB)
 - SPDX-FileCopyrightText: 2023,Siemens AG

--- a/docs-kits_versioned_docs/version-23.12/kits/Modular Production Kit/page_adoption-view.md
+++ b/docs-kits_versioned_docs/version-23.12/kits/Modular Production Kit/page_adoption-view.md
@@ -85,4 +85,4 @@ This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses
 
 - SPDX-License-Identifier: CC-BY-4.0
 - SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IWU & Fraunhofer IOSB & Fraunhofer IPA)
-- SPDX-FileCopyrightText: 2023,Siemens AG
+- SPDX-FileCopyrightText: 2023 Siemens AG

--- a/docs-kits_versioned_docs/version-23.12/kits/Modular Production Kit/page_adoption-view.md
+++ b/docs-kits_versioned_docs/version-23.12/kits/Modular Production Kit/page_adoption-view.md
@@ -84,5 +84,5 @@ The standards for release 3.2 will be published soon. Our relevant standards can
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: 2023,Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IWU & Fraunhofer IOSB)
+- SPDX-FileCopyrightText: 2023;Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IWU & Fraunhofer IOSB & Fraunhofer IPA)
 - SPDX-FileCopyrightText: 2023,Siemens AG


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

Clarification of copyright notice in the Modular Production KIT. The current release states 

> `Fraunhofer Institute of Optronics, System Technology and Image Exploitation (IOSB)`

where it should have been 

> `Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer IWU & Fraunhofer IOSB & Fraunhofer IPA)`


@wehrstedt-jan 

@danielmiehle @maximilianong 

<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
