### PR TITLE
doc(open planning): add new entry for open planning release 24.08

### DIFF
--- a/blog/2024-04-10-open-planning-r24.08.mdx
+++ b/blog/2024-04-10-open-planning-r24.08.mdx
@@ -1,0 +1,65 @@
+---
+title: Tractus-X Open Planning R24.08
+description: The Eclipse Tractus-X Open Planning Days - Empowering the Catena-X Data Space
+slug: open-planning-r24-08
+date: 2024-02-19T11:00
+hide_table_of_contents: false
+authors:
+  - name: Stephan Bauer
+    title: Platform Domain Manager
+    url: https://github.com/stephanbcbauer
+    image_url: https://github.com/stephanbcbauer.png
+    email: stephan.bauer@catena-x.net
+---
+
+![eclipse tractus x logo](@site/static/img/Tractus-X_openplanning.png)
+
+Dear Tractus-X Community Members 🎉,
+ 
+we are excited to extend this invitation to you for our upcoming Tractus-X meetings. These meetings are a great opportunity for both business stakeholders and developers to contribute and collaborate on the future of Tractus-X.
+Please feel free to forward this post to anyone interested in contributing, whether in planning or development.
+ 
+**Agenda:**
+
+- **Tractus-X Open Planning R24.08**
+  - Date: 10th April and 11th April 2024
+  - Time: 08:00 - 12:00
+  - Please see the [Open Meetings page](https://eclipse-tractusx.github.io/community/open-meetings) for downloadable ICS dile and session link
+
+<!--truncate-->
+
+:::info
+
+Will be published as soon as possible.
+
+:::
+
+
+
+## Staying Informed
+ 
+To stay updated on any changes or additional information, please subscribe to our mailing list. A great way to keep informed is through the provided [Tractus-X Development Mailing List RSS Feed](https://www.eclipse.org/lists/tractusx-dev/maillist.rss).
+
+:::tip
+
+Here, you can also find previous messages for reference.
+
+:::
+ 
+## Further Information
+ 
+For more details about the planning process and what these meetings entail, please refer to our guide on [Open Refinement and Planning in Open Source Communities](https://github.com/eclipse-tractusx/sig-release/blob/main/docs/open-refinement-and-planning.md)
+ and of course the sig-release [README](https://github.com/eclipse-tractusx/sig-release/blob/main/README.md)
+
+## Stay Connected
+
+Follow our [news section](https://eclipse-tractusx.github.io/blog) and join our [Tractus-X mailing list](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute/#dev-mailinglist)
+and be part of our [Matrix Chat from Eclipse Tractus-X](https://chat.eclipse.org/#/room/#tools.tractus-x:matrix.eclipse.org) 
+
+For more details about Tractus-X, visit the official [Eclipse Tractus-X Project Page](https://projects.eclipse.org/projects/automotive.tractusx).
+
+---
+
+We look forward to your participation and contributions in shaping the future of Tractus-X.
+
+🚀 **The Tractus-X Team**

--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -47,27 +47,14 @@ These are dedicated sync meetings for specific products, as well as open plannin
              meetingLink="/meetings/coordination-feature-development-trace-x.ics"
 />
 
-<MeetingInfo title="Tractus-X community call"
-             schedule="Every Friday 1pm CET"
-             description="Formerly known as the 'Office Hour', hosted by the System Team of the Catena-X Consortium, the Tractus-X is the open
-replacement meeting for everyone interested in general and overarching topics regarding Eclipse Tractus-X"
-             contact="devsecops@catena-x.net"
-/>
-
 ## One-time meetings
 
-<MeetingInfo title="[C-X] Alignment & Open Planning Trace-X (Follow-up)"
-             schedule="Monday, 22. January 2024 from 03:30 pm to 04:00 pm CET"
-             description="Open Planning (follow up for Trace-X features), planned for release 24.05"
-             contact="martin.kanal@doubleslash.de"
-             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NTA2NTRhNjAtYzMyYi00OTBkLWIxYTUtM2FhNjgzOGU2ZjBk%40thread.v2/0?context=%7b%22Tid%22%3a%2226f86412-f875-4281-b566-fe6fe385e17c%22%2c%22Oid%22%3a%22db3ba521-7335-4e4f-b672-fc9f7c3f5536%22%7d"
-             meetingLink="/meetings/alignment-and-planning-trace-x.ics"
-/>
-
-<MeetingInfo title="Tractus-X Open Planning R24.05"
-             schedule="Wednesday, 17. January 2024, 9.30 pm until 16.30 pm CET"
-             description="Open Planning, hosted by the Network Service Committee of the Catena-X association. The goal for this meeting is the planning of the features for the next Tractus-X release"
+<MeetingInfo title="Tractus-X Open Planning R24.08"
+             schedule="Occurs on Wednesday 10. Apr 2024 and Thursday 10. Apr 2024 from 08:00 am to 12:00 am CET"
+             description="Open Planning, hosted by the Network Service Committee of the Catena-X association. The goal for this meeting is the planning of the features for the next Tractus-X release. More information (also an agenda), can be found [here](https://eclipse-tractusx.github.io/blog/open-planning-r24-08)"
              contact="stephan.bauer@catena-x.net"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NzlmMTQzMjktMmQ4YS00ODAxLWIwMjktZmZmZmZiOGY2ZDYy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
+             meetingLink="/meetings/open-planning-r2408.ics"
 />
 
 

--- a/static/meetings/open-planning-r2408.ics
+++ b/static/meetings/open-planning-r2408.ics
@@ -1,0 +1,74 @@
+BEGIN:VCALENDAR
+METHOD:PUBLISH
+PRODID:Microsoft Exchange Server 2010
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:tzone://Microsoft/Utc
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+ORGANIZER;CN=Stephan Bauer:mailto:stephan.bauer@catena-x.net
+DESCRIPTION:Hello Tractus-X Community\,\n\nwe want to plan the release 24.0
+ 8 together with you and hereby invite you to the Open Planning.\nYou can f
+ ind the agenda and further information under the following link<https://ec
+ lipse-tractusx.github.io/blog/open-planning-r24-08>.\n\nBest regards\n\n__
+ __________________________________________________________________________
+ ____\nMicrosoft Teams Benötigen Sie Hilfe?<https://aka.ms/JoinTeamsMeetin
+ g?omkt=de-DE>\nJetzt an der Besprechung teilnehmen<https://teams.microsoft
+ .com/l/meetup-join/19%3ameeting_NzlmMTQzMjktMmQ4YS00ODAxLWIwMjktZmZmZmZiOG
+ Y2ZDYy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17
+ f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d>\
+ nBesprechungs-ID: 322 884 704 332\nKennung: vv9zsC\n______________________
+ __________\nEinwählen per Telefon\nFür Organisatoren: Besprechungsoption
+ en<https://teams.microsoft.com/meetingOptions/?organizerId=a8b7a5ee-66ff-4
+ 695-afa2-08f893d8aaf6&tenantId=1ad22c6d-2f08-4f05-a0ba-e17f6ce88380&thread
+ Id=19_meeting_NzlmMTQzMjktMmQ4YS00ODAxLWIwMjktZmZmZmZiOGY2ZDYy@thread.v2&m
+ essageId=0&language=de-DE> | Einwahl-PIN zurücksetzen<https://dialin.team
+ s.microsoft.com/usp/pstnconferencing>\n___________________________________
+ _____________________________________________\n
+RRULE:FREQ=WEEKLY;UNTIL=20240413T220000Z;INTERVAL=1;BYDAY=WE,TH;WKST=MO
+UID:040000008200E00074C5B7101A82E0080000000002D4B9B91863DA01000000000000000
+ 010000000E19998C151F27A428E4D6D5E99149FC8
+SUMMARY:Tractus-X Open Planning R24.08
+DTSTART:20240410T060000Z
+DTEND:20240410T100000Z
+CLASS:PUBLIC
+PRIORITY:5
+DTSTAMP:20240219T094804Z
+TRANSP:OPAQUE
+STATUS:CONFIRMED
+LOCATION:Microsoft Teams Meeting
+X-MICROSOFT-CDO-BUSYSTATUS:BUSY
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+X-MICROSOFT-CDO-ALLDAYEVENT:FALSE
+X-MICROSOFT-CDO-IMPORTANCE:1
+X-MICROSOFT-CDO-INSTTYPE:1
+X-MICROSOFT-SKYPETEAMSMEETINGURL:https://teams.microsoft.com/l/meetup-join/
+ 19%3ameeting_NzlmMTQzMjktMmQ4YS00ODAxLWIwMjktZmZmZmZiOGY2ZDYy%40thread.v2/
+ 0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22O
+ id%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d
+X-MICROSOFT-SKYPETEAMSPROPERTIES:{"cid":"19:meeting_NzlmMTQzMjktMmQ4YS00ODA
+ xLWIwMjktZmZmZmZiOGY2ZDYy@thread.v2"\,"rid":0\,"mid":0\,"uid":null\,"priva
+ te":true\,"type":0}
+X-MICROSOFT-ONLINEMEETINGEXTERNALLINK:
+X-MICROSOFT-ONLINEMEETINGINFORMATION:{"OnlineMeetingChannelId":null\,"Onlin
+ eMeetingProvider":3}
+X-MICROSOFT-DONOTFORWARDMEETING:FALSE
+X-MICROSOFT-DISALLOW-COUNTER:FALSE
+X-MICROSOFT-LOCATIONDISPLAYNAME:Microsoft Teams Meeting
+BEGIN:VALARM
+DESCRIPTION:REMINDER
+TRIGGER;RELATED=START:-PT15M
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/utils/newsTitles.js
+++ b/utils/newsTitles.js
@@ -1,5 +1,10 @@
 export const newsTitles = [
   {
+    date: "19.02.2024",
+    title: "Tractus-X Open Planning R24.08",
+    blogLink: "/blog/open-planning-r24-08"
+  },
+  {
     date: "11.12.2023",
     title: "Open Source Planning for Tractus-X release 24.05",
     blogLink: "/blog/open-planning-days-pi12"


### PR DESCRIPTION
## Description

This PR is the preparation for the next open planning r24.08. It provides some information, like:

- new open meeting entry (ics file and session link)
- news blog entry (agenda is not publishes yet)

![image](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/1e309709-2433-470b-929c-cbd33cdf93c4)

![image](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/b386b406-8148-4e70-ba47-6f7f05d2ee8e)

![image](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/d0926ab1-993c-40ec-b67c-76a1aeb06eda)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
