### PR TITLE
docs(office-hour): add april 05 meeting minutes

### DIFF
--- a/blog-meeting-minutes/2024-04-05-office-hour.md
+++ b/blog-meeting-minutes/2024-04-05-office-hour.md
@@ -1,0 +1,46 @@
+---
+slug: office-hour-2024-04-05 title: Office Hour 2024-04-05 authors:
+
+- sebastian_bezold tags: [tractus-x-office-hour, meeting-minutes, community]
+
+---
+
+## Office Hour meeting minutes
+
+### System team
+
+- Several TRGs in Draft
+  - See [TRG 0](https://eclipse-tractusx.github.io/docs/release/trg-0/)
+  - Dedicated PRs will be raised to gather feedback before publishing
+
+### Security team
+
+- Veracode license finally expired
+  - Dashboards still accessible
+  - No new scans can be run
+  - CodeQL is the replacement
+- Security TRGs live. See the "TRG 8 - Security" section
+  in [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
+
+### FOSS
+
+- n/a
+
+### Open planning / community
+
+- n/a
+
+### Discussions
+
+- Dependabot PRs
+  - In general: keep your dependencies up to date. Keep the `DEPENDENCIES` file in mind. Ask committers for help, if you
+    don't have one in your team.
+  - Specifically Docker base images: If dependabot suggests to upgrade the base image to a new major library version,
+    that you do not support. Ask a committer to tell dependabot to ignore the dependency
+  - Specifically Chart Releaser Action: Should not be an issue, but we can investigate if the upgrade would raise
+    issues (`1.4.1` to `1.6.0` in this case)
+- Are there updates to API versioning
+  - No one in the call had an update
+  - The [Discussion](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/discussions/580) is untouched for a
+    while
+  - If this is an issue for anyone, please push that topic again

--- a/blog-meeting-minutes/2024-04-05-office-hour.md
+++ b/blog-meeting-minutes/2024-04-05-office-hour.md
@@ -1,7 +1,9 @@
 ---
-slug: office-hour-2024-04-05 title: Office Hour 2024-04-05 authors:
-
-- sebastian_bezold tags: [tractus-x-office-hour, meeting-minutes, community]
+slug: office-hour-2024-04-05
+title: Office Hour 2024-04-05
+authors:
+  - sebastian_bezold
+tags: [tractus-x-office-hour, meeting-minutes, community]
 
 ---
 


### PR DESCRIPTION
## Description

This is the meeting minutes for the office hour meeting on 05 april

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
