### PR TITLE
feat: enable markdown linter for kits

### DIFF
--- a/.github/workflows/lint-on-pull-request.yaml
+++ b/.github/workflows/lint-on-pull-request.yaml
@@ -41,5 +41,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run markdown lint
+      - name: Run markdown lint for docs folder
         run: npm run lint-doc
+
+      - name: Run markdown lint for docs-kits folder
+        run: npm run lint-kits

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ We do want to follow a specific style for our markdown based documentation.
 Therefore, this repository is configured to use a [markdown linter](https://github.com/DavidAnson/markdownlint-cli2).
 Specific rules are configured via [.markdownlint.yaml](./.markdownlint.yaml).
 
-Additionally, there is a npm script `lint-doc`, that will lint all the markdown files inside [docs](./docs).
+Additionally, there is a npm script `lint-doc`, that will lint all the markdown files inside [docs](./docs) and `lint-kits`, that will lint all the markdown files inside [docs-kits](./docs-kits).
 This script is also run as a pre-commit hook, set up via [husky](https://www.npmjs.com/package/husky).
-You can also run the linting step manually by running `npm run lint-doc`.
+You can also run the linting step manually by running `npm run lint-doc` or `npm run lint-kits`.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "lint-doc": "markdownlint-cli2-config .markdownlint.yaml \"docs/**/*.md\" \"#node_modules\"",
+    "lint-kits": "markdownlint-cli2-config .markdownlint.yaml \"docs-kits/**/*.md\" \"#node_modules\"",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
This PR enables the markdown linter for the KITs.

Fixes #673 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
