### PR TITLE
fix: link to trg 7-08

### DIFF
--- a/docs/release/trg-7/trg-7-01.md
+++ b/docs/release/trg-7/trg-7-01.md
@@ -42,7 +42,7 @@ In Eclipse Tractus-X the primary outbound license is Apache-2.0.
 
 See the [Handbook#legaldoc-license](https://www.eclipse.org/projects/handbook/#legaldoc-license).
 
-For specifically defined documentation files the Creative Commons Attribution 4.0 International (CC BY 4.0) is required, see TRG 7.08.
+For specifically defined documentation files the Creative Commons Attribution 4.0 International (CC BY 4.0) is required, see [TRG 7.08](trg-7-08.md).
 
 ### NOTICE FILE
 
@@ -50,7 +50,7 @@ For specifically defined documentation files the Creative Commons Attribution 4.
 - Add the link(s) to your SBOM, e.g. the DEPENDENCY file (one or more)
 - Add information for third party content checks, if not covered by the Dash Tool (e.g. IP checks for icons, fonts, ...)
 
-[Further information](/docs/release/trg-7/trg-7-04#checking-other-content-fonts-images-) and see the [Handbook#legaldoc-notice](https://www.eclipse.org/projects/handbook/#legaldoc-notice).
+[Further information](trg-7-04.md#checking-other-content-fonts-images-) and see the [Handbook#legaldoc-notice](https://www.eclipse.org/projects/handbook/#legaldoc-notice).
 
 ### DEPENDENCY FILE
 
@@ -64,7 +64,7 @@ Third-party dependencies need to be checked regularly to reflect your code chang
 
 If different technologies / package managers (e.g. npm and maven) are used you are free to have several dependency files. Use the naming convention DEPENDENCY_XYZ, e.g. DEPENDENCY_FRONTEND and DEPENDENCY_BACKEND.
 
-[Further information](/docs/release/trg-7/trg-7-04)
+[Further information](trg-7-04.md)
 
 ### SECURITY FILE
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

- fix link within TRG 7-01 to 7.04 and 7.08

fixes https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/issues/722

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
