### PR TITLE
chore(ci): add dash workflow for PRs

### DIFF
--- a/.github/workflows/dash.yaml
+++ b/.github/workflows/dash.yaml
@@ -1,0 +1,46 @@
+# #############################################################################
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+---
+
+name: "3rd Party dependency check (Eclipse Dash)"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  check-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # See https://github.com/eclipse-tractusx/sig-infra/tree/main/.github/actions/run-dash for infos
+      # about the dash actions and possible config
+      - name: Run dash
+        id: run-dash
+        uses: eclipse-tractusx/sig-infra/.github/actions/run-dash@main
+        with:
+          dash_input: "package-lock.json"
+          fail_on_restricted: "true"


### PR DESCRIPTION
## Description

This PR adds a PR check, that runs [eclipse dash-licenses](https://github.com/eclipse/dash-licenses) and verifies, that our `DEPENDENCIES` files is up-to-date and does not contain any `restricted` or `rejected` dependencies.

Fixes #655 