### PR TITLE
chore(trg-4.08): add draft for multi-platform builds

### DIFF
--- a/docs/release/trg-0/trg-4-08.md
+++ b/docs/release/trg-0/trg-4-08.md
@@ -1,0 +1,49 @@
+---
+title: TRG 4.08 - Multi-platform
+---
+
+| Status | Created     | Post-History                              |
+|--------|-------------|-------------------------------------------|
+| Draft  | 14-Mar-2024 | Initial contribution                      |
+
+## Why
+
+Providing container images that support multiple CPU architectures enhances flexibility, compatibility, and efficiency across hardware devices.
+
+This is especially beneficial for supporting use cases like tutorials and local playgrounds.
+
+## Description
+
+Container images **must** be built for **amd64 and arm64** CPU architectures.
+
+### Implementation
+
+Add and enhance the GitHub Workflow with the following steps:
+
+```yaml
+name: Build - Docker image (SemVer)
+
+...
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      ...
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+           context: .
+           platforms: linux/amd64, linux/arm64
+           ...
+      ...
+```

--- a/docs/release/trg-0/trg-4-08.md
+++ b/docs/release/trg-0/trg-4-08.md
@@ -1,10 +1,10 @@
 ---
-title: TRG 4.08 - Multi-platform
+title: TRG 4.08 - Multi-platform images
 ---
 
 | Status | Created     | Post-History                              |
 |--------|-------------|-------------------------------------------|
-| Draft  | 14-Mar-2024 | Initial contribution                      |
+| Draft  | 20-Mar-2024 | Initial contribution                      |
 
 ## Why
 
@@ -18,32 +18,4 @@ Container images **must** be built for **amd64 and arm64** CPU architectures.
 
 ### Implementation
 
-Add and enhance the GitHub Workflow with the following steps:
-
-```yaml
-name: Build - Docker image (SemVer)
-
-...
-
-jobs:
-  docker:
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-
-    steps:
-      ...
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-           context: .
-           platforms: linux/amd64, linux/arm64
-           ...
-      ...
-```
+The example workflow from [TRG 4.01](../trg-4/trg-4-01.md) contains the necessary steps for building a multi-platform image.

--- a/docs/release/trg-0/trg-4-08.md
+++ b/docs/release/trg-0/trg-4-08.md
@@ -18,4 +18,4 @@ Container images **must** be built for **amd64 and arm64** CPU architectures.
 
 ### Implementation
 
