### PR TITLE
doc(open meetings): add four open meetings

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -7,6 +7,38 @@ These are dedicated sync meetings for specific products, as well as open plannin
 
 ## Regular meetings
 
+<MeetingInfo title="Office Hour"
+             schedule="Every Friday effective 16. Feb 2024 until 31. Dec 2024 from 01:05 pm to 02:00 pm CET (UTC +1)"
+             description="Open hour meeting for all interests. The goal of the meeting is to inform and share information about different topics."
+             contact="stephan.bauer@catena-x.net"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MDFiNDJjMmQtNjFkYi00ODdjLTk2NDgtZGMwNTRmYzg3NzM0%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
+             meetingLink="/meetings/office-hour.ics"
+/>
+
+<MeetingInfo title="NewJoiner - Office Hour"
+             schedule="The second Friday of every month effective 8. Mar 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm CET (UTC +1)"
+             description="Open hour meeting for all new joiner. The goal of the meeting is to provide an easy entry on all topics. The meeting will only take place if specific questions have been submitted."
+             contact="stephan.bauer@catena-x.net"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjAzYzVjZGEtZjEwNC00NDI5LWEwODEtN2RhNmI0NDEzNTI2%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
+             meetingLink="/meetings/newjoiner-office-hour.ics"
+/>
+
+<MeetingInfo title="Committer - Office Hour"
+             schedule="Tthe third Friday of every month effective 16. Feb 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm CET (UTC +1)"
+             description="Open hour meeting for all committers. The goal of the meeting is to discuss and share specific committer tasks/responsibilities."
+             contact="stephan.bauer@catena-x.net"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTItNWE1MmMzMWUzNmYw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
+             meetingLink="/meetings/committer-office-hour.ics"
+/>
+
+<MeetingInfo title="Security - Office Hour"
+             schedule="Every 2 weeks on Thursday effective 15. Feb 2024 until 31. Dec 2024 from 08:35 am to 09:30 am CET (UTC +1)"
+             description="Open hour meeting, hosted by the sig-security team of the catena-x association. The goal of the meeting is to follow-up on security incidents, request review and assignments, and progress through security tools and procedures."
+             contact="rohan.krishnamurthy@zf.com"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MzYzMzVhODMtYWQyOC00NWVlLWEyMjMtNjVlZmY2NTlkNTdk%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
+             meetingLink="/meetings/security-office-hour.ics"
+/>
+
 <MeetingInfo title="[TRACE-X] Trace-X Open Meeting"
              schedule="Every Thursday effective 8. Feb 2024 until 20. Jun 2024 from 02:05 pm to 02:45 pm CET (UTC +1)"
              description="Coordination of feature development & concepts. For further information, please contact Martin Kanal or have a look into the downloadable ics file."

--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -8,7 +8,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 ## Regular meetings
 
 <MeetingInfo title="Office Hour"
-             schedule="Every Friday effective 16. Feb 2024 until 31. Dec 2024 from 01:05 pm to 02:00 pm CET (UTC +1)"
+             schedule="Every Friday effective 16. Feb 2024 until 31. Dec 2024 from 01:05 pm to 02:00 pm CET"
              description="Open hour meeting for all interests. The goal of the meeting is to inform and share information about different topics."
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MDFiNDJjMmQtNjFkYi00ODdjLTk2NDgtZGMwNTRmYzg3NzM0%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
@@ -16,31 +16,31 @@ These are dedicated sync meetings for specific products, as well as open plannin
 />
 
 <MeetingInfo title="NewJoiner - Office Hour"
-             schedule="The second Friday of every month effective 8. Mar 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm CET (UTC +1)"
-             description="Open hour meeting for all new joiner. The goal of the meeting is to provide an easy entry on all topics. The meeting will only take place if specific questions have been submitted."
+             schedule="Every second Friday of the month effective 8. Mar 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm CET"
+             description="Open hour meeting for all new joiner. The goal of the meeting is to provide an easy entry on all topics. The meeting will only take place if specific questions have been submitted. Please reach out in the first place to Stephan Bauer"
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjAzYzVjZGEtZjEwNC00NDI5LWEwODEtN2RhNmI0NDEzNTI2%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
              meetingLink="/meetings/newjoiner-office-hour.ics"
 />
 
