### PR TITLE
docs: new Dependabot TRG

### DIFF
--- a/docs/release/trg-0/trg-2-6.md
+++ b/docs/release/trg-0/trg-2-6.md
@@ -20,7 +20,7 @@ Key Benefits:
 
 Dependabot is an excellent fit for application dependencies/vulnerabilities. By regularly checking for updates, it allows you to seamlessly integrate the latest improvements into your application.
 
-For Docker images, Dependabot ensures that your base images and dependencies are regularly updated, reducing the risk of using outdated or vulnerable components.
+For Docker images, Dependabot ensures that your [base images](https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-02) and dependencies are regularly updated, reducing the risk of using outdated or vulnerable components.
 
 Dependabot can also assist in keeping used GitHub Actions up to date. This is crucial for ensuring that your workflows leverage the latest GitHub Actions features and improvements.
 
@@ -37,6 +37,11 @@ To enable Dependabot for version updates, create a dependabot.yml file in .githu
 ### Example
 
 This configuration checks for Maven, GitHub Action and Docker updates on a weekly basis and creates pull requests for up to 5 updates at a time.
+
+:::caution
+Be careful, Dependabot PR merge can lead to out of date DEPENDENCIES file.
+Make sure DEPENDENCIES file is updated by DASH tool.
+:::
 
 ```yaml
 version: 2
@@ -66,11 +71,6 @@ updates:
 More information:  
 <https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates>  
 <https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file>
-
-:::caution
-Be careful, Dependabot PR merge can lead to out of date DEPENDENCIES file.
-Make sure DEPENDENCIES file is updated by DASH tool.
-:::
 
 :::info
 Importance of Implemented Tests:

--- a/docs/release/trg-0/trg-2-6.md
+++ b/docs/release/trg-0/trg-2-6.md
@@ -18,4 +18,23 @@ Key Benefits:
 
 ## Description
 
+Dependabot is an excellent fit for application dependencies/vulnerabilities. By regularly checking for updates, it allows you to seamlessly integrate the latest improvements into your application.
+
+For Docker images, Dependabot ensures that your base images and dependencies are regularly updated, reducing the risk of using outdated or vulnerable components.
+
+Dependabot can also assist in keeping your GitHub Actions workflows up-to-date. This is crucial for ensuring that your continuous integration and delivery processes leverage the latest GitHub Actions features and improvements.
+
+### Version updates
+
+To enable Dependabot for version updates, create a dependabot.yml file in the root of your repository. See provided example below.
+More information:
+<https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates>
+<https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file>
+
+### Security updates
+
+To enable Dependabot for security updates, you can leverage GitHub's Security tab. Go to the "Security" tab in your repository and follow the prompts to enable automated security updates.
+More information:
+<https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates>
+
 ## Example

--- a/docs/release/trg-0/trg-2-6.md
+++ b/docs/release/trg-0/trg-2-6.md
@@ -8,6 +8,14 @@ title: TRG 2.06 - Dependabot
 
 ## Why
 
+GitHub Dependabot is a powerful tool designed to help keep your project's dependencies up-to-date. By automating the process of checking for updates and creating pull requests when new versions are available, Dependabot ensures that your project benefits from the latest features, bug fixes, and security patches.
+
+Key Benefits:
+
+    - Security: Receive timely updates for security vulnerabilities in your project's dependencies.
+    - Stability: Keep your project stable by staying current with the latest releases.
+    - Efficiency: Automate the time-consuming task of manually checking for updates and creating pull requests.
+
 ## Description
 
 ## Example

--- a/docs/release/trg-0/trg-2-6.md
+++ b/docs/release/trg-0/trg-2-6.md
@@ -70,5 +70,5 @@ More information:
 :::info
 Importance of Implemented Tests:
 
-Ensure that your project has comprehensive test coverage. Automated tests are crucial for quickly validating that updates do not introduce regressions or break existing functionality. 
+Ensure that your project has comprehensive test coverage. Automated tests are crucial for quickly validating that updates do not introduce regressions or break existing functionality.
 :::

--- a/docs/release/trg-0/trg-2-6.md
+++ b/docs/release/trg-0/trg-2-6.md
@@ -12,9 +12,9 @@ GitHub Dependabot is a powerful tool designed to help keep your project's depend
 
 Key Benefits:
 
-    - Security: Receive timely updates for security vulnerabilities in your project's dependencies.
-    - Stability: Keep your project stable by staying current with the latest releases.
-    - Efficiency: Automate the time-consuming task of manually checking for updates and creating pull requests.
+- Security: Receive timely updates for security vulnerabilities in your project's dependencies.
+- Stability: Keep your project stable by staying current with the latest releases.
+- Efficiency: Automate the time-consuming task of manually checking for updates and creating pull requests.
 
 ## Description
 
@@ -22,19 +22,19 @@ Dependabot is an excellent fit for application dependencies/vulnerabilities. By 
 
 For Docker images, Dependabot ensures that your base images and dependencies are regularly updated, reducing the risk of using outdated or vulnerable components.
 
-Dependabot can also assist in keeping your GitHub Actions workflows up-to-date. This is crucial for ensuring that your continuous integration and delivery processes leverage the latest GitHub Actions features and improvements.
+Dependabot can also assist in keeping used GitHub Actions up to date. This is crucial for ensuring that your workflows leverage the latest GitHub Actions features and improvements.
 
 ### Version updates
 
 To enable Dependabot for version updates, create a dependabot.yml file in the root of your repository. See provided example below.
-More information:
-<https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates>
+More information:  
+<https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates>  
 <https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file>
 
 ### Security updates
 
 To enable Dependabot for security updates, you can leverage GitHub's Security tab. Go to the "Security" tab in your repository and follow the prompts to enable automated security updates.
-More information:
-<https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates>
+More information:  
+<https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates>  
 
 ## Example

--- a/docs/release/trg-0/trg-2-6.md
+++ b/docs/release/trg-0/trg-2-6.md
@@ -8,13 +8,13 @@ title: TRG 2.06 - Dependabot
 
 ## Why
 
-GitHub Dependabot is a powerful tool designed to help keep your project's dependencies up-to-date. By automating the process of checking for updates and creating pull requests when new versions are available, Dependabot ensures that your project benefits from the latest features, bug fixes, and security patches.
+GitHub Dependabot is a powerful tool designed to help keep your project's dependencies up to date. By automating the process of checking for updates and creating pull requests when new versions are available, Dependabot ensures that your project benefits from the latest features, bug fixes, and security patches.
 
 Key Benefits:
 
 - Security: Receive timely updates for security vulnerabilities in your project's dependencies.
 - Stability: Keep your project stable by staying current with the latest releases.
-- Efficiency: Automate the time-consuming task of manually checking for updates and creating pull requests.
+- Efficiency: Automate the time consuming task of manually checking for updates and creating pull requests.
 
 ## Description
 
@@ -24,17 +24,45 @@ For Docker images, Dependabot ensures that your base images and dependencies are
 
 Dependabot can also assist in keeping used GitHub Actions up to date. This is crucial for ensuring that your workflows leverage the latest GitHub Actions features and improvements.
 
-### Version updates
-
-To enable Dependabot for version updates, create a dependabot.yml file in the root of your repository. See provided example below.
-More information:  
-<https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates>  
-<https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file>
-
 ### Security updates
 
 To enable Dependabot for security updates, you can leverage GitHub's Security tab. Go to the "Security" tab in your repository and follow the prompts to enable automated security updates.
 More information:  
 <https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates>  
 
-## Example
+### Version updates
+
+To enable Dependabot for version updates, create a dependabot.yml file in .github directory the root of your repository. In order to reduce number of generated bump Pull Requests, recommendation is to change default interval to i.e. weekly, as well as limit open PRs. See provided example below.
+
+### Example
+
+This configuration checks for Maven, GitHub Action and Docker updates on a weekly basis and creates pull requests for up to 5 updates at a time.
+
+```yaml
+version: 2
+updates:
+    # Maintain dependencies for Maven
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+    # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+    # Maintain dependencies for Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+```
+
+More information:  
+<https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates>  
+<https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file>

