### PR TITLE
docs: add requirement to TRG-6.01

### DIFF
--- a/docs/release/trg-6/trg-6-1.md
+++ b/docs/release/trg-6/trg-6-1.md
@@ -39,6 +39,14 @@ the [central Tractus-X Helm repository](https://eclipse-tractusx.github.io/chart
 To get the GitHub Chart Releaser Action working, the following prerequisites must be met:
 
 - A branch named `gh-pages` in your repository
+- Change `Source Branch` to `gh-pages` in your repository settings. Submit request via Otterdog, ensure following are set:
+
+  ```json
+    gh_pages_build_type:"legacy",
+    gh_pages_source_branch:"gh-pages",
+    gh_pages_source_path:"/",
+  ```
+
 - Helm charts must be located in folder `/charts`
 - A GitHub Actions Workflow (see section [Implementaion](#implementation))
 

--- a/docs/release/trg-6/trg-6-1.md
+++ b/docs/release/trg-6/trg-6-1.md
@@ -39,7 +39,7 @@ the [central Tractus-X Helm repository](https://eclipse-tractusx.github.io/chart
 To get the GitHub Chart Releaser Action working, the following prerequisites must be met:
 
 - A branch named `gh-pages` in your repository
-- Change `Source Branch` to `gh-pages` in your repository settings. Submit request via Otterdog, ensure following are set:
+- Change the GitHub Pages source branch to `gh-pages` in your repository settings. Submit request via Otterdog, ensure following are set:
 
   ```json
     gh_pages_build_type:"legacy",


### PR DESCRIPTION
PR to update prerequisites of TRG-6.01 related to GitHub Chart Releaser Action as per https://github.com/helm/chart-releaser-action the `Source Branch` needs to be set to `gh-pages`.

Fixes https://github.com/eclipse-tractusx/sig-infra/issues/444