### PR TITLE
docs(open-meetings): add 03-14 security office hour minutes

### DIFF
--- a/blog-meeting-minutes/2024-03-14-security-hour.md
+++ b/blog-meeting-minutes/2024-03-14-security-hour.md
@@ -1,0 +1,22 @@
+---
+slug: security-office-hour-2024-03-14
+title: Security Office Hour 14.03.2024
+authors: 
+    - daniel_dilger
+tags: [meeting-minutes, community, security]
+---
+
+## Security Office Hour meeting minutes
+
+### Announcements
+
+- SAST: CodeQL transition is ongoing, PRs to add corresponding workflows is ongoing. Veracode license will expire at the end of March, so everyone is encouraged to review their workflows to ensure a timely transition to CodeQL.
+- DAST: Invicti license will expire at the end of August and already exceeded the website limit. There will be no DAST tool required for the next Quality Gate.
+- Secret scanning
+  - Gitguardian is currently set up, but Gitleaks is a potential successor.
+  - Testing of Github secret scanning is still in progress.
+- TRG 8.0 has been published as a draft, adjustments as PR are warmly welcome.
+
+### Open Discussions
+
+- none


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Adding the security office hour meeting minutes for 2024-03-14.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
