### PR TITLE
docs: restructure and update TRG 5.01 and 5.05

### DIFF
--- a/docs/release/trg-5/trg-5-01.md
+++ b/docs/release/trg-5/trg-5-01.md
@@ -19,7 +19,7 @@ All Eclipse Tractus-X components **must** be installable via Helm and meet follo
 chart **has to meet** all of these criteria!
 
 - Helm chart **must be released**.
-- Appropriate versioning stratetgy must be used for `version` and `appVersion` in the `Chart.yaml` file
+- Appropriate versioning strategy must be used for `version` and `appVersion` in the `Chart.yaml` file
 - The released Helm chart **must not** contain any environment specific `values-xyz.yaml` files
 - Helm chart **must be** configurable via the `values.yaml` file by using proper default values/placeholders. See more details [here](../trg-5/trg-5-05).
 - Default values file must not contain references to any secret engine services (e.g.: Hashicorp Vault)

--- a/docs/release/trg-5/trg-5-01.md
+++ b/docs/release/trg-5/trg-5-01.md
@@ -2,9 +2,10 @@
 title: TRG 5.01 - Helm Chart requirements
 ---
 
- | Status | Created     | Post-History    |
-|--------|-------------|-----------------|
-| Active | 10-Nov-2022 | Initial release |
+| Status | Created     | Post-History                |
+| ------ | ----------- | --------------------------- |
+| Update | 29-Feb-2024 | restructuring and rewording |
+| Active | 10-Nov-2022 | Initial release             |
 
 ## Why
 
@@ -18,18 +19,14 @@ All Eclipse Tractus-X components **must** be installable via Helm and meet follo
 chart **has to meet** all of these criteria!
 
 - Helm chart **must be released**.
-- Appropriate versioning for `version` and `appVersion` has to be used in `Chart.yaml`
+- Appropriate versioning stratetgy must be used for `version` and `appVersion` in the `Chart.yaml` file
 - The released Helm chart **must not** contain any environment specific `values-xyz.yaml` files
-- Helm chart `values.yaml` file **must** contain proper default values/placeholders
-  - No hostname provided for ingress
-  - Ingress is disabled
-  - No references to any secret engine service (e.g.: Hashicorp Vault)
-  - Dependencies should be prefixed with the `nameOverride` and/or `fullnameOverride` properties
-  - Image tag is set to the **Chart.yaml** `appVersion` property
+- Helm chart **must be** configurable via the `values.yaml` file by using proper default values/placeholders. See more details [here](../trg-5/trg-5-05).
+- Default values file must not contain references to any secret engine services (e.g.: Hashicorp Vault)
 - Helm chart **must be deployable to any environment without overwriting default values** with a simple `helm install`
   command
 - If there is an **Ingress** resource present, it can be turned off, and it is disabled by default
-- Helm dependencies have to be declared in `Chart.yaml` file
+- Helm Chart dependencies have to be declared in the `Chart.yaml` file
 
 ### Released Helm Charts
 
