### PR TITLE
feat(open meetings): add functionality to add additional links

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -41,10 +41,15 @@ These are dedicated sync meetings for specific products, as well as open plannin
 
 <MeetingInfo title="Security - Office Hour"
              schedule="Every 2 weeks on Thursday effective 15. Feb 2024 until 31. Dec 2024 from 08:35 am to 09:30 am CET"
-             description="Open hour meeting, hosted by the [sig-security](https://github.com/eclipse-tractusx/sig-security?tab=readme-ov-file#readme) team. The goal of the meeting is to follow-up on security incidents, request review and assignments, and progress through security tools and procedures."
+             description="Open hour meeting, hosted by the sig-security team. The goal of the meeting is to follow-up on security incidents, request review and assignments, and progress through security tools and procedures."
              contact="rohan.krishnamurthy@zf.com"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MzYzMzVhODMtYWQyOC00NWVlLWEyMjMtNjVlZmY2NTlkNTdk%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
              meetingLink="/meetings/security-office-hour.ics"
+             additionalLinks={
+                [
+                    {title: 'sig-security', url: 'https://github.com/eclipse-tractusx/sig-security?tab=readme-ov-file#readme'},
+                ]
+            }
 />
 
 <MeetingInfo title="[TRACE-X] Trace-X Open Meeting"

--- a/src/components/OpenMeetings/MeetingInfo.jsx
+++ b/src/components/OpenMeetings/MeetingInfo.jsx
@@ -9,24 +9,16 @@
  * https://www.apache.org/licenses/LICENSE-2.0.
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
  * under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-import React from "react";
+import React from 'react';
 
