### PR TITLE
fix: Syntax of a broken link

### DIFF
--- a/docs/tutorials/e2e/inform/onboardingMaterial.md
+++ b/docs/tutorials/e2e/inform/onboardingMaterial.md
@@ -61,7 +61,7 @@ Setting up all technical components is only the first step towards active partic
 
 :::note
 
-The data integration pattern guide gives an overview over the tasks and challenges associated with backend integration: <<https://catena-x.net/fileadmin/user_upload/04_Einfuehren_und_umsetzen/Onboarding/DataIntegrationPatterns_Guide_V1.1.pdf>>
+The data integration pattern guide gives an overview over the tasks and challenges associated with backend integration: <https://catena-x.net/fileadmin/user_upload/04_Einfuehren_und_umsetzen/Onboarding/DataIntegrationPatterns_Guide_V1.1.pdf>
 
 :::
 


### PR DESCRIPTION
## Description
Fixes that a link was surrounded by double `<<` and `>>`, which resulted in a broken link when rendered. 
Attribution goes to `sovity GmbH` (already covered) even though coming from a private fork.

![image](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/22075788/89fb6fa2-693e-4efe-a6ce-ab59b6139893)
