### PR TITLE
docs: adjust trg 4.03 on userid

### DIFF
--- a/docs/release/trg-4/trg-4-03.md
+++ b/docs/release/trg-4/trg-4-03.md
@@ -52,6 +52,5 @@ spec:
   - name: example-container
     image: gcr.io/google-samples/node-hello:1.0
     securityContext:
-      runAsUser: 1000 # SPECIFY USER ID HERE
       allowPrivilegeEscalation: false # SET THIS TO FALSE
 ```

--- a/docs/release/trg-4/trg-4-03.md
+++ b/docs/release/trg-4/trg-4-03.md
@@ -4,6 +4,7 @@ title: TRG 4.03 - Non-root container
 
 | Status | Created      | Post-History                     |
 |--------|--------------|----------------------------------|
+| Active | 04-Jan-2024  | Adjust user ids                  |
 | Active | 29-Dec-2022  | Initial Release                  |
 | Draft  | 14-Sept-2022 | Draft                            |
 
@@ -19,14 +20,19 @@ For security reasons this is **must** be followed.
 
 The container's **Dockerfile** and the **Pod resource file (yaml)** has to be modified to be able to run as a non-root user.
 
-- Modify the image's Dockerfile with a `RUN` command that adds a non-root user and a `USER` command that specifies which user runs the container on startup. The example below can be modified for specific needs/requirements.
+- First it is recommended to check how the base image is built to see if it
+  might already have a non-root user defined and used. In this case it is enough
+  to specify that user in the Dockerfile with the `USER` instruction.
+- Otherwise modify the image's Dockerfile with a `RUN` command that adds a non-root user
+  and a `USER` command that specifies which user runs the container on startup.
+  The example below can be modified for specific needs/requirements.
 
 ```Dockerfile
 #Pull the base image as Ubuntu
 FROM ubuntu:latest
 
-#Add a user with userid 8877 and name nonroot
-RUN useradd −u 8877 nonroot
+#Add a user with userid 1000 and name nonroot
+RUN useradd −u 1000 nonroot
 
 #Run Container as nonroot
 USER nonroot


### PR DESCRIPTION
## Description

Fixes https://github.com/eclipse-tractusx/sig-infra/issues/369

Adjusted the user ids in the Pod template and added a recommendation section to look for user id created in the base image.

----

I would consider adding more fields as described in the [Kubernetes docs](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) to further enhance security like `runAsGroup`, `fsGroup` and also dropping capabilities. I would welcome some suggestions here.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
