### PR TITLE
doc(open meetings): change of the committer meeting rotation

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -24,7 +24,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 />
 
 <MeetingInfo title="Committer Meeting"
-             schedule="Every third Friday of the month effective 16. Feb 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm CET"
+             schedule="Eevery 2 weeks on Friday effective 16. Feb 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm CET"
              description="Open hour meeting for Eclipse Tractus-X committers. The goal of the meeting is to discuss and share specific committer tasks/responsibilities."
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTItNWE1MmMzMWUzNmYw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"

--- a/static/meetings/committer-office-hour.ics
+++ b/static/meetings/committer-office-hour.ics
@@ -17,31 +17,31 @@ END:DAYLIGHT
 END:VTIMEZONE
 BEGIN:VEVENT
 ORGANIZER;CN=Stephan Bauer:mailto:stephan.bauer@catena-x.net
-DESCRIPTION:Open hour meeting for all committers. The goal of the meeting i
- s to discuss and share specific committer tasks/responsibilities.\n\n\n\n_
- __________________________________________________________________________
- _____\nMicrosoft Teams meeting\nJoin on your computer\, mobile app or room
-  device\nClick here to join the meeting<https://teams.microsoft.com/l/meet
- up-join/19%3ameeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTItNWE1MmMzMWUzNmYw%40th
- read.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%2
- 2%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d>\nMeeting ID
- : 332 054 435 962\nPasscode: bDwMjb\nDownload Teams<https://www.microsoft.
- com/en-us/microsoft-teams/download-app> | Join on the web<https://www.micr
- osoft.com/microsoft-teams/join-a-meeting>\nLearn More<https://aka.ms/JoinT
- eamsMeeting> | Meeting options<https://teams.microsoft.com/meetingOptions/
- ?organizerId=a8b7a5ee-66ff-4695-afa2-08f893d8aaf6&tenantId=1ad22c6d-2f08-4
- f05-a0ba-e17f6ce88380&threadId=19_meeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTIt
- NWE1MmMzMWUzNmYw@thread.v2&messageId=0&language=en-GB>\n__________________
- ______________________________________________________________\n
-RRULE:FREQ=MONTHLY;UNTIL=20241230T230000Z;INTERVAL=1;BYDAY=3FR
+DESCRIPTION:Open hour meeting for Eclipse Tractus-X committers. The goal of
+  the meeting is to discuss and share specific committer tasks/responsibili
+ ties.\n\n_________________________________________________________________
+ _______________\nMicrosoft Teams meeting\nJoin on your computer\, mobile a
+ pp or room device\nClick here to join the meeting<https://teams.microsoft.
+ com/l/meetup-join/19%3ameeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTItNWE1MmMzMWU
+ zNmYw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f
+ 6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d>\n
+ Meeting ID: 332 054 435 962\nPasscode: bDwMjb\nDownload Teams<https://www.
+ microsoft.com/en-us/microsoft-teams/download-app> | Join on the web<https:
+ //www.microsoft.com/microsoft-teams/join-a-meeting>\nLearn More<https://ak
+ a.ms/JoinTeamsMeeting> | Meeting options<https://teams.microsoft.com/meeti
+ ngOptions/?organizerId=a8b7a5ee-66ff-4695-afa2-08f893d8aaf6&tenantId=1ad22
+ c6d-2f08-4f05-a0ba-e17f6ce88380&threadId=19_meeting_ZjlmNTc5MjMtN2Y2YS00Yj
+ liLTg3NTItNWE1MmMzMWUzNmYw@thread.v2&messageId=0&language=en-GB>\n________
+ ________________________________________________________________________\n
+RRULE:FREQ=WEEKLY;UNTIL=20241230T230000Z;INTERVAL=2;BYDAY=FR;WKST=MO
 UID:040000008200E00074C5B7101A82E0080000000051BBCDCF435BDA01000000000000000
  010000000F334FB7EDA04724AA775688B06788E20
-SUMMARY:Committer - Office Hour
+SUMMARY:Committer Meeting
 DTSTART:20240216T130500Z
 DTEND:20240216T140000Z
 CLASS:PUBLIC
 PRIORITY:5
-DTSTAMP:20240209T103620Z
+DTSTAMP:20240216T131141Z
 TRANSP:OPAQUE
 STATUS:CONFIRMED
 LOCATION:Microsoft Teams Meeting


### PR DESCRIPTION
## Description

This PR changes the committer meeting rotation from every third Friday to every two weeks.

<img width="980" alt="image" src="https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/07dada08-1dcb-47c5-a66b-ea28c0757e50">

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
