### PR TITLE
chore update markdown links and rename sidebar to same format + fix typos  

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -808,7 +808,7 @@ npm/npmjs/-/semver/6.3.0, ISC, approved, clearlydefined
 npm/npmjs/-/semver/7.3.5, ISC, approved, clearlydefined
 npm/npmjs/-/semver/7.3.8, ISC, approved, clearlydefined
 npm/npmjs/-/send/0.18.0, MIT, approved, clearlydefined
-npm/npmjs/-/serialize-javascript/6.0.0, BSD-3-Clause, approved, clearlydefined
+npm/npmjs/-/serialize-javascript/6.0.0, BSD-3-Clause, approved, #12680
 npm/npmjs/-/serve-handler/6.1.5, MIT, approved, clearlydefined
 npm/npmjs/-/serve-index/1.9.1, MIT, approved, clearlydefined
 npm/npmjs/-/serve-static/1.15.0, MIT, approved, clearlydefined

--- a/docs-kits_versioned_docs/version-23.09/kits/tractusx-edc/docs/README.md
+++ b/docs-kits_versioned_docs/version-23.09/kits/tractusx-edc/docs/README.md
@@ -3,7 +3,7 @@
 The Tractus-X EDC repository creates runnable applications out of EDC extensions from
 the [Eclipse DataSpace Connector](https://github.com/eclipse-edc/Connector) repository.
 
-When running a EDC connector from the Tractus-X EDC repository there are three setups to choose from. They only vary by
+When running an EDC connector from the Tractus-X EDC repository there are three setups to choose from. They only vary by
 using different extensions for
 
 - Resolving of Connector-Identities
@@ -32,9 +32,9 @@ The three supported setups are.
   - [Control Plane](../edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/README.md)
     - [IDS DAPS Extensions](https://github.com/eclipse-edc/Connector/tree/main/extensions/common/iam/oauth2/daps)
     - [PostgreSQL Persistence Extensions](https://github.com/eclipse-edc/Connector/tree/main/extensions/control-plane/store/sql)
-    - [HashiCorp Vault Extension](../edc-extensions/hashicorp-vault/README.md)
+    - [HashiCorp Vault Extension](../edc-dataplane/edc-dataplane-hashicorp-vault/README.md)
   - [Data Plane](../edc-dataplane/edc-dataplane-hashicorp-vault/README.md)
-    - [HashiCorp Vault Extension](../edc-extensions/hashicorp-vault/README.md)
+    - [HashiCorp Vault Extension](../edc-dataplane/edc-dataplane-hashicorp-vault/README.md)
 
 ## Recommended Documentation
 
@@ -44,7 +44,7 @@ The three supported setups are.
 - [Application: Control Plane](../edc-controlplane)
 - [Application: Data Plane](../edc-dataplane)
 - [Extension: Business Partner Numbers](../edc-extensions/business-partner-validation/README.md)
-- [Example: Local TXDC Setup](samples/Local%20TXDC%20Setup.md)
+- [Example: Local TXDC Setup](../docs/samples/example-dataspace/README.md)
 - [Example: Data Transfer](samples/Transfer%20Data.md)
 
 ### Eclipse Dataspace Connector

--- a/docs-kits_versioned_docs/version-23.09/kits/tractusx-edc/docs/samples/Transfer Data.md
+++ b/docs-kits_versioned_docs/version-23.09/kits/tractusx-edc/docs/samples/Transfer Data.md
@@ -26,7 +26,7 @@ consumer. But the roles could be inverse as well.
 ## 1. Optional - Local Setup
 
 To create a local setup with two connectors have a look at
-the [Local TXDC Setup Documentation](Local%20TXDC%20Setup.md).
+the [Local TXDC Setup Documentation](/docs-kits_versioned_docs/version-23.09/kits/tractusx-edc/docs/samples/example-dataspace/README.md).
 It creates two connectors (Plato & Sokrates) with exposed Node Ports.
 
 ### See Node Ports using Minikube
@@ -262,7 +262,7 @@ offer (received in step 2).
 In the diagram the IDS contract negotiation is marked as simplified, because the EDC is exchanging multiple messages
 during contract negotiation. But the inter-controlplane communication is not in the scope of this document.
 
-After the negotiation is initiated ensure that is has concluded. This is done by requesting the negotiation from the API
+After the negotiation is initiated ensure that it has concluded. This is done by requesting the negotiation from the API
 and checking whether the `contractAgreementId` is set. This might take a few seconds.
 
 ![Sequence 1](diagrams/transfer_sequence_3.png)

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/page_software-operation-view.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/page_software-operation-view.md
@@ -30,7 +30,7 @@ The project can be run with the following command: `mvn clean spring-boot:run`
 
 When running, the project requires a Postgresql database and an Opensearch instance to be available to connect to.
 Per default configuration the application expects postgres to run on `localhost` on port `5432`.
-Opensearch needs to run on `localhost` on port `9200` on default.
+OpenSearch needs to run on `localhost` on port `9200` on default.
 
 You can find and edit the default configuration for the Pool in the `application.properties`,  `application-auth.properties` and `application-saas.properties`
 files in the `resources` folder.
@@ -41,7 +41,7 @@ The REST API documentation can be accessed at `http://localhost:8080/api/swagger
 
 The default configuration of the application is determined by the `application.properties` file.
 Here you can find core application configuration such as Swagger documentation, BPN generation and Actuator.
-Furthermore, here you can find the configuration for the connection to the Spring datasource (currently, developed against PostgreSQL) and Opensearch.
+Furthermore, here you can find the configuration for the connection to the Spring datasource (currently, developed against PostgreSQL) and OpenSearch.
 
 You can also run the project with Spring profiles to enable additional components on top of the default configuration.
 Currently, the BPDM Pool offers the profiles `auth` and `saas`.
@@ -56,12 +56,12 @@ The following sections detail the configuration properties for each profile.
 
 `application-auth.properties` enables authorization of endpoints and configures the connection to a Keycloak instance on which the authorization relies on.
 The application expects the Keycloak to run on `localhost` on port `8180`.
-However, as with the Spring datasource and Opensearch connections, the connection to the Keycloak can be freely configured.
+However, as with the Spring datasource and OpenSearch connections, the connection to the Keycloak can be freely configured.
 The application uses the configured auth server URL to validate incoming tokens.
 
 For authorization purposes the application checks incoming token's permissions:
 
-* add_company_data: For endpoints creating or updating business partner records including triggering imports from SaaS/exports to Opensearch
+* add_company_data: For endpoints creating or updating business partner records including triggering imports from SaaS/exports to OpenSearch
 * view_company_data: For read-only endpoints of business partner data
 
 The BPDM Pool looks for these permissions in the client/resource and not on the realm level.
@@ -82,7 +82,7 @@ should be imported by the application.
 ### Helm Deployment
 
 This repository contains Helm files for deploying the BPDM Pool to a Kubernetes environment.
-See the [BPDM Pool Helm README](charts/pool/README.md) for details.
+See the [BPDM Pool Helm README](https://github.com/eclipse-tractusx/bpdm/blob/main/charts/bpdm/charts/bpdm-pool/README.md) for details.
 
 ## BPDM Gate
 
@@ -149,4 +149,4 @@ secret for the client.
 ### Helm Deployment
 
 This repository contains Helm files for deploying the BPDM Gate to a Kubernetes environment.
-See the [BPDM Gate Helm README](charts/gate/README.md) for details.
+See the [BPDM Gate Helm README](https://github.com/eclipse-tractusx/bpdm/blob/main/charts/bpdm/charts/bpdm-gate/README.md) for details.

--- a/docs/dev_faq.md
+++ b/docs/dev_faq.md
@@ -8,10 +8,10 @@ sidebar_position: 1
 See the [Handbook](https://www.eclipse.org/projects/handbook/#resources-github)
 
 1. Verify that all contributors to this PR have a signed ECA.
-1. Verify that the EF account email addresses and the primary email address configured in GitHub match.
-1. Verify that your commits include the correct email address (tip: add .patch to the GitHub commit url to see the plaintext).
-1. Make sure you have added your GitHub ID to your Eclipse profile (Section: Social Media Links).
-1. Check the [Helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/?sort=created_date&state=opened) issues, if there is a known problem or open an issue.
+2. Verify that the EF account email addresses and the primary email address configured in GitHub match.
+3. Verify that your commits include the correct email address (tip: add .patch to the GitHub commit url to see the plaintext).
+4. Make sure you have added your GitHub ID to your Eclipse profile (Section: Social Media Links).
+5. Check the [Helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/?sort=created_date&state=opened) issues, if there is a known problem or open an issue.
 
 ## How can I check that somebody has a valid ECA?
 
@@ -24,6 +24,6 @@ See the [Handbook](https://www.eclipse.org/projects/handbook/#resources-github)
 - More information about [GitHub repository roles](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization)
 - More information about [Eclipse roles](https://eclipse-tractusx.github.io/docs/oss/contributor-committer#official-project-contributor)
 
-## How do I figure out the user name in Eclipse (= GitLab) ?
+## How do I figure out the username in Eclipse (= GitLab) ?
 
 - GitLab: Use the search GitLab field

--- a/docs/kit-process/coverpage.md
+++ b/docs/kit-process/coverpage.md
@@ -4,6 +4,6 @@ title: KIT - Guidelines
 
 In this section you find out KIT Guidelines here you find the basic concepts and requirements. If you are new and want to create or contribute to a KIT, start with our [Graduation Process](/docs/kit-process/graduation-process.md)!
 
-If you need additional help consult our [FAQ](/docs/kit-process/processes/contribute.md).
+If you need additional help consult our [FAQ](processes/kit-faq.md).
 
-**Wellcome to Tractus-X!**
+**Welcome to Tractus-X!**

--- a/docs/kit-process/processes/create_KIT_page.md
+++ b/docs/kit-process/processes/create_KIT_page.md
@@ -13,9 +13,9 @@ title: Create KIT website
 
 ## Project Structure
 
-Following our project structure, the collection of our KITs documentation is developed in the `./docs-kits/kits` folder, where each KIT is a subfolder called by its name for organisation purposes. The `Data Chain KIT`, for example, is defined here: `./docs-kits/kits/Data Chain Kit`.
+Following our project structure, the collection of our KITs documentation is developed in the `./docs-kits/kits` folder, where each KIT is a sub folder called by its name for organisation purposes. The `Data Chain KIT`, for example, is defined here: `./docs-kits/kits/Data Chain Kit`.
 
-Each folder/KIT's content is structured in at least four pages/subfolders:
+Each folder/KIT's content is structured in at least four pages/sub-folders:
 
 - Adoption View -> `page_adoption-view.md`
 - Software Operation View -> `page_software-operation-view.md`
@@ -84,7 +84,7 @@ Each folder/KIT's content is structured in at least four pages/subfolders:
                     └──page_software-development-view.md
     ```
 
-6. To generate the `OpenAPI` based documentation of your KIT, please consult the [Plugins section](/docs/website-guidelines/wiki#plugins) to configure your instance of the `Docusaurus-OpenAPI-Docs` in the `docusaurus.config.js`.
+6. To generate the `OpenAPI` based documentation of your KIT, please consult the [Plugins section](/docs/website-guidelines/wiki.md#plugins) to configure your instance of the `Docusaurus-OpenAPI-Docs` in the `docusaurus.config.js`.
 
 7. Add your newly created KIT documentation to the Kits `sidebar` page, by incorporating the following declaration in the sidebar object of the `sidebar.js` file:
 
@@ -112,7 +112,7 @@ Each folder/KIT's content is structured in at least four pages/subfolders:
     };
     ```
 
-    **Note** the sidebars may required bigger customisation based on your requirements, for that matters consult the [official documentation](https://docusaurus.io/docs/2.2.0/sidebar)
+    **Note** the sidebars may require bigger customisation based on your requirements, for that matters consult the [official documentation](https://docusaurus.io/docs/2.2.0/sidebar)
 
 8. After the NewKIT documentation and the corresponding `sidebar` are created, you would want to make it accessible from the `NavBar` of the page. More specifically under the `KITs dropdown menu`. This is easily handled by `Docusaurus` in the `docusaurus.config.js` file, where you'll need to add to the existing `navbar` object your newly created `route` and `label` (name of kit) to be added as a `dropdown` menu item. More specifically in:
 
@@ -169,4 +169,4 @@ The results of your newly created _KIT_ will be visible only (for now) in the `N
 
 To access the `Next` and the rest of the versions, you'll notice a `dropdown` menu with all of them in the `top-right` corner of the `NavBar` that is only been displayed when the user is navigating any of the existing `KITs`.
 
-Please check our [Understanding our multi-instance and versioning behaviour](/docs/website-guidelines/understanding-multi-instance_versioning) page, where we explain a little bit more in deep the structure of the project, the different instances of documentation, how to create versions and how the conditional rendering of the `versions dropdown` menu is been handled.
+Please check our [Understanding our multi-instance and versioning behaviour](/docs/website-guidelines/understanding-multi-instance-versioning.md) page, where we explain a little bit more in deep the structure of the project, the different instances of documentation, how to create versions and how the conditional rendering of the `versions dropdown` menu is being handled.

--- a/docs/kit-process/processes/kit-faq.md
+++ b/docs/kit-process/processes/kit-faq.md
@@ -6,35 +6,35 @@ title: KIT FAQ
 This page is currently under construction!
 :::
 
-On this page you will find an FAQ focused on questions related to the KIT documentation. There is also a general [FAQ for Tractus-X](/docs/dev_faq) and the [Tractus-X link collection](/docs/dev_links).
+On this page you will find an FAQ focused on questions related to the KIT documentation. There is also a general [FAQ for Tractus-X](/docs/dev_faq.md) and the [Tractus-X link collection](/docs/dev_links.md).
 
 ## How do I start?
 
 There are several resources providing information about contributing to the Eclipse Tractus-X project. Before you begin, please familiarize yourself with the following documentation:
 
-- [Getting started](/docs/oss/getting-started)
-- [How to contribute](/docs/oss/how-to-contribute)
-- [Eclipse project roles](/docs/oss/contributor-committer)
-- [Tractus-X link collection](/docs/dev_links)
+- [Getting started](../../../docs/oss/getting-started.md)
+- [How to contribute](../../../docs/oss/how-to-contribute.md)
+- [Eclipse project roles](../../../docs/oss/contributor-committer.md)
+- [Tractus-X link collection](/docs/dev_links.md)
 
 Tractus-X is an Eclipse project, the [Eclipse Foundation Project Handbook](https://www.eclipse.org/projects/handbook/#legaldoc) is the leading documentation.
 
 ## How do I get support?
 
-If you have any questions not answered here, in the general [FAQ](/docs/dev_faq) or in the documentation, please feel free to ask questions in our community channels:
+If you have any questions not answered here, in the general [FAQ](/docs/dev_faq.md) or in the documentation, please feel free to ask questions in our community channels:
 
 - [Tractus-X General Chat Room](https://chat.eclipse.org/#/room/#tools.tractus-x:matrix.eclipse.org)
 - [Tractus-X Developer Mailingliste](https://accounts.eclipse.org/mailing-list/tractusx-dev)
 
-There are several issue tracker for different purpose, please see the [issue tracker documentation](/docs/oss/issues).
+There are several issue tracker for different purpose, please see the [issue tracker documentation](/docs/oss/issues.md).
 
 ## How do I become a Tractus-X contributor?
 
-See [here](/docs/kit-process/processes/kit-faq#how-to-start)
+See [here](/docs/kit-process/processes/kit-faq.md#how-do-i-become-a-tractus-x-contributor)
 
 :::info
 You are an Eclipse contributor once you have signed the Eclipse Contributor Agreement (ECA).
-GitHub has automated checks that check your contributions. Without a signed ECA, the [checks will fail](/docs/dev_faq#the-eca-check-is-failing-while-merging-a-pr-what-to-do).
+GitHub has automated checks that check your contributions. Without a signed ECA, the [checks will fail](/docs/dev_faq.md#the-eca-check-is-failing-while-merging-a-pr-what-to-do).
 :::
 
 ## How to contribute ?
@@ -43,7 +43,7 @@ If you and your team want to contribute to an existing KIT or suggest a new KIT 
 
 1. See the process for creating a new KIT (TBD)
 
-1. Become an Eclipse Tractus-X project contributor, see [here](/docs/kit-process/processes/kit-faq#how-to-start)
+2. Become an Eclipse Tractus-X project contributor, see [here](/docs/kit-process/processes/kit-faq.md#how-do-i-start)
 
 <!--
 1. Make yourself familiar with git best practices, the Eclipse contribution guidelines and our processes.
@@ -55,7 +55,7 @@ If you and your team want to contribute to an existing KIT or suggest a new KIT 
 
 ## How do I get a Tractus-X repository?
 
-After your KIT suggestion is accepted you need to [request a Tractus-X repository](/docs/oss/issues#create-manage-a-repository-in-eclipse-tractusx). Tractus-X is an Eclipse project, the repositories are managed by the Eclipse Foundation.
+After your KIT suggestion is accepted you need to [request a Tractus-X repository](/docs/oss/issues.md#create-manage-a-repository-in-eclipse-tractusx). Tractus-X is an Eclipse project, the repositories are managed by the Eclipse Foundation.
 
 ## How to update the KIT documentation on the Tractus-X website ?
 
@@ -78,15 +78,15 @@ View the Tractus-X [versioning scheme](/docs/kit-process/versioning.md). On this
 
 (TBD)
 <!--
-Usually a new version is assigned when a new release is created. So a the version and release are closely releated. Below you find the github documentation to manage your [releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository).
+Usually a new version is assigned when a new release is created. So a version and release are closely related. Below you find the GitHub documentation to manage your [releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository).
 -->
 
 <!--
-## What to do with an project external KIT repository ?
+## What to do with a project external KIT repository ?
 
-It may be the case that you already started the development of your KIT outside of the Tractus-X project. In that case you should move your progress to your kit repository within the Tractus-X project. If you don't have an Tractus-X repository consult this [guide](/docs/kit-process/contribute.md#how-to-obtain-a-tractus-x-repository). Otherwise there are two options to move your content.
+It may be the case that you already started the development of your KIT outside the Tractus-X project. In that case you should move your progress to your kit repository within the Tractus-X project. If you don't have a Tractus-X repository consult this [guide](/docs/kit-process/contribute.md#how-to-obtain-a-tractus-x-repository). Otherwise, there are two options to move your content.
 
-1. If you have write access to your repositrory and it is empty you may see this code-tabe within the empty repository:
+1. If you have write access to your repository, and it is empty you may see this code-tab within the empty repository:
 
    ![import repository](resources/import-repository.png)
 
@@ -117,22 +117,22 @@ It may be the case that you already started the development of your KIT outside 
 
      `git push -u origin main`
 
-After moving your content to the new repository you should make your old repositry as read-only and add a link to the new repositry to your Readme. You find this option within the settings of your repository in the "Danger Zone" at the bottom of your settings page. Note that for other git providers this may be reached in different ways.
+After moving your content to the new repository you should make your old repository as read-only and add a link to the new repository to your Readme. You find this option within the settings of your repository in the "Danger Zone" at the bottom of your settings page. Note that for other git providers this may be reached in different ways.
 
-## How to request a artefact/request review?
+## How to request an artefact/request review?
 
-Raise an issue within the Tractus-X Repository and add a decription where to find the artefact/devliverable.
+Raise an issue within the Tractus-X Repository and add a description where to find the artefact/deliverable.
 
 ## How to request a promotion?
 
-Raise an Issue within the Tractus-X Repository and request an promotion to the next development stage. Consult the [Graduation Process](/docs/kit-process/graduation-process.md) page to know which artefacts must be finished to be able to be promited to the next stage. Additionally link the review Issue to each artefact! If it is the case that an artefact is not relevant to you provide a detailed description why.
+Raise an Issue within the Tractus-X Repository and request a promotion to the next development stage. Consult the [Graduation Process](/docs/kit-process/graduation-process.md) page to know which artefacts must be finished to be able to be promoted to the next stage. Additionally, link the review Issue to each artefact! If it is the case that an artefact is not relevant to you provide a detailed description why.
 
 -->
 ## General KIT workflow
 
 (TBD)
 <!--
-In this section we describe the general worklfow on how to contribute with git:
+In this section we describe the general workflow on how to contribute with git:
 
 1. Create a fork of the repository where you want to contribute.
 
@@ -152,9 +152,9 @@ You may update your KITs documentation as soon as you have published a new KIT R
 
 ## What to do to change already within Catena-x released content
 
-It may occurr that after the release of a new Catena-X version that you want to change something on your released documentation. Don't create a PR on the versionend documenation since it will be refused and more importantly it defeats the the purpose of versioning! If it is the case that you need to change something, we want to consider the following:
+It may occur that after the release of a new Catena-X version that you want to change something on your released documentation. Don't create a PR on the versioned documentation since it will be refused and more importantly it defeats the purpose of versioning! If it is the case that you need to change something, we want to consider the following:
 
-1. Is it feasable to let the error be within the release e.g. typo or similar minor errors
-2. If it is a critical error, raise an issue within the [community repository](https://github.com/eclipse-tractusx/community). Explain your problem and why it is critical that you need to add a change. The issue will be reviewd and then there will be an decision made whether the changes will be approved or not.
+1. Is it feasible to let the error be within the release e.g. typo or similar minor errors
+2. If it is a critical error, raise an issue within the [community repository](https://github.com/eclipse-tractusx/community). Explain your problem and why it is critical that you need to add a change. The issue will be reviewed and then there will be a decision made whether the changes will be approved or not.
 (TBD)
 -->

--- a/docs/kit-process/processes/kit-faq.md
+++ b/docs/kit-process/processes/kit-faq.md
@@ -84,7 +84,7 @@ Usually a new version is assigned when a new release is created. So a version an
 <!--
 ## What to do with a project external KIT repository ?
 
-It may be the case that you already started the development of your KIT outside the Tractus-X project. In that case you should move your progress to your kit repository within the Tractus-X project. If you don't have a Tractus-X repository consult this [guide](/docs/kit-process/contribute.md#how-to-obtain-a-tractus-x-repository). Otherwise, there are two options to move your content.
+It may be the case that you already started the development of your KIT outside the Tractus-X project. In that case you should move your progress to your kit repository within the Tractus-X project. If you don't have a Tractus-X repository consult this [guide](/docs/oss/issues.md#create-manage-a-repository-in-eclipse-tractusx) Otherwise, there are two options to move your content.
 
 1. If you have write access to your repository, and it is empty you may see this code-tab within the empty repository:
 

--- a/docs/kit-process/processes/update-documentation.md
+++ b/docs/kit-process/processes/update-documentation.md
@@ -12,13 +12,13 @@ title: Update Documentation
 
 On this page you find a description on how to create/update your KITs documentation.
 
-Before you can generate KIT documentation on the Tractus-X website repository, ensure that a dedicated repository exists for your product ([How to obtain a Tractus-X repository](/docs/kit-process/processes/kit-faq/#how-to-obtain-a-tractus-x-repository-)). This repository will serve as a storage space for your files and provide a platform for your work.
+Before you can generate KIT documentation on the Tractus-X website repository, ensure that a dedicated repository exists for your product. This repository will serve as a storage space for your files and provide a platform for your work.
 
 Subsequently, the KIT documentation will be duplicated to the Tractus-X website repository. The specific process for accomplishing this will be elucidated in the subsequent documentation.
 
 ## Process
 
-Currently the documentation has to be manually maintained by the process described below. This is only a temporary solution as we are still in process on finding the perfect fitting process.
+Currently, the documentation has to be manually maintained by the process described below. This is only a temporary solution as we are still in process on finding the perfect fitting process.
 
 ### Overview
 
@@ -36,7 +36,7 @@ Currently the documentation has to be manually maintained by the process describ
 
       ![IMG: Click on New Pull request](resources/click-on-new-pr.png)
 
-   3. Select Branch which should be merge into the base repository
+   3. Select Branch which should be merged into the base repository
 
       ![IMG: Select Branch to Merge](resources/select-branch-to-merge.png)
 
@@ -44,17 +44,17 @@ Currently the documentation has to be manually maintained by the process describ
 
       ![IMG: Click on Create Pull Request second](resources/click-create-pr.png)
 
-   5. Add Description, what you add/change/improve. If available link an Issue with "#\<Issue Number\>. Then click on "Create Pull request"
+   5. Add Description, what you add/change/improve. If available link an Issue with `#Issue Number`. Then click on "Create Pull request"
 
       ![IMG: Click on Create Pull Request final](resources/click-create-pr-final.png)
 
 4. The process owners ([@danielmiehle](https://github.com/danielmiehle) / [@maximilianong](https://github.com/maximilianong)) of publishing a KIT will review your pull request.
 
-The pull request will be approved if it meets our schema, liniting requirements and follows the [open source governance](/docs/release/trg-7/trg-7-00/).
+The pull request will be approved if it meets our schema, linting requirements and follows the [open source governance](/docs/release/trg-7/trg-7-00.md).
 
 ### Schema
 
-In order to have a uniform apperance we expect the documentation to be in a similar structure. You find the template in the template folder, a structural overview is below:
+In order to have a uniform appearance we expect the documentation to be in a similar structure. You find the template in the template folder, a structural overview is below:
 
 ```md
     .
@@ -66,9 +66,9 @@ In order to have a uniform apperance we expect the documentation to be in a simi
         └── page-software-operation-view.md
 ```
 
-The sections within these files are the aligned with the artefacts described [here](/docs/kit-process/artefacts).
+The sections within these files are the aligned with the artefacts described [here](/docs/kit-process/artefacts.md).
 
-Additionaly we apply linter for to the submitted code which will atomatically reject your pull request if these fail.
+Additionally, we apply linter for to the submitted code which will automatically reject your pull request if these fail.
 
 ## Notes
 

--- a/docs/website-guidelines/understanding-multi-instance-versioning.md
+++ b/docs/website-guidelines/understanding-multi-instance-versioning.md
@@ -3,11 +3,11 @@ title: Understanding our multi instance and versioning behaviour
 sidebar_position: 6
 ---
 
-Like mentioned in the [important to know!](/docs/kit-process/processes/create_KIT_page#important-to-know) section, In this `guideline` page we want to talk a bit about the structure, documentation instances, versioning and conditional rendering (non official) solution for the `versions dropdown` menu.
+Like mentioned in the [important to know!](/docs/kit-process/processes/create_KIT_page.md#important-to-know) section, In this `guideline` page we want to talk a bit about the structure, documentation instances, versioning and conditional rendering (non-official) solution for the `versions dropdown` menu.
 
 ## Our multi-instance structure
 
-We have structured our documentation i a way that it's divided in 3 instances/folders:
+We have structured our documentation in a way that it's divided in 3 instances/folders:
 
 - `./docs` -> dedicated to the `Developer Hub` content (not versioned)
 - `./docs-kits` -> dedicated to the `KITs` content (versioned)
@@ -29,7 +29,7 @@ The creation/tagging of a new version will follow a scheduled period of time, th
 npm run docusaurus docs:version:docs-kits 1.0.0
 ```
 
-This `command` will freeze (create a copy) all the documentation included in the `./docs-kits` folder at the moment of the creation and storage said copy in the `./docs-kits-versioned_docs` folder. At the same time, it will create a copy of the `sidebarsDocsKits.js` file and it will storage it in the `./docs-kits_versioned_sidebars` folder.
+This `command` will freeze (create a copy) all the documentation included in the `./docs-kits` folder at the moment of the creation and storage said copy in the `./docs-kits-versioned_docs` folder. At the same time, it will create a copy of the `sidebarsDocsKits.js` file, and it will document it in the `./docs-kits_versioned_sidebars` folder.
 
 That way `docusaurus` handles the different versions and is the reason why the `./docs-kits` folder is pointing always to the `Next` version.
 
@@ -64,4 +64,4 @@ themeConfig:
     })
 ```
 
-This last declaration will include automatically all the created versions from the `./docs-kits` instance, but it will be displayed at all time. This is a behaviour that we wanted to avoid, because it could create a misunderstanding for the user and raised questions like: what documentation does that `version dropdown menu` is pointing at? what if other instance needs to be versioned as well? `Docusaurus` doesn't provided an official solution for this scenario, but the community provided a good one that you can check at the end of this [tread](https://github.com/facebook/docusaurus/issues/4389), it required to [swizzle](https://docusaurus.io/docs/2.2.0/swizzling) the `DocsVersionDropdownNavbarItem` to make the conditional rendering of it depending on the navigation location in the page.
+This last declaration will include automatically all the created versions from the `./docs-kits` instance, but it will be displayed at all time. This is a behaviour that we wanted to avoid, because it could create a misunderstanding for the user and raised questions like: what documentation does that `version dropdown menu` is pointing at? what if other instance needs to be versioned as well? `Docusaurus` doesn't provide an official solution for this scenario, but the community provided a good one that you can check at the end of this [tread](https://github.com/facebook/docusaurus/issues/4389), it required to [swizzle](https://docusaurus.io/docs/2.2.0/swizzling) the `DocsVersionDropdownNavbarItem` to make the conditional rendering of it depending on the navigation location in the page.

--- a/sidebars.js
+++ b/sidebars.js
@@ -74,7 +74,7 @@ const sidebars = {
             collapsed: true,
             items: [
                 "website-guidelines/create-open-api-doc",
-                "website-guidelines/understanding-multi-instance_versioning",
+                "website-guidelines/understanding-multi-instance-versioning",
                 "website-guidelines/update-and-integrate-react-components",
                 "website-guidelines/update-news-page",
                 "website-guidelines/automate-kit-doc-update",


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

- update some markdown links to suggested location where they should point to
- rephrase wording and fix some typos
- rename sidebar.js to same format


updates #639 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