--- a/docs/release/trg-0/trg-2-6.md
+++ b/docs/release/trg-0/trg-2-6.md
@@ -1,0 +1,13 @@
+---
+title: TRG 2.06 - Dependabot
+---
+
+| Status | Created      | Post-History    |
+|--------|--------------|-----------------|
+| Draft  | 4-Jan-2024   | Initial release |
+
+## Why
+
+## Description
+
+## Example

--- a/docs/release/trg-0/trg-2-6.md
+++ b/docs/release/trg-0/trg-2-6.md
@@ -66,3 +66,9 @@ updates:
 More information:  
 <https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates>  
 <https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file>
+
+:::info
+Importance of Implemented Tests:
+
+Ensure that your project has comprehensive test coverage. Automated tests are crucial for quickly validating that updates do not introduce regressions or break existing functionality. 
+:::

--- a/docs/release/trg-0/trg-2-6.md
+++ b/docs/release/trg-0/trg-2-6.md
@@ -67,6 +67,11 @@ More information:
 <https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates>  
 <https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file>
 
+:::caution
+Be careful, Dependabot PR merge can lead to out of date DEPENDENCIES file.
+Make sure DEPENDENCIES file is updated by DASH tool.
+:::
+
 :::info
 Importance of Implemented Tests:
 


### PR DESCRIPTION
PR to introduce new TRG for Dependabot. It's a GitHub feature which supports security and versions' updates automation. 
Idea behind the TRG creation is to help the project keep up to date in best, optimal effort wise way.

Proposing to park it as next item in the GIT section, any suggestions for better place always welcomed.

Fixes https://github.com/eclipse-tractusx/sig-infra/issues/150