### PR TITLE
fix: reference links for helm test TRG 5-09 within TRG 5-08

### DIFF
--- a/docs/release/trg-5/trg-5-08.md
+++ b/docs/release/trg-5/trg-5-08.md
@@ -20,5 +20,5 @@ A "Product Helm Chart" is a released helm chart that contains all the components
 - name of the Chart **should** be just the `product-name` without prefix or suffix (similar to the [leading product repository](../trg-2/trg-2-4))
 - values file **should** contain all available variables (even from subcharts) with default values and comments about what they do
 - [helm install](https://helm.sh/docs/helm/helm_install/#helm-install) command should successfully install the chart to any supported Kubernetes version cluster (without overwriting default values)
-- [helm test](https://helm.sh/docs/helm/helm_test/) runs without errors (see [TRG 5.09 - Helm test](trg-5-09))
+- [helm test](https://helm.sh/docs/helm/helm_test/) runs without errors (see [TRG 5.09 - Helm test](trg-5-09.md))
 - create a single helm chart for the whole product or combine charts into a single one using [dependencies](https://helm.sh/docs/helm/helm_dependency/#helm-dependency) feature

--- a/docs/release/trg-5/trg-5-09.md
+++ b/docs/release/trg-5/trg-5-09.md
@@ -28,13 +28,13 @@ Helm charts and their dependent images (the application to test) need to be vali
 Helm test is the technical solution helm provides to verify that a helm chart works as expected. It basically installs the helm chart (which installs and runs the application) and then allows an additional
 container to run. This test container can do everything, especially calling an api, executing tests etc.
 
-This needs to be running in a Github Action in the repository which contains the Helm Chart, which gets released.
+This needs to be running in a GitHub Action in the repository which contains the Helm Chart, which gets released.
 
-Example Github Action Workflow:
+Example GitHub Action Workflow:
 
 - Build all necessary container images / pull the container image under test
-- Create [kind](https://kind.sigs.k8s.io/) setup (kind creates a kubernetes cluster through container images, github action supports this which allows you to create a kubernetes cluster inside the github action run)
-- Make the necessary container images available through the kind setup (see github action example, it uses the local kind registry)
+- Create [kind](https://kind.sigs.k8s.io/) setup (kind creates a kubernetes cluster through container images, GitHub action supports this which allows you to create a kubernetes cluster inside the GitHub action run)
+- Make the necessary container images available through the kind setup (see GitHub action example, it uses the local kind registry)
 - Prepare and execute helm test
 - Fail on a failing helm test
 - The example also contains the upgradeability test as the last step which
@@ -42,12 +42,12 @@ Example Github Action Workflow:
 
 Technical requirements:
 
-- A Github action exist which builds or uses the helm chart which gets released
-- The Github action can be triggered manually through Github WebUI [manually running a workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)
+- A GitHub action exist which builds or uses the helm chart which gets released
+- The GitHub action can be triggered manually through GitHub WebUI [manually running a workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)
 - Helm test verifies that the application is up and running
   - Example verifications:
     - Frontend: Frontend returns valid page
-    - API: API is reachable and returns valid response (access denied / test user can login)
+    - API: API is reachable and returns valid response (access denied / test user can log in)
 
 Example .github/workflows/helm-test.yaml
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

- fix markdown reference with the full filename within the link, like example in [TRG 5-11](https://raw.githubusercontent.com/eclipse-tractusx/eclipse-tractusx.github.io/main/docs/release/trg-5/trg-5-11.md)

https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/blob/0ba0454a402d4c8c3ccf727c9ce0151efaeb8af5/docs/release/trg-5/trg-5-11.md?plain=1#L18

- fix typo `GitHub`

fixes https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/issues/219

## Test 

was validated with 

- `npm run build`
- `npm run serve`

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