-<MeetingInfo title="Committer - Office Hour"
-             schedule="The third Friday of every month effective 16. Feb 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm CET (UTC +1)"
-             description="Open hour meeting for all committers. The goal of the meeting is to discuss and share specific committer tasks/responsibilities."
+<MeetingInfo title="Committer Meeting"
+             schedule="Every third Friday of the month effective 16. Feb 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm CET"
+             description="Open hour meeting for Eclipse Tractus-X committers. The goal of the meeting is to discuss and share specific committer tasks/responsibilities."
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTItNWE1MmMzMWUzNmYw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
              meetingLink="/meetings/committer-office-hour.ics"
 />
 
 <MeetingInfo title="Security - Office Hour"
-             schedule="Every 2 weeks on Thursday effective 15. Feb 2024 until 31. Dec 2024 from 08:35 am to 09:30 am CET (UTC +1)"
-             description="Open hour meeting, hosted by the sig-security team of the catena-x association. The goal of the meeting is to follow-up on security incidents, request review and assignments, and progress through security tools and procedures."
+             schedule="Every 2 weeks on Thursday effective 15. Feb 2024 until 31. Dec 2024 from 08:35 am to 09:30 am CET"
+             description="Open hour meeting, hosted by the [sig-security](https://github.com/eclipse-tractusx/sig-security?tab=readme-ov-file#readme) team. The goal of the meeting is to follow-up on security incidents, request review and assignments, and progress through security tools and procedures."
              contact="rohan.krishnamurthy@zf.com"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MzYzMzVhODMtYWQyOC00NWVlLWEyMjMtNjVlZmY2NTlkNTdk%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
              meetingLink="/meetings/security-office-hour.ics"
 />
 
 <MeetingInfo title="[TRACE-X] Trace-X Open Meeting"
-             schedule="Every Thursday effective 8. Feb 2024 until 20. Jun 2024 from 02:05 pm to 02:45 pm CET (UTC +1)"
+             schedule="Every Thursday effective 8. Feb 2024 until 20. Jun 2024 from 02:05 pm to 02:45 pm CET"
              description="Coordination of feature development & concepts. For further information, please contact Martin Kanal or have a look into the downloadable ics file."
              contact="martin.kanal@doubleslash.de"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MTEyNTAyNTYtY2VkOC00ZDdjLTk0NTItNWViYTJmNmJmOTlh%40thread.v2/0?context=%7b%22Tid%22%3a%2226f86412-f875-4281-b566-fe6fe385e17c%22%2c%22Oid%22%3a%22db3ba521-7335-4e4f-b672-fc9f7c3f5536%22%7d"
@@ -48,7 +48,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 />
 
 <MeetingInfo title="Tractus-X community call"
-             schedule="Every Friday 1pm CET (UTC +1)"
+             schedule="Every Friday 1pm CET"
              description="Formerly known as the 'Office Hour', hosted by the System Team of the Catena-X Consortium, the Tractus-X is the open
 replacement meeting for everyone interested in general and overarching topics regarding Eclipse Tractus-X"
              contact="devsecops@catena-x.net"
@@ -57,7 +57,7 @@ replacement meeting for everyone interested in general and overarching topics re
 ## One-time meetings
 
 <MeetingInfo title="[C-X] Alignment & Open Planning Trace-X (Follow-up)"
