### PR TITLE
(doc) About: two small typos

### DIFF
--- a/src/components/AboutUsCard/index.js
+++ b/src/components/AboutUsCard/index.js
@@ -41,7 +41,7 @@ export default function AboutUsCard() {
         </div>
         <div className={styles.information_container}>
           <p className={styles.description}>
-            <span className={styles.descriptionhighlight}> The Eclipse Tractus-X™ project</span> is the official open-source project in the Catena-X ecosystem under the umbrella of the Eclipse Foundation. The Eclipse Foundation is not-for-profit corporation that it supported by over 320 members, and represents the worlds largest sponsored collection of Open Source projects and developers.
+            <span className={styles.descriptionhighlight}> The Eclipse Tractus-X™ project</span> is the official open-source project in the Catena-X ecosystem under the umbrella of the Eclipse Foundation. The Eclipse Foundation is a not-for-profit corporation that is supported by over 320 members, and represents the worlds largest sponsored collection of Open Source projects and developers.
           </p>
           <div>
             <Link className={styles.outlinedbutton} to="/aboutus">


### PR DESCRIPTION
## Description
Fixed two small typos in prominent https://eclipse-tractusx.github.io/ start page
```diff
- is not-for-profit corporation
+ is a not-for-profit corporation
- that it supported
+ that is supported
```



## Pre-review checks
- [✅] DEPENDENCIES are up-to-date. 
- [✅] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files

![image](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/154517566/bc55c405-df86-4f48-b00f-172dc09841e4)
