### PR TITLE
docs(trg): make dedicated container image notice mandatory

### DIFF
--- a/docs/release/trg-4/trg-4-06.md
+++ b/docs/release/trg-4/trg-4-06.md
@@ -76,7 +76,7 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 
 ## Best practice and examples
 
-- Use "Container images" as headline to link to the container image notice files
+- Use "Container images" as headline to link to the container image notice files from the repositories README.md file
 - Name the notice file "notice.md"
 - Provide important information about your image with your notice. Examples:
   - Available volumes
@@ -88,7 +88,7 @@ Keeping the DockerHub description up-to-date with the latest notice content is c
 The following workflow step can be used as part of the DockerHub publishing workflow to ensure that:
 
 ```yaml
-# DockerHub publishing worklflow 
+# DockerHub publishing worklflow
 
 ...
 
@@ -110,7 +110,7 @@ The following workflow step can be used as part of the DockerHub publishing work
 The following examples are shown as reference, to see already existing and complete versions of a 'Notice for docker images'.
 They **can not** be used for your product without modifications.
 
-- [edc-controlplane-memory-hashicorp-vault](https://github.com/eclipse-tractusx/tractusx-edc/edit/main/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md)
+- [edc-controlplane-memory-hashicorp-vault](https://github.com/eclipse-tractusx/tractusx-edc/blob/main/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md)
 - [Country Risk](https://github.com/eclipse-tractusx/vas-country-risk/blob/main/DOCKER_NOTICE.md)
 
 ## Already collected base image information

--- a/docs/release/trg-4/trg-4-06.md
+++ b/docs/release/trg-4/trg-4-06.md
@@ -23,13 +23,10 @@ The minimum set of information is:
 - Direct link to the Dockerfile used to build your image
 - Link to `LICENCE` file in your repo as 'Project License' (make clear, that this is the PROJECT licence, not an image license)
 
-## How and where to annotate the base image
-
-The above information **must** be provided in Markdown format, either in your toplevel `README.md`, or in a dedicated
-notice Markdown file, that you then reference from your toplevel `README.md`.
-
-A dedicated notice file can be necessary, if you built multiple container image from a single repository.
-Multiple notice files ensure, that you can directly link the specific `Dockerfile`, that is used and include it in the description, that is pushed to `DockerHub`.
+The above information **must** be provided as dedicated Markdown file in your repository.
+It **should** be located next to the `Dockerfile`, that is used to build the image you are annotating.
+Provide a dedicated notice file for every image, that is published.
+It **must** be linked in your top-level `README.md`. Link all notice files, in case you publish multiple images.
 
 The notice **must** follow a specific structure, starting with a specific headline, a reference to your image on `DockerHub` and information about your product.
 You can use the following example as a starting point. Remember to update the placeholders indicated by `<>` brackets.
@@ -77,17 +74,44 @@ As with all Docker images, these likely also contain other software which may be
 As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.
 ```
 
-## Examples
+## Best practice and examples
+
+- Use "Container images" as headline to link to the container image notice files
+- Name the notice file "notice.md"
+- Provide important information about your image with your notice. Examples:
+  - Available volumes
+  - Default port the service is listening on
+
+### GitHub workflow step
+
+Keeping the DockerHub description up-to-date with the latest notice content is crucial.
+The following workflow step can be used as part of the DockerHub publishing workflow to ensure that:
+
+```yaml
+# DockerHub publishing worklflow 
+
+...
+
+# https://github.com/peter-evans/dockerhub-description
+- name: Update Docker Hub description
+  # Ensure the DockerHub description is updated with contents from a PR (usually images are not published on PR)
+  if: github.event_name != 'pull_request'
+  uses: peter-evans/dockerhub-description@v3
+  with:
+    username: ${{ secrets.DOCKER_HUB_USER }}
+    password: ${{ secrets.DOCKER_HUB_TOKEN }}
+    repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+    # IMPORTANT: Adjust this to the actual path of your container image notice
+    readme-filepath: <path/to/your/notice.md>
+```
+
+### Examples
 
 The following examples are shown as reference, to see already existing and complete versions of a 'Notice for docker images'.
 They **can not** be used for your product without modifications.
 
-Good example for notice integrated in toplevel `README.md`:
-
-- [IRS](https://github.com/eclipse-tractusx/item-relationship-service#notice-for-docker-image) or
-- [app-dashboard](https://github.com/eclipse-tractusx/app-dashboard#notice-for-docker-image)
-
-Good example for a dedicated notice file: [edc-controlplane-memory-hashicorp-vault](https://github.com/eclipse-tractusx/tractusx-edc/edit/main/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md)
+- [edc-controlplane-memory-hashicorp-vault](https://github.com/eclipse-tractusx/tractusx-edc/edit/main/edc-controlplane/edc-controlplane-memory-hashicorp-vault/notice.md)
+- [Country Risk](https://github.com/eclipse-tractusx/vas-country-risk/blob/main/DOCKER_NOTICE.md)
 
 ## Already collected base image information
 


### PR DESCRIPTION
## Description

This PR is a follow up to a [discussion on our mailing list](https://www.eclipse.org/lists/tractusx-dev/msg00306.html).
The discussion is about making a dedicated "Notice for Docker image" mandatory and no longer allow it to be a section in the top-level `README.md`.
So far, there has only been feedback pro change.

TL;DR from the discussion:

- Moving to a dedicated file is not a lot of work
- Can be used to better address target audience
- There is a character limit for DockerHub descriptions, which might cut off the mandatory notice section at the end of long repository README.md files

Fixes eclipse-tractusx/sig-infra#360

