### PR TITLE
fix(trace): replace broken link to the traceability kit

### DIFF
--- a/utils/kitsGallery.js
+++ b/utils/kitsGallery.js
@@ -53,7 +53,7 @@ export const kitsGallery = [
     name: 'Traceability Kit',
     domain: 'PLM / Quality',
     img: Traceability_Kit,
-    pageRoute: "/docs-kits/kits/Traceability Kit/Adoption View Traceability Kit"
+    pageRoute: "/docs-kits/kits/Traceability Kit/Business View Traceability Kit"
   },
   {
     id: 5,


### PR DESCRIPTION
## Description
The link to the traceability kit on the developer page is broken. This PR fixes the bug by replacing the link.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
