### PR TITLE
fix(business partner kit): fixed markdown linter warnings for kit

### DIFF
--- a/docs-kits_versioned_docs/version-23.12/kits/Business Partner Kit/Software Development View/page_software-development-view.md
+++ b/docs-kits_versioned_docs/version-23.12/kits/Business Partner Kit/Software Development View/page_software-development-view.md
@@ -163,7 +163,7 @@ The Address Controller is the controller that updates, creates, or retrieves bus
 
 | Address Controller |
 | :----------- |
-| [Create or update addresses (Output).](../Software%20Development%20View/Gate%20Api/put-addresses-output.api.mdx) |
+| [Create or update addresses (Output).](../Software%20Development%20View/Gate%20Api/upsert-addresses-output.api.mdx) |
 | [Get page of addresses](../Software%20Development%20View/Gate%20Api/get-addresses.api.mdx) |
 | [Create or update addresses](../Software%20Development%20View/Gate%20Api/upsert-addresses.api.mdx) |
 | [Get page of addresses. Can optionally be filtered by external ids.](../Software%20Development%20View/Gate%20Api/get-addresses-output.api.mdx) |

--- a/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/page_software-operation-view.md
+++ b/docs-kits_versioned_docs/version-3.1.0/kits/Business Partner Kit/page_software-operation-view.md
@@ -82,7 +82,7 @@ should be imported by the application.
 ### Helm Deployment
 
 This repository contains Helm files for deploying the BPDM Pool to a Kubernetes environment.
-See the [BPDM Pool Helm README](charts/pool/README.md) for details.
+See the [BPDM Pool Helm README](https://github.com/eclipse-tractusx/bpdm/blob/main/charts/bpdm/charts/bpdm-pool/README.md) for details.
 
 ## BPDM Gate
 
@@ -149,4 +149,4 @@ secret for the client.
 ### Helm Deployment
 
 This repository contains Helm files for deploying the BPDM Gate to a Kubernetes environment.
-See the [BPDM Gate Helm README](charts/gate/README.md) for details.
+See the [BPDM Gate Helm README](https://github.com/eclipse-tractusx/bpdm/blob/main/charts/bpdm/charts/bpdm-gate/README.md) for details.


### PR DESCRIPTION
## Description
References/links for Business parter kit were broken for old versions, and in this pull request we have fixed them.

This pull request fixes, warning mentioned in  #639 to tag @SujitMBRDI

The issue #639 cannot be closed by this PR because there are more warnings from other kits.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
