### PR TITLE
fix(open meetings): cleanup open meetings

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1284,7 +1284,7 @@ npm/npmjs/@types/parse-json/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/@types/parse5/5.0.3, MIT, approved, clearlydefined
 npm/npmjs/@types/parse5/6.0.3, MIT, approved, clearlydefined
 npm/npmjs/@types/prop-types/15.7.5, MIT, approved, clearlydefined
-npm/npmjs/@types/qs/6.9.7, MIT, approved, clearlydefined
+npm/npmjs/@types/qs/6.9.7, MIT, approved, #13991
 npm/npmjs/@types/range-parser/1.2.4, MIT, approved, #10795
 npm/npmjs/@types/react-is/17.0.3, MIT, approved, #8424
 npm/npmjs/@types/react-redux/7.1.25, MIT, approved, #10970

--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -21,6 +21,12 @@ These are dedicated sync meetings for specific products, as well as open plannin
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MDFiNDJjMmQtNjFkYi00ODdjLTk2NDgtZGMwNTRmYzg3NzM0%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
              meetingLink="/meetings/office-hour.ics"
+             additionalLinks={
+                [
+                    {title: 'meeting minutes', url: 'https://eclipse-tractusx.github.io/community/meeting-minutes/tags/tractus-x-office-hour'},
+                ]
+             }
+             
 />
 
 <MeetingInfo title="NewJoiner - Office Hour"
@@ -47,6 +53,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
              meetingLink="/meetings/security-office-hour.ics"
              additionalLinks={
                 [
+                    {title: 'meeting minutes', url: 'https://eclipse-tractusx.github.io/community/meeting-minutes/tags/security'},
                     {title: 'sig-security', url: 'https://github.com/eclipse-tractusx/sig-security?tab=readme-ov-file#readme'},
                 ]
              }
@@ -69,16 +76,8 @@ These are dedicated sync meetings for specific products, as well as open plannin
 
 ## One-time meetings
 
-<MeetingInfo title="OSP Feature Demo"
-             schedule="Monday, 26. February 2024 from 11:00 am to 12:00 am CET"
-             description="Feature demonstration of the Onboarding Service Provider (OSP) functionality. The goal for this meeting is to demonstrate the purpose and current state and flow of registering a partner as an Onboarding Service Providers. OSPs enable data providers/consumers to be integrated into the Catena-X network. This includes organizational and technical integration."
-             contact="julia.jeroch@bmw.de"
-             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_OGQ1MDdjYWMtYWQyOS00ZmM0LWFjYzUtZmZiMGFmYTA3MmVm%40thread.v2/0?context=%7b%22Tid%22%3a%22ce849bab-cc1c-465b-b62e-18f07c9ac198%22%2c%22Oid%22%3a%222c9ec8f6-66c3-40ce-b042-e5ef75528cef%22%7d"
-             meetingLink="/meetings/osp-feature-demo.ics"
-/>
-
 <MeetingInfo title="Tractus-X Open Planning R24.08"
-             schedule="Occurs on Wednesday 10. Apr 2024 and Thursday 10. Apr 2024 from 08:00 am to 12:00 am CET"
+             schedule="Occurs on Wednesday 10. Apr 2024 and Thursday 11. Apr 2024 from 08:00 am to 12:00 am CET"
              description="Open Planning, hosted by the Network Service Committee of the Catena-X association. The goal for this meeting is planning of the intended work content for the next program increment - which contains also preparation of future release content, refactoring, general architectural work, tool & process improvements and feature planning for the next Tractus-X release. More information (also an agenda) can be found under the Additional Links."
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NzlmMTQzMjktMmQ4YS00ODAxLWIwMjktZmZmZmZiOGY2ZDYy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
@@ -89,5 +88,3 @@ These are dedicated sync meetings for specific products, as well as open plannin
                 ]
              }
 />
-
-


### PR DESCRIPTION
## Description

This PR fixes a date issue for the open meeting `Tractus-X Open Planning R24.08`. It also cleans up the [Onetime](https://eclipse-tractusx.github.io/community/open-meetings#one-time-meetings) because old meetings should be deleted. Additionally it adds the links for the meeting minutes.

<img width="995" alt="image" src="https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/f3581df5-8be7-454a-a0ad-1fb448282eee">

<img width="958" alt="image" src="https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/3d8a0ba9-c4b8-4560-bbc8-4e4a52381694">



## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
