### PR TITLE
fix: reference static content correctly

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -10,7 +10,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
              description="Open Planning (follow up for Trace-X features), planned for release 24.05"
              contact="martin.kanal@doubleslash.de"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NTA2NTRhNjAtYzMyYi00OTBkLWIxYTUtM2FhNjgzOGU2ZjBk%40thread.v2/0?context=%7b%22Tid%22%3a%2226f86412-f875-4281-b566-fe6fe385e17c%22%2c%22Oid%22%3a%22db3ba521-7335-4e4f-b672-fc9f7c3f5536%22%7d"
-             meetingLink="../meetings/alignment-and-planning-trace-x.ics"
+             meetingLink="/meetings/alignment-and-planning-trace-x.ics"
 />
 
 <MeetingInfo title="Tractus-X Open Planning R24.05"


### PR DESCRIPTION
Fix broken link in community open meetings section.

closes #619 