-             schedule="Monday, 22. January 2024 from 03:30 pm to 04:00 pm CET (UTC +1)"
+             schedule="Monday, 22. January 2024 from 03:30 pm to 04:00 pm CET"
              description="Open Planning (follow up for Trace-X features), planned for release 24.05"
              contact="martin.kanal@doubleslash.de"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NTA2NTRhNjAtYzMyYi00OTBkLWIxYTUtM2FhNjgzOGU2ZjBk%40thread.v2/0?context=%7b%22Tid%22%3a%2226f86412-f875-4281-b566-fe6fe385e17c%22%2c%22Oid%22%3a%22db3ba521-7335-4e4f-b672-fc9f7c3f5536%22%7d"
@@ -65,7 +65,7 @@ replacement meeting for everyone interested in general and overarching topics re
 />
 
 <MeetingInfo title="Tractus-X Open Planning R24.05"
-             schedule="Wednesday, 17. January 2024, 9.30 pm until 16.30 pm CET (UTC +1)"
+             schedule="Wednesday, 17. January 2024, 9.30 pm until 16.30 pm CET"
              description="Open Planning, hosted by the Network Service Committee of the Catena-X association. The goal for this meeting is the planning of the features for the next Tractus-X release"
              contact="stephan.bauer@catena-x.net"
 />

--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -24,7 +24,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 />
 
 <MeetingInfo title="Committer - Office Hour"
-             schedule="Tthe third Friday of every month effective 16. Feb 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm CET (UTC +1)"
+             schedule="The third Friday of every month effective 16. Feb 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm CET (UTC +1)"
              description="Open hour meeting for all committers. The goal of the meeting is to discuss and share specific committer tasks/responsibilities."
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTItNWE1MmMzMWUzNmYw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"

