### PR TITLE
fix(tutorials): Update prerequisites.md - minor changes

### DIFF
--- a/docs/tutorials/e2e/prerequisites/prerequisites.md
+++ b/docs/tutorials/e2e/prerequisites/prerequisites.md
@@ -139,7 +139,6 @@ export NO_PROXY="localhost,127.0.0.1,::1"
 
 The port http (80) should not be used, but it will, you can apply the above hints just by replacing https by http.
 
-
 #### ssh (22)
 
 For the [MXD], which is running locally, you only need secure shell access, which means port 22 should be open.

--- a/docs/tutorials/e2e/prerequisites/prerequisites.md
+++ b/docs/tutorials/e2e/prerequisites/prerequisites.md
@@ -121,7 +121,7 @@ export https_proxy=http://[username]:[password]@ [proxy-web-or-IP-address]:[port
 
 :::tip
 
-The above URLs then will be passed only if your proxy server is configured to forward the above whitelist of URLs. To ensure your setting is permant, you may want to add the above command in your .bashrc or /etc/environment. Futher you can configure apt to use the proxy by entering the following into the configuration file /etc/apt/apt.conf:
+The above URLs then will be passed only if your proxy server is configured to forward the above whitelist of URLs. To ensure your setting is permant, you may want to add the above command in your .bashrc or /etc/environment. Further you can configure apt to use the proxy by entering the following into the configuration file /etc/apt/apt.conf:
 
 ```bash
 Acquire::https::Proxy "http://[username]:[password]@ [proxy-web-or-IP-address]:[port-number]";
@@ -137,7 +137,7 @@ export NO_PROXY="localhost,127.0.0.1,::1"
 
 #### http (80)
 
-The port http (80) should not be used, but it will, you can apply the above hints just by replacing https by http.
+The port http (80) should not be used, but it will. You can apply the above hints for https (port 443) just by replacing https by http.
 
 #### ssh (22)
 

--- a/docs/tutorials/e2e/prerequisites/prerequisites.md
+++ b/docs/tutorials/e2e/prerequisites/prerequisites.md
@@ -110,7 +110,7 @@ The above list is currently a candidate for changes, especially as long as the u
 You will need https (port 443) as open port for getting access to the above repositories. If you do not have direct access from your system, you most likely work in an environment which is using proxy forwarding for https. An easy way to configure your system to use the proxy server is by setting the envionment variabale "https_proxy". For example with the command below (bash), if the port 8080 is used for the forwarding:
 
 ```bash
-export https_proxy=http://arena2036-proxy.rus.uni-stuttgart.de:8080
+export https_proxy=http://[proxy-web-or-IP-address]:8080
 ```
 
 The complete format is:

--- a/docs/tutorials/e2e/prerequisites/prerequisites.md
+++ b/docs/tutorials/e2e/prerequisites/prerequisites.md
@@ -226,7 +226,7 @@ Verify the generated key is working:
 sudo gpg --no-default-keyring --keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg --fingerprint
 ```
 
-Store location into source öist for hashicorp:
+Store location into source for hashicorp:
 
 ```bash
 echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \

--- a/docs/tutorials/e2e/prerequisites/prerequisites.md
+++ b/docs/tutorials/e2e/prerequisites/prerequisites.md
@@ -139,9 +139,6 @@ export NO_PROXY="localhost,127.0.0.1,::1"
 
 The port http (80) should not be used, but it will, you can apply the above hints just by replacing https by http.
 
-#### Port 8080
-
-Port 8080 will be used by the EDC, you will need the port 8080 once you want to exchnage data with a remote node.  
 
 #### ssh (22)
 

--- a/docs/tutorials/e2e/prerequisites/prerequisites.md
+++ b/docs/tutorials/e2e/prerequisites/prerequisites.md
@@ -137,7 +137,11 @@ export NO_PROXY="localhost,127.0.0.1,::1"
 
 #### http (80)
 
-The port http (80) should not be used, but in case it will, you can apply the above hints just by replacing https by http.
+The port http (80) should not be used, but it will, you can apply the above hints just by replacing https by http.
+
+#### Port 8080
+
+Port 8080 will be used by the EDC, you will need the port 8080 once you want to exchnage data with a remote node.  
 
 #### ssh (22)
 
@@ -208,17 +212,23 @@ Prepare the installation of Terraform including helm:
 
 ```bash
 sudo apt-get update && sudo apt-get install -y gnupg software-properties-common
+```
 
-sudo wget -o - https://apt.releases.hashicorp.com/gpg | | sudo gpg --dearmor -o | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
+Generate key for terraform:
+
+```bash
+sudo wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
 ```
   
 Verify the generated key is working:
 
 ```bash
-sudo gpg --no-default-keyring \
---keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg \
---fingerprint
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg --fingerprint
+```
 
+Store location into source öist for hashicorp:
+
+```bash
 echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
 https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
 ```


### PR DESCRIPTION
## Description

Added info for port 8080, correction of the shell command for generating the hashicorp key, some minor additions.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Closes #577 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