-The example workflow from [TRG 4.01](../trg-4/trg-4-01.md) contains the necessary steps for building a multi-platform image.
+Make sure to choose a base image, out of the list in [TRG 4.02](../trg-4/trg-4-02.md#aligned-base-images) which is built for amd64 and arm64 CPU architecture, (e.g. [eclipse-temurin/tags?page=1&name=21-jre-alpine](https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=21-jre-alpine)) and enable the image build workflow: the example workflow from [TRG 4.01](../trg-4/trg-4-01.md) contains the necessary steps for building a multi-platform image.

--- a/docs/release/trg-4/trg-4-01.md
+++ b/docs/release/trg-4/trg-4-01.md
@@ -79,8 +79,8 @@ on:
       - main
 
 env:
-   IMAGE_NAMESPACE: "tractusx"
-   IMAGE_NAME: "YourApplicationName"
+  IMAGE_NAMESPACE: "tractusx"
+  IMAGE_NAME: "YourApplicationName"
 
 jobs:
   docker:
@@ -92,48 +92,58 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # Needed to create multi-platfrom image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      # Needed to create multi-platfrom image
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       # Create SemVer or ref tags dependent of trigger event
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-           images: |
-              ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
-           # Automatically prepare image tags; See action docs for more examples. 
-           # semver patter will generate tags like these for example :1 :1.2 :1.2.3
-           tags: |
-              type=ref,event=branch
-              type=ref,event=pr
-              type=semver,pattern={{version}}
-              type=semver,pattern={{major}}
-              type=semver,pattern={{major}}.{{minor}}
+          images: |
+            ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          # Automatically prepare image tags; See action docs for more examples. 
+          # semver patter will generate tags like these for example :1 :1.2 :1.2.3
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: DockerHub login
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-           # Use existing DockerHub credentials present as secrets
-           username: ${{ secrets.DOCKER_HUB_USER }}
-           password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          # Use existing DockerHub credentials present as secrets
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
-           context: .
-           # Build image for verification purposes on every trigger event. Only push if event is not a PR
-           push: ${{ github.event_name != 'pull_request' }}
-           tags: ${{ steps.meta.outputs.tags }}
-           labels: ${{ steps.meta.outputs.labels }}
+          context: .
+          # Needed to create multi-platfrom image
+          platforms: linux/amd64, linux/arm64
+          # Build image for verification purposes on every trigger event. Only push if event is not a PR
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
-       # https://github.com/peter-evans/dockerhub-description
-       # Important step to push image description to DockerHub 
+      # https://github.com/peter-evans/dockerhub-description
+      # Important step to push image description to DockerHub 
       - name: Update Docker Hub description
         if: github.event_name != 'pull_request'
         uses: peter-evans/dockerhub-description@v3
         with:
-           # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'   
-           # readme-filepath: path/to/dedicated/notice-for-docker-image.md 
-           username: ${{ secrets.DOCKER_HUB_USER }}
-           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-           repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'   
+          # readme-filepath: path/to/dedicated/notice-for-docker-image.md 
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
 ```

--- a/docs/release/trg-4/trg-4-01.md
+++ b/docs/release/trg-4/trg-4-01.md
@@ -2,11 +2,12 @@
 title: TRG 4.01 - Image tagging
 ---
 
-| Status | Created     | Post-History                              |
-|--------|-------------|-------------------------------------------|
-| Active | 11-May-2023 | update example workflow to match TRG 4.05 |
-|        | 24-Nov-2022 | more precise process description          |
-|        | 10-Nov-2022 | Initial release                           |
+| Status | Created     | Post-History                                       |
+|--------|-------------|----------------------------------------------------|
+| Active | 20-Mar-2024 | update example workflow for TRG 4.08               |
+| Active | 11-May-2023 | update example workflow to match TRG 4.05          |
+|        | 24-Nov-2022 | more precise process description                   |
+|        | 10-Nov-2022 | Initial release                                    |
 
 ## Why
 

--- a/docs/release/trg-4/trg-4-01.md
+++ b/docs/release/trg-4/trg-4-01.md
@@ -97,10 +97,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      # Needed to create multi-platfrom image
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       # Create SemVer or ref tags dependent of trigger event
       - name: Docker meta
         id: meta

--- a/docs/release/trg-4/trg-4-01.md
+++ b/docs/release/trg-4/trg-4-01.md
@@ -93,7 +93,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Needed to create multi-platfrom image
+      # Needed to create multi-platform image
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -125,7 +125,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          # Needed to create multi-platfrom image
+          # Needed to create multi-platform image
           platforms: linux/amd64, linux/arm64
           # Build image for verification purposes on every trigger event. Only push if event is not a PR
           push: ${{ github.event_name != 'pull_request' }}

--- a/docs/release/trg-4/trg-4-05.md
+++ b/docs/release/trg-4/trg-4-05.md
@@ -4,7 +4,8 @@ title: TRG 4.05 - Container registries
 
 | Status | Created      | Post-History                                                            |
 |--------|--------------|-------------------------------------------------------------------------|
-| Draft  | 04-May-2023  | Place DockerHub as mandatory container registry; remove GHCR references |
+| Active | 20-Mar-2024  | Remove example workflow and refer to TRG 4.01                           |
+| Active | 04-May-2023  | Place DockerHub as mandatory container registry; remove GHCR references |
 | Active | 05-Jan-2023  | Initial release                                                         |
 | Draft  | 14-Sept-2022 | n/a                                                                     |
 

--- a/docs/release/trg-4/trg-4-05.md
+++ b/docs/release/trg-4/trg-4-05.md
@@ -20,85 +20,8 @@ All container images released for an Eclipse Tractus-X product **must** be prese
 Also be aware of the necessary remarks for container images described in [TRG 4-06](./trg-4-06.md) and alignment on common base images
 described in [TRG 4.02](./trg-4-02.md).
 
-## How
+## Implementation
 
-Following example shows a simple workflow, that can be used to publish your Docker image(s) to `DockerHub`.
+The example from [TRG 4.01](./trg-4-01.md) shows a simple workflow, that can be used to publish your Docker image(s) to `DockerHub`.
 It is using secrets, that contain credentials to authenticate at `DockerHub`. These secrets are present at GitHub organization
 level and can therefore be used in any repository in our org.
-
-```yaml
-# Reference from https://github.com/eclipse-tractusx/app-dashboard/blob/main/.github/workflows/build-image.yaml
-# You might want to check the source for recent updates
-name: Build - Docker image (SemVer)
-
-on:
-  push:
-    branches:
-      - main
-    # trigger events for SemVer like tags
-    tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
-  pull_request:
-    branches:
-      - main
-
-env:
-  IMAGE_NAMESPACE: "tractusx"
-  IMAGE_NAME: "app-dashboard"
-
-jobs:
-  docker:
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      # Create SemVer or ref tags dependent of trigger event
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
-          # Automatically prepare image tags; See action docs for more examples. 
-          # semver patter will generate tags like these for example :1 :1.2 :1.2.3
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}
-            type=semver,pattern={{major}}.{{minor}}
-
-      - name: DockerHub login
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
-        with:
-          # Use existing DockerHub credentials present as secrets
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          # Build image for verification purposes on every trigger event. Only push if event is not a PR
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      # https://github.com/peter-evans/dockerhub-description
-      # Important step to push image description to DockerHub 
-      - name: Update Docker Hub description
-        if: github.event_name != 'pull_request'
-        uses: peter-evans/dockerhub-description@v3
-        with:
-        # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'   
-        # readme-filepath: path/to/dedicated/notice-for-docker-image.md 
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
-```

--- a/docs/release/trg-4/trg-4-08.md
+++ b/docs/release/trg-4/trg-4-08.md
@@ -4,6 +4,7 @@ title: TRG 4.08 - Multi-platform images
 
 | Status | Created     | Post-History                              |
 |--------|-------------|-------------------------------------------|
+| Active | 01-Sep-2024 | Initial contribution                      |
 | Draft  | 20-Mar-2024 | Initial contribution                      |
 
 ## Why
@@ -19,3 +20,5 @@ Container images **must** be built for **amd64 and arm64** CPU architectures.
 ### Implementation
 
 Make sure to choose a base image, out of the list in [TRG 4.02](../trg-4/trg-4-02.md#aligned-base-images) which is built for amd64 and arm64 CPU architecture, (e.g. [eclipse-temurin/tags?page=1&name=21-jre-alpine](https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=21-jre-alpine)) and enable the image build workflow: the example workflow from [TRG 4.01](../trg-4/trg-4-01.md) contains the necessary steps for building a multi-platform image.
+
+Depending on the [multi platform strategies](https://docs.docker.com/build/building/multi-platform/#strategies) your base image supports, you might need additional enabling, for instance enabling the Dockerfile for cross-compilation or [setting up QEMU](https://github.com/docker/setup-qemu-action). Have a look to peer repositories within Tractus-X for inspiration.

--- a/docs/release/trg-4/trg-4-08.md
+++ b/docs/release/trg-4/trg-4-08.md
@@ -15,7 +15,7 @@ This is especially beneficial for supporting use cases like tutorials and local 
 
 ## Description
 
-Container images **must** be built for **amd64 and arm64** CPU architectures.
+Container images **should** be built for **amd64 and arm64** CPU architectures.
 
 ### Implementation
 

--- a/docs/release/trg-4/trg-4-08.md
+++ b/docs/release/trg-4/trg-4-08.md
@@ -13,6 +13,8 @@ Providing container images that support multiple CPU architectures enhances flex
 
 This is especially beneficial for supporting use cases like tutorials and local playgrounds.
 
+For instance, arm64 images are optimized for ARM-based processors, such as Apple's M1/M2/M3 chips and Amazon's Graviton processors, providing better performance and efficiency compared to emulated or non-native architectures.
+
 ## Description
 
 Container images **should** be built for **amd64 and arm64** CPU architectures.


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

- add TRG for multi-platform (amd64 and arm64) builds of container images

this is especially beneficial for supporting use cases like tutorials and local playgrounds

- also, consolidate to one example workflow for TRG-4 section

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
