### PR TITLE
fix: pin client redirect plugin version to stay compatible with docusaurus

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.2.0",
-    "@docusaurus/plugin-client-redirects": "^2.2.0",
+    "@docusaurus/plugin-client-redirects": "2.2.0",
     "@docusaurus/preset-classic": "2.2.0",
     "@docusaurus/theme-mermaid": "2.2.0",
     "@emotion/react": "^11.10.5",


### PR DESCRIPTION
This PR pins the version of "@docusaurus/plugin-client-redirects" to exactly match the core docsaurus version.
This is a mandatory requirement for all `@docusarus` libraries