### PR TITLE
fix(connector kit): fix markdown linter errors for connector kit

### DIFF
--- a/docs-kits_versioned_docs/version-23.09/kits/tractusx-edc/docs/README.md
+++ b/docs-kits_versioned_docs/version-23.09/kits/tractusx-edc/docs/README.md
@@ -32,9 +32,7 @@ The three supported setups are.
   - [Control Plane](../edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/README.md)
     - [IDS DAPS Extensions](https://github.com/eclipse-edc/Connector/tree/main/extensions/common/iam/oauth2/daps)
     - [PostgreSQL Persistence Extensions](https://github.com/eclipse-edc/Connector/tree/main/extensions/control-plane/store/sql)
-    - [HashiCorp Vault Extension](../edc-extensions/hashicorp-vault/README.md)
   - [Data Plane](../edc-dataplane/edc-dataplane-hashicorp-vault/README.md)
-    - [HashiCorp Vault Extension](../edc-extensions/hashicorp-vault/README.md)
 
 ## Recommended Documentation
 
@@ -44,8 +42,8 @@ The three supported setups are.
 - [Application: Control Plane](../edc-controlplane)
 - [Application: Data Plane](../edc-dataplane)
 - [Extension: Business Partner Numbers](../edc-extensions/business-partner-validation/README.md)
-- [Example: Local TXDC Setup](samples/Local%20TXDC%20Setup.md)
-- [Example: Data Transfer](samples/Transfer%20Data.md)
+- [Example: Local TXDC Setup](./samples/example-dataspace/README.md)
+- [Example: Data Transfer](./samples/Transfer%20Data.md)
 
 ### Eclipse Dataspace Connector
 

--- a/docs-kits_versioned_docs/version-23.09/kits/tractusx-edc/docs/kit/operation-view/page08_api.md
+++ b/docs-kits_versioned_docs/version-23.09/kits/tractusx-edc/docs/kit/operation-view/page08_api.md
@@ -3,7 +3,7 @@
 ## API Spec
 
 The API spec of the EDC is constantly evolving.
-The full API documentation for each release can be viewed on [management-api](../development-view/openAPI/management-api/management-api.info.mdx).
+The full API documentation for each release can be viewed on [management-api](../development-view/openAPI/tractusx-edc-api/tractus-x-edc-rest-api.info.mdx).
 The following are some example API calls for common use cases.
 They assume the default parameters from the previous local setup.
 

--- a/docs-kits_versioned_docs/version-23.09/kits/tractusx-edc/docs/samples/Transfer Data.md
+++ b/docs-kits_versioned_docs/version-23.09/kits/tractusx-edc/docs/samples/Transfer Data.md
@@ -26,7 +26,7 @@ consumer. But the roles could be inverse as well.
 ## 1. Optional - Local Setup
 
 To create a local setup with two connectors have a look at
-the [Local TXDC Setup Documentation](Local%20TXDC%20Setup.md).
+the [Local TXDC Setup Documentation](../samples/example-dataspace/README.md).
 It creates two connectors (Plato & Sokrates) with exposed Node Ports.
 
 ### See Node Ports using Minikube

--- a/docs-kits_versioned_docs/version-23.12/kits/tractusx-edc/docs/README.md
+++ b/docs-kits_versioned_docs/version-23.12/kits/tractusx-edc/docs/README.md
@@ -42,8 +42,8 @@ The three supported setups are.
 - [Application: Control Plane](../edc-controlplane)
 - [Application: Data Plane](../edc-dataplane)
 - [Extension: Business Partner Numbers](../edc-extensions/business-partner-validation/README.md)
-- [Example: Local TXDC Setup](samples/Local%20TXDC%20Setup.md)
-- [Example: Data Transfer](samples/Transfer%20Data.md)
+- [Example: Local TXDC Setup](./samples/example-dataspace/README.md)
+- [Example: Data Transfer](./samples/Transfer%20Data.md)
 
 ### Eclipse Dataspace Connector
 

--- a/docs-kits_versioned_docs/version-23.12/kits/tractusx-edc/docs/README.md
+++ b/docs-kits_versioned_docs/version-23.12/kits/tractusx-edc/docs/README.md
@@ -32,9 +32,7 @@ The three supported setups are.
   - [Control Plane](../edc-controlplane/edc-controlplane-postgresql-hashicorp-vault/README.md)
     - [IDS DAPS Extensions](https://github.com/eclipse-edc/Connector/tree/main/extensions/common/iam/oauth2/daps)
     - [PostgreSQL Persistence Extensions](https://github.com/eclipse-edc/Connector/tree/main/extensions/control-plane/store/sql)
-    - [HashiCorp Vault Extension](../edc-extensions/hashicorp-vault/README.md)
   - [Data Plane](../edc-dataplane/edc-dataplane-hashicorp-vault/README.md)
-    - [HashiCorp Vault Extension](../edc-extensions/hashicorp-vault/README.md)
 
 ## Recommended Documentation
 

--- a/docs-kits_versioned_docs/version-23.12/kits/tractusx-edc/docs/kit/operation-view/page08_api.md
+++ b/docs-kits_versioned_docs/version-23.12/kits/tractusx-edc/docs/kit/operation-view/page08_api.md
@@ -3,7 +3,7 @@
 ## API Spec
 
 The API spec of the EDC is constantly evolving.
-The full API documentation for each release can be viewed on [management-api](../development-view/openAPI/management-api/management-api.info.mdx).
+The full API documentation for each release can be viewed on [management-api](../development-view/openAPI/tractusx-edc-api/tractus-x-edc-rest-api.info.mdx).
 The following are some example API calls for common use cases.
 They assume the default parameters from the previous local setup.
 

--- a/docs-kits_versioned_docs/version-23.12/kits/tractusx-edc/docs/samples/Transfer Data.md
+++ b/docs-kits_versioned_docs/version-23.12/kits/tractusx-edc/docs/samples/Transfer Data.md
@@ -26,7 +26,7 @@ consumer. But the roles could be inverse as well.
 ## 1. Optional - Local Setup
 
 To create a local setup with two connectors have a look at
-the [Local TXDC Setup Documentation](Local%20TXDC%20Setup.md).
+the [Local TXDC Setup Documentation](../samples/example-dataspace/README.md).
 It creates two connectors (Plato & Sokrates) with exposed Node Ports.
 
 ### See Node Ports using Minikube

--- a/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/docs/kit/operation-view/page08_api.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/docs/kit/operation-view/page08_api.md
@@ -3,7 +3,7 @@
 ## API Spec
 
 The API spec of the EDC is constantly evolving.
-The full API documentation for each release can be viewed on [management-api](../development-view/openAPI/management-api/management-api.info.mdx).
+The full API documentation for each release can be viewed on the openAPI section, e.g [api-observability](../development-view/openAPI/management-api/api-observability/check-health.api.mdx).
 The following are some example API calls for common use cases.
 They assume the default parameters from the previous local setup.
 

--- a/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/docs/samples/Local TXDC Setup.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/docs/samples/Local TXDC Setup.md
@@ -121,4 +121,4 @@ helm uninstall --namespace cx plato
 helm uninstall --namespace cx sokrates
 ```
 
-> To try out the local setup, have a look at the [Transfer Example Documentation](Transfer%20Data.md)
+> To try out the local setup, have a look at the [Transfer Example Documentation](./Transfer%20Data.md)

--- a/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/docs/samples/Local TXDC Setup.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/docs/samples/Local TXDC Setup.md
@@ -33,7 +33,7 @@ Before the connectors can be setup, the Supporting Infrastructure must be in pla
 to run two connectors independently.
 
 For this local test scenario,
-the [Supporting Infrastructure](../../edc-tests/cucumber/src/main/resources/deployment/helm/supporting-infrastructure/README.md)
+the [Supporting Infrastructure](../../edc-tests/deployment/test-infrastructure/README.md)
 of the TXDC Business Tests can be used.
 
 Install the TXDC Supporting Infrastructure by running the following command from the project root directory. The Minio

--- a/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/docs/samples/Transfer Data.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/docs/samples/Transfer Data.md
@@ -20,7 +20,7 @@ consumer. But the roles could be inverse as well.
 ## 1. Optional - Local Setup
 
 To create a local setup with two connectors have a look at
-the [Local TXDC Setup Documentation](Local%20TXDC%20Setup.md).
+the [Local TXDC Setup Documentation](./Local%20TXDC%20Setup.md).
 It creates two connectors (Plato & Sokrates) with exposed Node Ports.
 
 ### See Node Ports using Minikube

--- a/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/edc-tests/cucumber/README.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/tractusx-edc/edc-tests/cucumber/README.md
@@ -16,4 +16,4 @@ act -j business-test
 
 ## Run and debug Business-Tests local within IDE
 
-Please refer to [run-local documentation in docs](../docs/development/Run-business-tests-local.md)
+Please refer to [run-local documentation in docs](../../docs/development/Run-business-tests-local.md)


### PR DESCRIPTION
## Description

Some links (references in the documentation) are broken, and this PR fixes them. The errors were mentioned in #639 
This PR fixes the errors related to the tags @stephanbcbauer and @stefan-ettl 

The issue #639 cannot be closed by this PR because there are more errors from other kits.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