-export default function MeetingInfo({
-  title,
-  schedule,
-  description,
-  contact,
-  sessionLink = undefined,
-  meetingLink = undefined,
-  additionalLinks = [],
-}) {
+export default function MeetingInfo({title, schedule, description, contact, sessionLink = undefined, meetingLink = undefined, additionalLinks = []}) {
   return (
     <section style={meetingInfo}>
       <div style={meetingOverview}>
@@ -75,48 +67,48 @@ export default function MeetingInfo({
 }
 
 const itemLink = {
-  fontWeight: "400",
-  fontSize: "14px",
-  lineHeight: "18px",
-  color: "#faa023",
+  fontWeight: '400',
+  fontSize: '14px',
+  lineHeight: '18px',
+  color: '#faa023',
   listStyleImage: 'url("/img/product_link_bullet.png")',
 };
 
 const itemTitle = {
-  fontWeight: "400",
-  fontSize: "14px",
-  lineHeight: "18px",
-  listStyle: "none",
+  fontWeight: '400',
+  fontSize: '14px',
+  lineHeight: '18px',
+  listStyle: 'none',
 };
 
 const meetingInfo = {
-  display: "flex",
-  width: "100%",
-  padding: "1rem 0 0.5rem",
+  display: 'flex',
+  width: '100%',
+  padding: '1rem 0 0.5rem',
 };
 
 const meetingOverview = {
-  width: "33%",
-  margin: "auto 0",
-  padding: "2rem 0 0.5rem",
-  borderRight: "2px solid #faa023",
+  width: '33%',
+  margin: 'auto 0',
+  padding: '2rem 0 0.5rem',
+  borderRight: '2px solid #faa023',
 };
 
 const meetingTitle = {
-  fontWeight: "700",
-  fontSize: "20px",
-  lineHeight: "25px",
+  fontWeight: '700',
+  fontSize: '20px',
+  lineHeight: '25px',
 };
 
 const meetingSchedule = {
-  fontWeight: "400",
-  fontSize: "12px",
-  lineHeight: "16px",
-  color: "#a5a5a5",
+  fontWeight: '400',
+  fontSize: '12px',
+  lineHeight: '16px',
+  color: '#a5a5a5',
 };
 
 const meetingDetails = {
-  width: "67%",
-  margin: "auto 0",
-  padding: "0.5rem 1.5rem",
+  width: '67%',
+  margin: 'auto 0',
+  padding: '0.5rem 1.5rem',
 };

--- a/src/components/OpenMeetings/MeetingInfo.jsx
+++ b/src/components/OpenMeetings/MeetingInfo.jsx
@@ -9,7 +9,7 @@
  * https://www.apache.org/licenses/LICENSE-2.0.
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
  * under the License.
@@ -19,48 +19,48 @@
 import React from 'react';
 
 export default function MeetingInfo({title, schedule, description, contact, sessionLink = undefined, meetingLink = undefined, additionalLinks = []}) {
-  return (
-    <section style={meetingInfo}>
-      <div style={meetingOverview}>
-        <h2 style={meetingTitle}>{title}</h2>
-        <div style={meetingSchedule}>{schedule}</div>
-      </div>
-      <div style={meetingDetails}>
-        <p>{description}</p>
+    return (
+        <section style={meetingInfo}>
+            <div style={meetingOverview}>
+                <h2 style={meetingTitle}>{title}</h2>
+                <div style={meetingSchedule}>{schedule}</div>
+            </div>
+            <div style={meetingDetails}>
+                <p>{description}</p>
 
-        <ul>
-          <li style={itemTitle}>Contact:</li>
-          <li style={itemLink}>
-            <a href={"mailto:" + contact}>{contact}</a>
-          </li>
-        </ul>
+                <ul>
+                    <li style={itemTitle}>Contact:</li>
+                    <li style={itemLink}>
+                        <a href={"mailto:" + contact}>{contact}</a>
+                    </li>
+                </ul>
 
-        <ul>
-          <li style={itemTitle}>Participation opportunities:</li>
-          {sessionLink && (
-            <li style={itemLink}>
-              <a href={sessionLink}>Join Meeting</a>
-            </li>
-          )}
-          {meetingLink && (
-            <li style={itemLink}>
-              <a href={meetingLink}>Download calendar file</a>
-            </li>
-          )}
-        </ul>
-        {additionalLinks.length > 0 && (
-          <ul>
-            <li style={itemTitle}>Additional links:</li>
-            {additionalLinks.map((link, index) => {
-                const { url, title } = link;
-                return (
-                  <li key={`${index}${url}`} style={itemLink}>
-                    <a href={url}>{title}</a>
-                  </li>
-                );
-              })}
-          </ul>
-        )}
+                <ul>
+                    <li style={itemTitle}>Participation opportunities:</li>
+                        {sessionLink && (
+                            <li style={itemLink}>
+                                <a href={sessionLink}>Join Meeting</a>
+                            </li>
+                        )}
+                        {meetingLink && (
+                            <li style={itemLink}>
+                                <a href={meetingLink}>Download calendar file</a>
+                            </li>
+                        )}
+                </ul>
+                {additionalLinks.length > 0 && (
+                <ul>
+                    <li style={itemTitle}>Additional links:</li>
+                    {additionalLinks.map((link, index) => {
+                        const { url, title } = link;
+                        return (
+                            <li key={`${index}${url}`} style={itemLink}>
+                                <a href={url}>{title}</a>
+                            </li>
+                        );
+                    })}
+                </ul>
+                )}
       </div>
     </section>
   );

--- a/src/components/OpenMeetings/MeetingInfo.jsx
+++ b/src/components/OpenMeetings/MeetingInfo.jsx
@@ -16,88 +16,107 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-import React from 'react';
+import React from "react";
 
-export default function MeetingInfo({title, schedule, description, contact, sessionLink = undefined, meetingLink = undefined}) {
-    return (
-        <section style={meetingInfo}>
-            <div style={meetingOverview}>
-                <h2 style={meetingTitle}>{title}</h2>
-                <div style={meetingSchedule}>{schedule}</div>
-            </div>
-            <div style={meetingDetails}>
-                <p>{description}</p>
-                
-                <ul>
-                    <li style={itemTitle}>Contact:</li>
-                    <li style={itemLink}>
-                        <a href={"mailto:" + contact}>{contact}</a>
-                    </li>
-                </ul>
+export default function MeetingInfo({
+  title,
+  schedule,
+  description,
+  contact,
+  sessionLink = undefined,
+  meetingLink = undefined,
+  additionalLinks = [],
+}) {
+  return (
+    <section style={meetingInfo}>
+      <div style={meetingOverview}>
+        <h2 style={meetingTitle}>{title}</h2>
+        <div style={meetingSchedule}>{schedule}</div>
+      </div>
+      <div style={meetingDetails}>
+        <p>{description}</p>
 
-                <ul>
-                    <li style={itemTitle}>Participation opportunities:</li>
-                    { 
-                        sessionLink && 
-                            <li style={itemLink}>
-                                <a href={sessionLink}>Join Meeting</a>
-                            </li> 
-                    }
-                    { 
-                        meetingLink &&
-                            <li style={itemLink}>
-                                <a href={meetingLink}>Download calendar file</a>
-                            </li>
-                    }
-                </ul>
-            </div>
-        </section>
-    );
+        <ul>
+          <li style={itemTitle}>Contact:</li>
+          <li style={itemLink}>
+            <a href={"mailto:" + contact}>{contact}</a>
+          </li>
+        </ul>
+
+        <ul>
+          <li style={itemTitle}>Participation opportunities:</li>
+          {sessionLink && (
+            <li style={itemLink}>
+              <a href={sessionLink}>Join Meeting</a>
+            </li>
+          )}
+          {meetingLink && (
+            <li style={itemLink}>
+              <a href={meetingLink}>Download calendar file</a>
+            </li>
+          )}
+        </ul>
+        {additionalLinks.length > 0 && (
+          <ul>
+            <li style={itemTitle}>Additional links:</li>
+            {additionalLinks.map((link, index) => {
+                const { url, title } = link;
+                return (
+                  <li key={`${index}${url}`} style={itemLink}>
+                    <a href={url}>{title}</a>
+                  </li>
+                );
+              })}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
 }
 
 const itemLink = {
-    fontWeight: '400',
-    fontSize: '14px',
-    lineHeight: '18px',
-    color: '#faa023',
-    listStyleImage: 'url("/img/product_link_bullet.png")'
-}
+  fontWeight: "400",
+  fontSize: "14px",
+  lineHeight: "18px",
+  color: "#faa023",
+  listStyleImage: 'url("/img/product_link_bullet.png")',
+};
 
 const itemTitle = {
-    fontWeight: '400',
-    fontSize: '14px',
-    lineHeight: '18px',
-    listStyle: 'none'
-  }
+  fontWeight: "400",
+  fontSize: "14px",
+  lineHeight: "18px",
+  listStyle: "none",
+};
 
 const meetingInfo = {
-    display: 'flex',
-    width: '100%',
-    padding: '1rem 0 0.5rem'
-}
+  display: "flex",
+  width: "100%",
+  padding: "1rem 0 0.5rem",
+};
 
 const meetingOverview = {
-    width: '33%',
-    margin: 'auto 0',
-    padding: '2rem 0 0.5rem',
-    borderRight: '2px solid #faa023'
-}
+  width: "33%",
+  margin: "auto 0",
+  padding: "2rem 0 0.5rem",
+  borderRight: "2px solid #faa023",
+};
 
 const meetingTitle = {
-    fontWeight: '700',
-    fontSize: '20px',
-    lineHeight: '25px'
-}
+  fontWeight: "700",
+  fontSize: "20px",
+  lineHeight: "25px",
+};
 
 const meetingSchedule = {
-    fontWeight: '400',
-    fontSize: '12px',
-    lineHeight: '16px',
-    color: '#a5a5a5'
-}
+  fontWeight: "400",
+  fontSize: "12px",
+  lineHeight: "16px",
+  color: "#a5a5a5",
+};
 
 const meetingDetails = {
-    width: '67%',
-    margin: 'auto 0',
-    padding: '0.5rem 1.5rem'
-}
+  width: "67%",
+  margin: "auto 0",
+  padding: "0.5rem 1.5rem",
+};

--- a/src/components/OpenMeetings/MeetingInfo.jsx
+++ b/src/components/OpenMeetings/MeetingInfo.jsx
@@ -67,48 +67,48 @@ export default function MeetingInfo({title, schedule, description, contact, sess
 }
 
 const itemLink = {
-  fontWeight: '400',
-  fontSize: '14px',
-  lineHeight: '18px',
-  color: '#faa023',
-  listStyleImage: 'url("/img/product_link_bullet.png")',
-};
+    fontWeight: '400',
+    fontSize: '14px',
+    lineHeight: '18px',
+    color: '#faa023',
+    listStyleImage: 'url("/img/product_link_bullet.png")',
+}
 
 const itemTitle = {
-  fontWeight: '400',
-  fontSize: '14px',
-  lineHeight: '18px',
-  listStyle: 'none',
-};
+    fontWeight: '400',
+    fontSize: '14px',
+    lineHeight: '18px',
+    listStyle: 'none',
+}
 
 const meetingInfo = {
-  display: 'flex',
-  width: '100%',
-  padding: '1rem 0 0.5rem',
-};
+    display: 'flex',
+    width: '100%',
+    padding: '1rem 0 0.5rem',
+}
 
 const meetingOverview = {
-  width: '33%',
-  margin: 'auto 0',
-  padding: '2rem 0 0.5rem',
-  borderRight: '2px solid #faa023',
-};
+    width: '33%',
+    margin: 'auto 0',
+    padding: '2rem 0 0.5rem',
+    borderRight: '2px solid #faa023',
+}
 
 const meetingTitle = {
-  fontWeight: '700',
-  fontSize: '20px',
-  lineHeight: '25px',
-};
+    fontWeight: '700',
+    fontSize: '20px',
+    lineHeight: '25px',
+}
 
 const meetingSchedule = {
-  fontWeight: '400',
-  fontSize: '12px',
-  lineHeight: '16px',
-  color: '#a5a5a5',
-};
+    fontWeight: '400',
+    fontSize: '12px',
+    lineHeight: '16px',
+    color: '#a5a5a5',
+}
 
 const meetingDetails = {
-  width: '67%',
-  margin: 'auto 0',
-  padding: '0.5rem 1.5rem',
-};
+    width: '67%',
+    margin: 'auto 0',
+    padding: '0.5rem 1.5rem',
+}


### PR DESCRIPTION
## Description

This PR adds the functionality to open meetings to publish also additional links, cause it is not possible in the description

e.g.

![image](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/31960da9-9ea4-4953-9f92-8e7751739435)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
