### PR TITLE
Thursday 10th April --> Thursday 11th April

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -78,7 +78,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 />
 
 <MeetingInfo title="Tractus-X Open Planning R24.08"
-             schedule="Occurs on Wednesday 10. Apr 2024 and Thursday 10. Apr 2024 from 08:00 am to 12:00 am CET"
+             schedule="Occurs on Wednesday 10. Apr 2024 and Thursday 11. Apr 2024 from 08:00 am to 12:00 am CET"
              description="Open Planning, hosted by the Network Service Committee of the Catena-X association. The goal for this meeting is planning of the intended work content for the next program increment - which contains also preparation of future release content, refactoring, general architectural work, tool & process improvements and feature planning for the next Tractus-X release. More information (also an agenda) can be found under the Additional Links."
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NzlmMTQzMjktMmQ4YS00ODAxLWIwMjktZmZmZmZiOGY2ZDYy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"


### PR DESCRIPTION
Date for the Tractus-X OpenPlanning was set incorrectly.
Fixed this. 