### PR TITLE
docs: add security office hour meeting minutes 2024-03-28

### DIFF
--- a/blog-meeting-minutes/2024-03-28-security-hour.md
+++ b/blog-meeting-minutes/2024-03-28-security-hour.md
@@ -15,6 +15,3 @@ tags: [meeting-minutes, community, security]
   -	CodeQL - Onboarding- Workflow Setup: [TRG 8.01](https://eclipse-tractusx.github.io/docs/release/trg-0/trg-8-01)
 -	DAST security scans are not part of the next release 24.05 (Updates will follow through the QG Acceptance Criteria)
 -	KICS, Trivy, GitGuardian and Dependabot tools will continue as it is.
-
-### Open Discussions
-- Cofinity-X Security contact for incident reporting - Security@cofinity-x.com

--- a/blog-meeting-minutes/2024-03-28-security-hour.md
+++ b/blog-meeting-minutes/2024-03-28-security-hour.md
@@ -1,0 +1,20 @@
+---
+slug: security-office-hour-2024-03-28
+title: Security Office Hour 28.03.2024
+authors: 
+    - rohan_krishnamurthy
+tags: [meeting-minutes, community, security]
+---
+
+## Security Office Hour meeting minutes
+
+### Announcements
+
+- SAST: 
+  -	Veracode - Offboarding: Last reminder, license terminates on 30-March-2024
+  -	CodeQL - Onboarding- Workflow Setup: [TRG 8.01](https://eclipse-tractusx.github.io/docs/release/trg-0/trg-8-01)
+-	DAST security scans are not part of the next release 24.05 (Updates will follow through the QG Acceptance Criteria)
+-	KICS, Trivy, GitGuardian and Dependabot tools will continue as it is.
+
+### Open Discussions
+- Cofinity-X Security contact for incident reporting - Security@cofinity-x.com

--- a/blog-meeting-minutes/authors.yaml
+++ b/blog-meeting-minutes/authors.yaml
@@ -30,3 +30,8 @@ daniel_dilger:
   name: Daniel Dilger
   title: Consortia Security Team Member
   url: https://github.com/mm73628486283/
+
+rohan_krishnamurthy:
+  name: Rohan Krishnamurthy
+  title: Consortia Security Team Member
+  url: https://github.com/RoKrish14


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Adding the security office hour meeting minutes for 2024-03-28.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
