### PR TITLE
fix(operator): update repo urls in the operator page

### DIFF
--- a/utils/coreOnboardingServices.js
+++ b/utils/coreOnboardingServices.js
@@ -5,8 +5,7 @@ export const coreOnboardingServices = [
     productDescription: "The core services for querying, adding, and changing business partner data in the Catena-X data space and the unique company identifier.",
     githubRepo: [
       "https://github.com/eclipse-tractusx/bpdm",
-      "https://github.com/daps-helm-chart",
-      "https://github.com/dft-frontend",
+      "https://github.com/eclipse-tractusx/bpdm-certificate-management",
       "https://github.com/bpdm"
     ],
     committers: [],
@@ -19,10 +18,13 @@ export const coreOnboardingServices = [
     subTitle: "",
     productDescription: "The entry point to the Catena-X data space for all participants such as registration or onboarding. Access to the Catena-X Marketplace and more.",
     githubRepo: [
-      "https://github.com/eclipse-tractusx/bpdm",
-      "https://github.com/eclipse-tractusx/daps-helm-chart",
-      "https://github.com/eclipse-tractusx/dft-frontend",
-      "https://github.com/eclipse-tractusx/bpdm"
+      "https://github.com/eclipse-tractusx/portal-frontend",
+      "https://github.com/eclipse-tractusx/portal-backend",
+      "https://github.com/eclipse-tractusx/portal-frontend-registration",
+      "https://github.com/eclipse-tractusx/portal-assets",
+      "https://github.com/eclipse-tractusx/portal-shared-components",
+      "https://github.com/eclipse-tractusx/portal-shared-components",
+      "https://github.com/eclipse-tractusx/portal-cd"
     ],
     committers: [],
     mailTo: "",
@@ -34,10 +36,8 @@ export const coreOnboardingServices = [
     subTitle: "",
     productDescription: "The Discovery Finder is used to find endpoints of BPN Discoveries for a specific type, e.g. 'oen'",
     githubRepo: [
-      "https://github.com/eclipse-tractusx/bpdm",
-      "https://github.com/eclipse-tractusx/daps-helm-chart",
-      "https://github.com/eclipse-tractusx/dft-frontend",
-      "https://github.com/eclipse-tractusx/bpdm"
+      "https://github.com/eclipse-tractusx/sldt-semantic-models",
+      "https://github.com/eclipse-tractusx/sldt-semantic-hub"
     ],
     committers: [],
     mailTo: "",
@@ -49,10 +49,7 @@ export const coreOnboardingServices = [
     subTitle: "",
     productDescription: "The Discovery Finder is used to find endpoints of BPN Discoveries for a specific type, e.g. 'oen'",
     githubRepo: [
-      "https://github.com/eclipse-tractusx/bpdm",
-      "https://github.com/eclipse-tractusx/daps-helm-chart",
-      "https://github.com/eclipse-tractusx/dft-frontend",
-      "https://github.com/eclipse-tractusx/bpdm"
+      "https://github.com/eclipse-tractusx/sldt-discovery-finder"
     ],
     committers: [],
     mailTo: "",
@@ -64,10 +61,7 @@ export const coreOnboardingServices = [
     subTitle: "",
     productDescription: "The BPN Discovery is used to search for a specific type/key-combination for a Business Partner Number (BPN).",
     githubRepo: [
-      "https://github.com/eclipse-tractusx/bpdm",
-      "https://github.com/eclipse-tractusx/daps-helm-chart",
-      "https://github.com/eclipse-tractusx/dft-frontend",
-      "https://github.com/eclipse-tractusx/bpdm"
+      "https://github.com/eclipse-tractusx/sldt-bpn-discovery"
     ],
     committers: [],
     mailTo: "",


### PR DESCRIPTION
## Description

operator page core and onboarding service section has wrong repo urls in the respective sections

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
