### PR TITLE
doc(open meetings): add new open planning meeting

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -7,7 +7,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 
 <MeetingInfo title="Tractus-X Open Planning R24.05"
              schedule="Wednesday, 17. January 2024, 9.30 pm until 16.30 pm CET (UTC +1)"
-             description="Open Planning, hosted by the Network Service Committee of the Catena-X association. The goal for this meeting is the planning of the features for the next Tracts-X release"
+             description="Open Planning, hosted by the Network Service Committee of the Catena-X association. The goal for this meeting is the planning of the features for the next Tractus-X release"
             contact="stephan.bauer@catena-x.net"
 />
 

--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -5,6 +5,11 @@ import MeetingInfo from '@site/src/components/MeetingInfo';
 This page hosts information about all of our open Tractus-X meetings.
 These are dedicated sync meetings for specific products, as well as open planning sessions.
 
+<MeetingInfo title="Tractus-X Open Planning R24.05"
+             schedule="Wednesday, 17. January 2024, 9.30 pm until 16.30 pm CET (UTC +1)"
+             description="Open Planning, hosted by the Network Service Committee of the Catena-X association. The goal for this meeting is the planning of the features for the next Tracts-X release"
+            contact="stephan.bauer@catena-x.net"
+
 <MeetingInfo title="Tractus-X community call"
              schedule="Every Friday 1pm CET (UTC +1)"
              description="Formerly known as the 'Office Hour', hosted by the System Team of the Catena-X Consortium, the Tractus-X is the open

--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -9,6 +9,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
              schedule="Wednesday, 17. January 2024, 9.30 pm until 16.30 pm CET (UTC +1)"
              description="Open Planning, hosted by the Network Service Committee of the Catena-X association. The goal for this meeting is the planning of the features for the next Tracts-X release"
             contact="stephan.bauer@catena-x.net"
+/>
 
 <MeetingInfo title="Tractus-X community call"
              schedule="Every Friday 1pm CET (UTC +1)"


### PR DESCRIPTION
<img width="950" alt="image" src="https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/a42eade6-4b22-4c3c-8d14-a68c31c1f455">

## Description

To follow the open source startegies, we want to publish/communicate all our open meetings. In this case the open planning meeting.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