@@ -53,6 +50,7 @@ change outside the Helm chart, e.g. container image tags (-> don't use container
 The `values.yaml` file is essential for Helm charts. The file **must** contain all values the chart is expecting and
 there **must** be no other values files except of `values.yaml` file. Released Helm charts **must** contain
 only `values.yaml` file.
+More rules and best practices for the file can be found [here](../trg-5/trg-5-05).
 
 ### Dependencies
 

--- a/docs/release/trg-5/trg-5-05.md
+++ b/docs/release/trg-5/trg-5-05.md
@@ -2,9 +2,10 @@
 title: TRG 5.05 - Chart Values
 ---
 
-| Status | Created      | Post-History    |
-|--------|--------------|-----------------|
-| Active | 10-Nov-2022  | Initial release |
+| Status | Created     | Post-History           |
+| ------ | ----------- | ---------------------- |
+| Update | 29-Feb-2024 | new examples and rules |
+| Active | 10-Nov-2022 | Initial release        |
 
 ## Why
 
@@ -12,9 +13,14 @@ When external entities need to setup a whole Eclipse Tractus-X setup, they might
 
 ## Description
 
-Best practices for Helm chart `values.yaml` file.
+Rules and best practices for Helm chart `values.yaml` file.
 
 ## Container images
+
+- Image tag **must** not be set by default, instead it should use the
+  `appVersion` property from the `Chart.yaml` file
+- `pullPolicy` **must** default to 'IfNotPresent'. If image tag is 'latest' it
+  should be changed to 'Always'
 
 A proper section for Container images **should** look like this:
 
@@ -22,12 +28,8 @@ A proper section for Container images **should** look like this:
 image:
   registry: docker.io
   repository: bitnami/postgresql
-  tag: 14.5.0-debian-11-r19
+  tag: ""
   digest: ""
-  ## Specify an imagePullPolicy
-  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-  ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-  ##
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -36,7 +38,7 @@ image:
   ## pullSecrets:
   ##   - myRegistryKeySecretName
   ##
-  pullSecrets: [ ]
+  pullSecrets: []
   ## Set to true if you would like to see extra information on logs
   ##
 ```
@@ -47,3 +49,55 @@ This might cause unexpected effects, as the Helm release could change without bu
 security reasons you shall not use `latest` tag.
 
 :::
+
+## Ingress
+
+- Ingress **must** be disabled by default
+- Hostname **must** not be set by default
+
+An example section for ingress resources:
+
+```yaml
+ingress:
+  enabled: false
+  # className: "nginx"
+  ## Optional annotations when using the nginx ingress class
+  #annotations:
+  #  nginx.ingress.kubernetes.io/rewrite-target: "/$1"
+  #  nginx.ingress.kubernetes.io/use-regex: "true"
+  #  nginx.ingress.kubernetes.io/enable-cors: "true"
+  #  nginx.ingress.kubernetes.io/cors-allow-origin: "https://*.example.org"
+  tls:
+    - secretName: ""
+      hosts:
+        - ""
+  hosts:
+    - host: ""
+      paths:
+        - path: "/(.*)"
+          pathType: "Prefix"
+          backend:
+            service: "app"
+            port: 8080
+```
+
+## Dependencies
+
+An example section for Postgresql dependency configuration:
+
+```yaml
+postgresql:
+  ## PostgreSQL chart configuration
+  enabled: true
+  ## Dependencies should be prefixed with the `nameOverride` and/or `fullnameOverride` properties
+  nameOverride: "app-postgresql"
+  auth:
+    ## Database name
+    database: "appdb"
+    ## Database port number
+    port: 5432
+    ## Secret containing the passwords
+    existingSecret: "secret-postgres-init"
+    ## Password for the root username 'postgres'. Secret-key 'postgres-password'
+    password: ""
+```

--- a/docs/release/trg-5/trg-5-05.md
+++ b/docs/release/trg-5/trg-5-05.md
@@ -17,7 +17,7 @@ Rules and best practices for Helm chart `values.yaml` file.
 
 ## Container images
 
-- Image tag **must** not be set by default, instead it should use the
+- Image tag **must not** be set by default, instead it should use the
   `appVersion` property from the `Chart.yaml` file
 - `pullPolicy` **must** default to 'IfNotPresent'
 

--- a/docs/release/trg-5/trg-5-05.md
+++ b/docs/release/trg-5/trg-5-05.md
@@ -19,8 +19,7 @@ Rules and best practices for Helm chart `values.yaml` file.
 
 - Image tag **must** not be set by default, instead it should use the
   `appVersion` property from the `Chart.yaml` file
-- `pullPolicy` **must** default to 'IfNotPresent'. If image tag is 'latest' it
-  should be changed to 'Always'
+- `pullPolicy` **must** default to 'IfNotPresent'
 
 A proper section for Container images **should** look like this:
 
@@ -46,7 +45,7 @@ image:
 :::caution do not use `latest` as image tag!
 
 This might cause unexpected effects, as the Helm release could change without bumping the chart version! Also due to
-security reasons you shall not use `latest` tag.
+security reasons you shall not use `latest` tag. If the image tag should be set to a pinned tag (e.g.: `latest`) anyway, it should done in an additional (environment specific) values.yaml and in this case the image's **pullPolicy** is recommended to be set to `Always`.
 
 :::
 
@@ -89,7 +88,7 @@ An example section for Postgresql dependency configuration:
 postgresql:
   ## PostgreSQL chart configuration
   enabled: true
-  ## Dependencies should be prefixed with the `nameOverride` and/or `fullnameOverride` properties
+  ## Dependencies should be prefixed with the `nameOverride` property
   nameOverride: "app-postgresql"
   auth:
     ## Database name

--- a/docs/release/trg-5/trg-5-05.md
+++ b/docs/release/trg-5/trg-5-05.md
@@ -17,8 +17,10 @@ Rules and best practices for Helm chart `values.yaml` file.
 
 ## Container images
 
-- Image tag **must not** be set by default, instead it should use the
-  `appVersion` property from the `Chart.yaml` file
+- Image tag **should not** be set by default and it should fall back to the
+  `appVersion` property from the `Chart.yaml` file. In specific cases
+  (e.g.: Chart contains multiple pod templates that use different images and versions)
+  image tag can be set explicitly.
 - `pullPolicy` **must** default to 'IfNotPresent'
 
 A proper section for Container images **should** look like this:

--- a/docs/release/trg-5/trg-5-05.md
+++ b/docs/release/trg-5/trg-5-05.md
@@ -90,8 +90,9 @@ An example section for Postgresql dependency configuration:
 postgresql:
   ## PostgreSQL chart configuration
   enabled: true
-  ## Dependencies should be prefixed with the `nameOverride` property
-  nameOverride: "app-postgresql"
+  ## `nameOverride` should be used when the same chart is added as a dependency
+  ## multiple times to ensure resource names do not conflict with each other
+  # nameOverride: "app-postgresql"
   auth:
     ## Database name
     database: "appdb"

--- a/docs/release/trg-5/trg-5-05.md
+++ b/docs/release/trg-5/trg-5-05.md
@@ -73,7 +73,7 @@ ingress:
   hosts:
     - host: ""
       paths:
-        - path: "/(.*)"
+        - path: "/"
           pathType: "Prefix"
           backend:
             service: "app"


### PR DESCRIPTION
## Description

- Restructure **TRG501** and **TRG5.05**, most values file related info over
- Add examples and rules for chart values like ingress, dependencies, container

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
