### PR TITLE
docs(open-meetings): add 02-29 security office hour minutes

### DIFF
--- a/blog-meeting-minutes/2024-02-29-security-hour.md
+++ b/blog-meeting-minutes/2024-02-29-security-hour.md
@@ -20,7 +20,7 @@ tags: [meeting-minutes, community, security]
 ### Open Discussions
 
 - An overarching issue for tracking the tool shifts was discussed, as it is necessary for proper planning by teams.
-  - Teams need to estimate efforts to adjust Github workflowss
+  - Teams need to estimate efforts to adjust Github workflows
 - The PR for the new Security TRG was discussed, which includes a new requirement of remediation of findings with medium severity, but not for the 25.05 release.
   - Concerns were raised about the need for additional planned team resources for triaging these issues, and it was suggested that the TRG should be finalized and teams made aware.
 - What are best-practices for scheduling security tools Action workflows, with every PR or another frequency?

--- a/blog-meeting-minutes/2024-02-29-security-hour.md
+++ b/blog-meeting-minutes/2024-02-29-security-hour.md
@@ -1,0 +1,30 @@
+---
+slug: security-office-hour-2024-02-29
+title: Security Office Hour 29.02.2024
+authors: 
+    - daniel_dilger
+tags: [meeting-minutes, community, security]
+---
+
+## Security Office Hour meeting minutes
+
+### Announcements
+
+- Security team approvals for most projects in scope of release 24.03 have been completed.
+- Upcoming changes for release 24.05 will focus on FOSS security tools, including
+  - switch from Veracode to CodeQL for SAST,
+  - gitleaks for secrets scanning,
+  - DAST will not be part of the upcoming TRG until further notice.
+- DAST was removed from TRG due to issues with authenticated scans and SARIF report as scanning alerts in repository security section.
+
+### Open Discussions
+
+- An overarching issue for tracking the tool shifts was discussed, as it is necessary for proper planning by teams.
+  - Teams need to estimate efforts to adjust Github workflowss
+- The PR for the new Security TRG was discussed, which includes a new requirement of remediation of findings with medium severity, but not for the 25.05 release.
+  - Concerns were raised about the need for additional planned team resources for triaging these issues, and it was suggested that the TRG should be finalized and teams made aware.
+- What are best-practices for scheduling security tools Action workflows, with every PR or another frequency?
+  - The TRG claims at least once, this is mandatory baseline for all.
+  - Best practice is more frequently, recommendations differ per tool (e.g. secret scanning for every PR, dependency scan on a weekly basis).
+  - The trigger will be on push + on pull + scheduled - frequency depends on repositories activity, so the team has to decide.
+  - Best practice recommendations will be published in the sig-security repository.

--- a/blog-meeting-minutes/2024-02-29-security-hour.md
+++ b/blog-meeting-minutes/2024-02-29-security-hour.md
@@ -13,7 +13,7 @@ tags: [meeting-minutes, community, security]
 - Security team approvals for most projects in scope of release 24.03 have been completed.
 - Upcoming changes for release 24.05 will focus on FOSS security tools, including
   - switch from Veracode to CodeQL for SAST,
-  - gitleaks for secrets scanning,
+  - switch from Gitguardian to gitleaks for secrets scanning,
   - DAST will not be part of the upcoming TRG until further notice.
 - DAST was removed from TRG due to issues with authenticated scans and SARIF report as scanning alerts in repository security section.
 

--- a/blog-meeting-minutes/authors.yaml
+++ b/blog-meeting-minutes/authors.yaml
@@ -25,3 +25,8 @@ tomasz_barwicki:
   name: Tomasz Barwicki
   title: Consortia System Team Member
   url: https://github.com/tomaszbarwicki
+
+daniel_dilger:
+  name: Daniel Dilger
+  title: Consortia Security Team Member
+  url: https://github.com/mm73628486283/


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Adding the security office hour meeting minutes for 2024-02-29.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