--- a/static/meetings/committer-office-hour.ics
+++ b/static/meetings/committer-office-hour.ics
@@ -1,0 +1,71 @@
+BEGIN:VCALENDAR
+METHOD:PUBLISH
+PRODID:Microsoft Exchange Server 2010
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:tzone://Microsoft/Utc
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+ORGANIZER;CN=Stephan Bauer:mailto:stephan.bauer@catena-x.net
+DESCRIPTION:Open hour meeting for all committers. The goal of the meeting i
+ s to discuss and share specific committer tasks/responsibilities.\n\n\n\n_
+ __________________________________________________________________________
+ _____\nMicrosoft Teams meeting\nJoin on your computer\, mobile app or room
+  device\nClick here to join the meeting<https://teams.microsoft.com/l/meet
+ up-join/19%3ameeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTItNWE1MmMzMWUzNmYw%40th
+ read.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%2
+ 2%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d>\nMeeting ID
+ : 332 054 435 962\nPasscode: bDwMjb\nDownload Teams<https://www.microsoft.
+ com/en-us/microsoft-teams/download-app> | Join on the web<https://www.micr
+ osoft.com/microsoft-teams/join-a-meeting>\nLearn More<https://aka.ms/JoinT
+ eamsMeeting> | Meeting options<https://teams.microsoft.com/meetingOptions/
+ ?organizerId=a8b7a5ee-66ff-4695-afa2-08f893d8aaf6&tenantId=1ad22c6d-2f08-4
+ f05-a0ba-e17f6ce88380&threadId=19_meeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTIt
+ NWE1MmMzMWUzNmYw@thread.v2&messageId=0&language=en-GB>\n__________________
+ ______________________________________________________________\n
+RRULE:FREQ=MONTHLY;UNTIL=20241230T230000Z;INTERVAL=1;BYDAY=3FR
+UID:040000008200E00074C5B7101A82E0080000000051BBCDCF435BDA01000000000000000
+ 010000000F334FB7EDA04724AA775688B06788E20
+SUMMARY:Committer - Office Hour
+DTSTART:20240216T130500Z
+DTEND:20240216T140000Z
+CLASS:PUBLIC
+PRIORITY:5
+DTSTAMP:20240209T103620Z
+TRANSP:OPAQUE
+STATUS:CONFIRMED
+LOCATION:Microsoft Teams Meeting
+X-MICROSOFT-CDO-BUSYSTATUS:BUSY
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+X-MICROSOFT-CDO-ALLDAYEVENT:FALSE
+X-MICROSOFT-CDO-IMPORTANCE:1
+X-MICROSOFT-CDO-INSTTYPE:1
+X-MICROSOFT-SKYPETEAMSMEETINGURL:https://teams.microsoft.com/l/meetup-join/
+ 19%3ameeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTItNWE1MmMzMWUzNmYw%40thread.v2/
+ 0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22O
+ id%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d
+X-MICROSOFT-SKYPETEAMSPROPERTIES:{"cid":"19:meeting_ZjlmNTc5MjMtN2Y2YS00Yjl
+ iLTg3NTItNWE1MmMzMWUzNmYw@thread.v2"\,"rid":0\,"mid":0\,"uid":null\,"priva
+ te":true\,"type":0\,"ct":null\,"btid":null}
+X-MICROSOFT-ONLINEMEETINGINFORMATION:{"OnlineMeetingChannelId":null\,"Onlin
+ eMeetingProvider":3}
+X-MICROSOFT-DONOTFORWARDMEETING:FALSE
+X-MICROSOFT-DISALLOW-COUNTER:FALSE
+X-MICROSOFT-LOCATIONDISPLAYNAME:Microsoft Teams Meeting
+BEGIN:VALARM
+DESCRIPTION:REMINDER
+TRIGGER;RELATED=START:-PT15M
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/static/meetings/newjoiner-office-hour.ics
+++ b/static/meetings/newjoiner-office-hour.ics
@@ -1,0 +1,72 @@
+BEGIN:VCALENDAR
+METHOD:PUBLISH
+PRODID:Microsoft Exchange Server 2010
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:tzone://Microsoft/Utc
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+ORGANIZER;CN=Stephan Bauer:mailto:stephan.bauer@catena-x.net
+DESCRIPTION:Open hour meeting for all new joiner. The goal of the meeting i
+ s to provide an easy entry on all topics. The meeting will only take place
+  if specific questions have been submitted.\n\n\n\n_______________________
+ _________________________________________________________\nMicrosoft Teams
+  meeting\nJoin on your computer\, mobile app or room device\nClick here to
+  join the meeting<https://teams.microsoft.com/l/meetup-join/19%3ameeting_Z
+ jAzYzVjZGEtZjEwNC00NDI5LWEwODEtN2RhNmI0NDEzNTI2%40thread.v2/0?context=%7b%
+ 22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b
+ 7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d>\nMeeting ID: 367 675 055 002\nPas
+ scode: EBDt6W\nDownload Teams<https://www.microsoft.com/en-us/microsoft-te
+ ams/download-app> | Join on the web<https://www.microsoft.com/microsoft-te
+ ams/join-a-meeting>\nLearn More<https://aka.ms/JoinTeamsMeeting> | Meeting
+  options<https://teams.microsoft.com/meetingOptions/?organizerId=a8b7a5ee-
+ 66ff-4695-afa2-08f893d8aaf6&tenantId=1ad22c6d-2f08-4f05-a0ba-e17f6ce88380&
+ threadId=19_meeting_ZjAzYzVjZGEtZjEwNC00NDI5LWEwODEtN2RhNmI0NDEzNTI2@threa
+ d.v2&messageId=0&language=en-GB>\n________________________________________
+ ________________________________________\n
+RRULE:FREQ=MONTHLY;UNTIL=20241230T230000Z;INTERVAL=1;BYDAY=2FR
+UID:040000008200E00074C5B7101A82E00800000000C9B82E063B5BDA01000000000000000
+ 010000000B9AF638BBA08F84CA9941F2C0756EE85
+SUMMARY:NewJoiner - Office Hour
+DTSTART:20240308T130500Z
+DTEND:20240308T140000Z
+CLASS:PUBLIC
+PRIORITY:5
+DTSTAMP:20240209T093325Z
+TRANSP:OPAQUE
+STATUS:CONFIRMED
+LOCATION:Microsoft Teams Meeting
+X-MICROSOFT-CDO-BUSYSTATUS:BUSY
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+X-MICROSOFT-CDO-ALLDAYEVENT:FALSE
+X-MICROSOFT-CDO-IMPORTANCE:1
+X-MICROSOFT-CDO-INSTTYPE:1
+X-MICROSOFT-SKYPETEAMSMEETINGURL:https://teams.microsoft.com/l/meetup-join/
+ 19%3ameeting_ZjAzYzVjZGEtZjEwNC00NDI5LWEwODEtN2RhNmI0NDEzNTI2%40thread.v2/
+ 0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22O
+ id%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d
+X-MICROSOFT-SKYPETEAMSPROPERTIES:{"cid":"19:meeting_ZjAzYzVjZGEtZjEwNC00NDI
+ 5LWEwODEtN2RhNmI0NDEzNTI2@thread.v2"\,"rid":0\,"mid":0\,"uid":null\,"priva
+ te":true\,"type":0\,"ct":null\,"btid":null}
+X-MICROSOFT-ONLINEMEETINGINFORMATION:{"OnlineMeetingChannelId":null\,"Onlin
+ eMeetingProvider":3}
+X-MICROSOFT-DONOTFORWARDMEETING:FALSE
+X-MICROSOFT-DISALLOW-COUNTER:FALSE
+X-MICROSOFT-LOCATIONDISPLAYNAME:Microsoft Teams Meeting
+BEGIN:VALARM
+DESCRIPTION:REMINDER
+TRIGGER;RELATED=START:-PT15M
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/static/meetings/office-hour.ics
+++ b/static/meetings/office-hour.ics
@@ -1,0 +1,84 @@
+BEGIN:VCALENDAR
+METHOD:PUBLISH
+PRODID:Microsoft Exchange Server 2010
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:tzone://Microsoft/Utc
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+ORGANIZER;CN=Stephan Bauer:mailto:stephan.bauer@catena-x.net
+DESCRIPTION:Weekly Office Hours from the DevSecOps Team.\n\n\n\nImportant:\
+ n\nThis session will be recorded and the result is available for the commu
+ nity in our CoP-Channel:\n\nCX-CoP DevSecOps<https://bcgcatenax.sharepoint
+ .com/:f:/s/CommunitiesofPractises/EkMga9rBDCNCgWn-PU4fipcBv2fnSL9lx5Yw4TFU
+ v1TUwg?e=b3vFiQ>\n\n\n\nHere you can find our agenda and feel free to add 
+ questions on the board:\n\nhttps://miro.com/app/board/uXjVOEDsHAI=/?invite
+ _link_id=963489014015\n\n\n\nNormally we start with an update from our tea
+ m\, then you have the possibility to ask questions and we can also solve y
+ our problems in this session directly.\n\nPlease notice: This is a hands-o
+ n-meeting!\n\n\n\nPlease use also our CoP-Channel to ask questions outside
+  this session:\n\nhttps://teams.microsoft.com/l/channel/19%3a9a3c4a05a3514
+ d07b973c13e7b468709%40thread.tacv2/CX%2520-%2520CoP%2520DevSecOps?groupId=
+ 17b1a2dc-67fb-4a49-a2ed-dd1344321439&tenantId=1ad22c6d-2f08-4f05-a0ba-e17f
+ 6ce88380\n\n\n\nMore information and how-to about our support or onboardin
+ g questions\, please take a look here:\n\nhttps://catenax-ng.github.io/\n\
+ n\n\n_____________________________________________________________________
+ ___________\nMicrosoft Teams meeting\nJoin on your computer\, mobile app o
+ r room device\nClick here to join the meeting<https://teams.microsoft.com/
+ l/meetup-join/19%3ameeting_MDFiNDJjMmQtNjFkYi00ODdjLTk2NDgtZGMwNTRmYzg3NzM
+ 0%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce8
+ 8380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d>\nMeet
+ ing ID: 364 910 945 155\nPasscode: GTG3zh\nDownload Teams<https://www.micr
+ osoft.com/en-us/microsoft-teams/download-app> | Join on the web<https://ww
+ w.microsoft.com/microsoft-teams/join-a-meeting>\nLearn More<https://aka.ms
+ /JoinTeamsMeeting> | Meeting options<https://teams.microsoft.com/meetingOp
+ tions/?organizerId=a8b7a5ee-66ff-4695-afa2-08f893d8aaf6&tenantId=1ad22c6d-
+ 2f08-4f05-a0ba-e17f6ce88380&threadId=19_meeting_MDFiNDJjMmQtNjFkYi00ODdjLT
+ k2NDgtZGMwNTRmYzg3NzM0@thread.v2&messageId=0&language=en-GB>\n____________
+ ____________________________________________________________________\n
+RRULE:FREQ=WEEKLY;UNTIL=20241230T230000Z;INTERVAL=1;BYDAY=FR;WKST=SU
+UID:040000008200E00074C5B7101A82E0080000000052FE40363C5BDA01000000000000000
+ 01000000031FBD9BB3BC2134D8FCF18D8B0284581
+SUMMARY:Office Hour
+DTSTART:20240216T120500Z
+DTEND:20240216T130000Z
+CLASS:PUBLIC
+PRIORITY:5
+DTSTAMP:20240209T094154Z
+TRANSP:OPAQUE
+STATUS:CONFIRMED
+LOCATION:Microsoft Teams Meeting
+X-MICROSOFT-CDO-BUSYSTATUS:BUSY
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+X-MICROSOFT-CDO-ALLDAYEVENT:FALSE
+X-MICROSOFT-CDO-IMPORTANCE:1
+X-MICROSOFT-CDO-INSTTYPE:1
+X-MICROSOFT-SKYPETEAMSMEETINGURL:https://teams.microsoft.com/l/meetup-join/
+ 19%3ameeting_MDFiNDJjMmQtNjFkYi00ODdjLTk2NDgtZGMwNTRmYzg3NzM0%40thread.v2/
+ 0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22O
+ id%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d
+X-MICROSOFT-SKYPETEAMSPROPERTIES:{"cid":"19:meeting_MDFiNDJjMmQtNjFkYi00ODd
+ jLTk2NDgtZGMwNTRmYzg3NzM0@thread.v2"\,"rid":0\,"mid":0\,"uid":null\,"priva
+ te":true\,"type":0\,"ct":null\,"btid":null}
+X-MICROSOFT-ONLINEMEETINGINFORMATION:{"OnlineMeetingChannelId":null\,"Onlin
+ eMeetingProvider":3}
+X-MICROSOFT-DONOTFORWARDMEETING:FALSE
+X-MICROSOFT-DISALLOW-COUNTER:FALSE
+X-MICROSOFT-LOCATIONDISPLAYNAME:Microsoft Teams Meeting
+BEGIN:VALARM
+DESCRIPTION:REMINDER
+TRIGGER;RELATED=START:-PT15M
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/static/meetings/security-office-hour.ics
+++ b/static/meetings/security-office-hour.ics
@@ -1,0 +1,73 @@
+BEGIN:VCALENDAR
+METHOD:PUBLISH
+PRODID:Microsoft Exchange Server 2010
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:tzone://Microsoft/Utc
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+ORGANIZER;CN=Stephan Bauer:mailto:stephan.bauer@catena-x.net
+DESCRIPTION:Open hour meeting\, hosted by the sig-security team of the cate
+ na-x association. The goal of the meeting is to follow-up on security inci
+ dents\, request review and assignments\, and progress through security too
+ ls and procedures.\n\n\n\n________________________________________________
+ ________________________________\nMicrosoft Teams meeting\nJoin on your co
+ mputer\, mobile app or room device\nClick here to join the meeting<https:/
+ /teams.microsoft.com/l/meetup-join/19%3ameeting_MzYzMzVhODMtYWQyOC00NWVlLW
+ EyMjMtNjVlZmY2NTlkNTdk%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f
+ 08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f8
+ 93d8aaf6%22%7d>\nMeeting ID: 315 482 131 546\nPasscode: 6uueMF\nDownload T
+ eams<https://www.microsoft.com/en-us/microsoft-teams/download-app> | Join 
+ on the web<https://www.microsoft.com/microsoft-teams/join-a-meeting>\nLear
+ n More<https://aka.ms/JoinTeamsMeeting> | Meeting options<https://teams.mi
+ crosoft.com/meetingOptions/?organizerId=a8b7a5ee-66ff-4695-afa2-08f893d8aa
+ f6&tenantId=1ad22c6d-2f08-4f05-a0ba-e17f6ce88380&threadId=19_meeting_MzYzM
+ zVhODMtYWQyOC00NWVlLWEyMjMtNjVlZmY2NTlkNTdk@thread.v2&messageId=0&language
+ =en-GB>\n_________________________________________________________________
+ _______________\n
+RRULE:FREQ=WEEKLY;UNTIL=20241230T230000Z;INTERVAL=2;BYDAY=TH;WKST=SU
+UID:040000008200E00074C5B7101A82E008000000006E992617395BDA01000000000000000
+ 01000000035F1C31BB4F030428E4B03DF703261C9
+SUMMARY:Security - Office Hour
+DTSTART:20240215T073500Z
+DTEND:20240215T083000Z
+CLASS:PUBLIC
+PRIORITY:5
+DTSTAMP:20240209T091945Z
+TRANSP:OPAQUE
+STATUS:CONFIRMED
+LOCATION:Microsoft Teams Meeting
+X-MICROSOFT-CDO-BUSYSTATUS:BUSY
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+X-MICROSOFT-CDO-ALLDAYEVENT:FALSE
+X-MICROSOFT-CDO-IMPORTANCE:1
+X-MICROSOFT-CDO-INSTTYPE:1
+X-MICROSOFT-SKYPETEAMSMEETINGURL:https://teams.microsoft.com/l/meetup-join/
+ 19%3ameeting_MzYzMzVhODMtYWQyOC00NWVlLWEyMjMtNjVlZmY2NTlkNTdk%40thread.v2/
+ 0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22O
+ id%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d
+X-MICROSOFT-SKYPETEAMSPROPERTIES:{"cid":"19:meeting_MzYzMzVhODMtYWQyOC00NWV
+ lLWEyMjMtNjVlZmY2NTlkNTdk@thread.v2"\,"rid":0\,"mid":0\,"uid":null\,"priva
+ te":true\,"type":0\,"ct":null\,"btid":null}
+X-MICROSOFT-ONLINEMEETINGINFORMATION:{"OnlineMeetingChannelId":null\,"Onlin
+ eMeetingProvider":3}
+X-MICROSOFT-DONOTFORWARDMEETING:FALSE
+X-MICROSOFT-DISALLOW-COUNTER:FALSE
+X-MICROSOFT-LOCATIONDISPLAYNAME:Microsoft Teams Meeting
+BEGIN:VALARM
+DESCRIPTION:REMINDER
+TRIGGER;RELATED=START:-PT15M
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+END:VCALENDAR


### PR DESCRIPTION
## Description

This PR adds four new meetings to our [open meetings](https://eclipse-tractusx.github.io/community/open-meetings) page.

<img width="989" alt="image" src="https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/946e234e-1945-4f2a-8afc-409170cfbcc6">

All the four meetings are created in the same way. They provide a session link and downloadable ICS file for the calendar.
Everybody can bypass the lobby and the recording doesn't start automaticity.

**You are welcome to comment and suggest changes if needed. We are a little bit limited in formating the description :) but we can add more information to the ics file**

_Initially, the plan for the committer hours was every first and third Friday, but that's not possible to select :(_

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
