### PR TITLE
feat(open meetings): add anchor to link to open meeting

### DIFF
--- a/src/components/OpenMeetings/MeetingInfo.jsx
+++ b/src/components/OpenMeetings/MeetingInfo.jsx
@@ -20,9 +20,12 @@ import React from 'react';
 
 export default function MeetingInfo({title, schedule, description, contact, sessionLink = undefined, meetingLink = undefined, additionalLinks = []}) {
     return (
-        <section style={meetingInfo}>
+        <section style={meetingInfo} id={title}>
             <div style={meetingOverview}>
-                <h2 style={meetingTitle}>{title}</h2>
+                <h2 className="anchor" style={meetingTitle}>
+                    {title}
+                    <a className="hash-link" href={`#${title}`} title="Direct link to open meeting"></a>
+                </h2>
                 <div style={meetingSchedule}>{schedule}</div>
             </div>
             <div style={meetingDetails}>


### PR DESCRIPTION
## Description

Currently, we can only link to the [open-meeting page](https://eclipse-tractusx.github.io/community/open-meetings) itself, but not to a specific meeting entry.

This PR adds the needed functionality to add id and anchor to each meeting.

<img width="1441" alt="image" src="https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/96883eb5-352f-4644-a6ce-b0f3fe3ba2e9">

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
