### PR TITLE
fix(open meetings): change open meeting timezosnes to cest

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -26,7 +26,6 @@ These are dedicated sync meetings for specific products, as well as open plannin
                     {title: 'meeting minutes', url: 'https://eclipse-tractusx.github.io/community/meeting-minutes/tags/tractus-x-office-hour'},
                 ]
              }
-
 />
 
 <MeetingInfo title="NewJoiner - Office Hour"

--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -8,7 +8,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 ## Regular meetings
 
 <MeetingInfo title="EDC Weekly | Extended"
-             schedule="Every Tuesday from 10:30 am to 11:00 am CET"
+             schedule="Every Tuesday from 10:30 am to 11:00 am CEST"
              description="Open house meeting to support with anything EDC related. You have questions about EDC, problems running/ configuring EDC in your environment or want to know what´s next in EDC and when to expect? This is the place to ask all these questions."
              contact="benjamin.bw.westphal@mercedes-benz.com"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_Y2JmZWMzNDktNmFkMC00ZThhLTg2N2QtNDRkYmUwNDcwNWRm%40thread.v2/0?context=%7b%22Tid%22%3a%229652d7c2-1ccf-4940-8151-4a92bd474ed0%22%2c%22Oid%22%3a%22a92c6916-f523-4c1d-9ab7-61b5e6eef3be%22%7d"
@@ -16,7 +16,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 />
 
 <MeetingInfo title="Office Hour"
-             schedule="Every Friday effective 16. Feb 2024 until 31. Dec 2024 from 01:05 pm to 02:00 pm CET"
+             schedule="Every Friday effective 16. Feb 2024 until 31. Dec 2024 from 01:05 pm to 02:00 pm CEST"
              description="Open hour meeting for all interests. The goal of the meeting is to inform and share information about different topics."
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MDFiNDJjMmQtNjFkYi00ODdjLTk2NDgtZGMwNTRmYzg3NzM0%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
@@ -26,11 +26,11 @@ These are dedicated sync meetings for specific products, as well as open plannin
                     {title: 'meeting minutes', url: 'https://eclipse-tractusx.github.io/community/meeting-minutes/tags/tractus-x-office-hour'},
                 ]
              }
-             
+
 />
 
 <MeetingInfo title="NewJoiner - Office Hour"
-             schedule="Every 4 weeks on Friday effective 8. Mar 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm CET"
+             schedule="Every 4 weeks on Friday effective 8. Mar 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm CEST"
              description="Open hour meeting for all new joiner. The goal of the meeting is to provide an easy entry on all topics. The meeting will only take place if specific questions have been submitted. Please reach out in the first place to Stephan Bauer"
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjAzYzVjZGEtZjEwNC00NDI5LWEwODEtN2RhNmI0NDEzNTI2%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
@@ -38,7 +38,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 />
 
 <MeetingInfo title="Committer Meeting"
-             schedule="Every 2 weeks on Friday effective 16. Feb 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm CET"
+             schedule="Every 2 weeks on Friday effective 16. Feb 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm CEST"
              description="Open hour meeting for Eclipse Tractus-X committers. The goal of the meeting is to discuss and share specific committer tasks/responsibilities."
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTItNWE1MmMzMWUzNmYw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
@@ -46,7 +46,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 />
 
 <MeetingInfo title="Security - Office Hour"
-             schedule="Every 2 weeks on Thursday effective 15. Feb 2024 until 31. Dec 2024 from 08:35 am to 09:30 am CET"
+             schedule="Every 2 weeks on Thursday effective 15. Feb 2024 until 31. Dec 2024 from 08:35 am to 09:30 am CEST"
              description="Open hour meeting, hosted by the sig-security team. The goal of the meeting is to follow-up on security incidents, request review and assignments, and progress through security tools and procedures."
              contact="rohan.krishnamurthy@zf.com"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MzYzMzVhODMtYWQyOC00NWVlLWEyMjMtNjVlZmY2NTlkNTdk%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
@@ -60,7 +60,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 />
 
 <MeetingInfo title="[TRACE-X] Trace-X Open Meeting"
-             schedule="Every Thursday effective 8. Feb 2024 until 20. Jun 2024 (except 22. Feb 2024) from 03:05 pm to 03:45 pm CET"
+             schedule="Every Thursday effective 8. Feb 2024 until 20. Jun 2024 (except 22. Feb 2024) from 03:05 pm to 03:45 pm CEST"
              description="Coordination of feature development & concepts. For further information, please contact Martin Kanal or have a look into the downloadable ics file."
              contact="martin.kanal@doubleslash.de"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MTEyNTAyNTYtY2VkOC00ZDdjLTk0NTItNWViYTJmNmJmOTlh%40thread.v2/0?context=%7b%22Tid%22%3a%2226f86412-f875-4281-b566-fe6fe385e17c%22%2c%22Oid%22%3a%22db3ba521-7335-4e4f-b672-fc9f7c3f5536%22%7d"
@@ -77,7 +77,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 ## One-time meetings
 
 <MeetingInfo title="Tractus-X Open Planning R24.08"
-             schedule="Occurs on Wednesday 10. Apr 2024 and Thursday 11. Apr 2024 from 08:00 am to 12:00 am CET"
+             schedule="Occurs on Wednesday 10. Apr 2024 and Thursday 11. Apr 2024 from 08:00 am to 12:00 am CEST"
              description="Open Planning, hosted by the Network Service Committee of the Catena-X association. The goal for this meeting is planning of the intended work content for the next program increment - which contains also preparation of future release content, refactoring, general architectural work, tool & process improvements and feature planning for the next Tractus-X release. More information (also an agenda) can be found under the Additional Links."
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NzlmMTQzMjktMmQ4YS00ODAxLWIwMjktZmZmZmZiOGY2ZDYy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"

--- a/static/meetings/committer-office-hour.ics
+++ b/static/meetings/committer-office-hour.ics
@@ -17,31 +17,15 @@ END:DAYLIGHT
 END:VTIMEZONE
 BEGIN:VEVENT
 ORGANIZER;CN=Stephan Bauer:mailto:stephan.bauer@catena-x.net
-DESCRIPTION:Open hour meeting for Eclipse Tractus-X committers. The goal of
-  the meeting is to discuss and share specific committer tasks/responsibili
- ties.\n\n_________________________________________________________________
- _______________\nMicrosoft Teams meeting\nJoin on your computer\, mobile a
- pp or room device\nClick here to join the meeting<https://teams.microsoft.
- com/l/meetup-join/19%3ameeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTItNWE1MmMzMWU
- zNmYw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f
- 6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d>\n
- Meeting ID: 332 054 435 962\nPasscode: bDwMjb\nDownload Teams<https://www.
- microsoft.com/en-us/microsoft-teams/download-app> | Join on the web<https:
- //www.microsoft.com/microsoft-teams/join-a-meeting>\nLearn More<https://ak
- a.ms/JoinTeamsMeeting> | Meeting options<https://teams.microsoft.com/meeti
- ngOptions/?organizerId=a8b7a5ee-66ff-4695-afa2-08f893d8aaf6&tenantId=1ad22
- c6d-2f08-4f05-a0ba-e17f6ce88380&threadId=19_meeting_ZjlmNTc5MjMtN2Y2YS00Yj
- liLTg3NTItNWE1MmMzMWUzNmYw@thread.v2&messageId=0&language=en-GB>\n________
- ________________________________________________________________________\n
-RRULE:FREQ=WEEKLY;UNTIL=20241230T230000Z;INTERVAL=2;BYDAY=FR;WKST=MO
-UID:040000008200E00074C5B7101A82E0080000000051BBCDCF435BDA01000000000000000
- 010000000F334FB7EDA04724AA775688B06788E20
+RRULE:FREQ=WEEKLY;UNTIL=20241229T230000Z;INTERVAL=2;BYDAY=FR;WKST=MO
+UID:040000008200E00074C5B7101A82E00800000000BEC23346A689DA01000000000000000
+ 0100000005B5619B57D8ABD45AA6CC43444A08EF3
 SUMMARY:Committer Meeting
-DTSTART:20240216T130500Z
-DTEND:20240216T140000Z
+DTSTART:20240412T120500Z
+DTEND:20240412T130000Z
 CLASS:PUBLIC
 PRIORITY:5
-DTSTAMP:20240216T131141Z
+DTSTAMP:20240408T111709Z
 TRANSP:OPAQUE
 STATUS:CONFIRMED
 LOCATION:Microsoft Teams Meeting

--- a/static/meetings/office-hour.ics
+++ b/static/meetings/office-hour.ics
@@ -17,44 +17,15 @@ END:DAYLIGHT
 END:VTIMEZONE
 BEGIN:VEVENT
 ORGANIZER;CN=Stephan Bauer:mailto:stephan.bauer@catena-x.net
-DESCRIPTION:Weekly Office Hours from the DevSecOps Team.\n\n\n\nImportant:\
- n\nThis session will be recorded and the result is available for the commu
- nity in our CoP-Channel:\n\nCX-CoP DevSecOps<https://bcgcatenax.sharepoint
- .com/:f:/s/CommunitiesofPractises/EkMga9rBDCNCgWn-PU4fipcBv2fnSL9lx5Yw4TFU
- v1TUwg?e=b3vFiQ>\n\n\n\nHere you can find our agenda and feel free to add 
- questions on the board:\n\nhttps://miro.com/app/board/uXjVOEDsHAI=/?invite
- _link_id=963489014015\n\n\n\nNormally we start with an update from our tea
- m\, then you have the possibility to ask questions and we can also solve y
- our problems in this session directly.\n\nPlease notice: This is a hands-o
- n-meeting!\n\n\n\nPlease use also our CoP-Channel to ask questions outside
-  this session:\n\nhttps://teams.microsoft.com/l/channel/19%3a9a3c4a05a3514
- d07b973c13e7b468709%40thread.tacv2/CX%2520-%2520CoP%2520DevSecOps?groupId=
- 17b1a2dc-67fb-4a49-a2ed-dd1344321439&tenantId=1ad22c6d-2f08-4f05-a0ba-e17f
- 6ce88380\n\n\n\nMore information and how-to about our support or onboardin
- g questions\, please take a look here:\n\nhttps://catenax-ng.github.io/\n\
- n\n\n_____________________________________________________________________
- ___________\nMicrosoft Teams meeting\nJoin on your computer\, mobile app o
- r room device\nClick here to join the meeting<https://teams.microsoft.com/
- l/meetup-join/19%3ameeting_MDFiNDJjMmQtNjFkYi00ODdjLTk2NDgtZGMwNTRmYzg3NzM
- 0%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce8
- 8380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d>\nMeet
- ing ID: 364 910 945 155\nPasscode: GTG3zh\nDownload Teams<https://www.micr
- osoft.com/en-us/microsoft-teams/download-app> | Join on the web<https://ww
- w.microsoft.com/microsoft-teams/join-a-meeting>\nLearn More<https://aka.ms
- /JoinTeamsMeeting> | Meeting options<https://teams.microsoft.com/meetingOp
- tions/?organizerId=a8b7a5ee-66ff-4695-afa2-08f893d8aaf6&tenantId=1ad22c6d-
- 2f08-4f05-a0ba-e17f6ce88380&threadId=19_meeting_MDFiNDJjMmQtNjFkYi00ODdjLT
- k2NDgtZGMwNTRmYzg3NzM0@thread.v2&messageId=0&language=en-GB>\n____________
- ____________________________________________________________________\n
-RRULE:FREQ=WEEKLY;UNTIL=20241230T230000Z;INTERVAL=1;BYDAY=FR;WKST=SU
-UID:040000008200E00074C5B7101A82E0080000000052FE40363C5BDA01000000000000000
- 01000000031FBD9BB3BC2134D8FCF18D8B0284581
+RRULE:FREQ=WEEKLY;UNTIL=20241229T230000Z;INTERVAL=1;BYDAY=FR;WKST=MO
+UID:040000008200E00074C5B7101A82E00800000000AA5570E7A589DA01000000000000000
+ 0100000008A72A38523A5574690821DB20381A598
 SUMMARY:Office Hour
-DTSTART:20240216T120500Z
-DTEND:20240216T130000Z
+DTSTART:20240412T110500Z
+DTEND:20240412T120000Z
 CLASS:PUBLIC
 PRIORITY:5
-DTSTAMP:20240209T094154Z
+DTSTAMP:20240408T111427Z
 TRANSP:OPAQUE
 STATUS:CONFIRMED
 LOCATION:Microsoft Teams Meeting

--- a/static/meetings/security-office-hour.ics
+++ b/static/meetings/security-office-hour.ics
@@ -17,33 +17,15 @@ END:DAYLIGHT
 END:VTIMEZONE
 BEGIN:VEVENT
 ORGANIZER;CN=Stephan Bauer:mailto:stephan.bauer@catena-x.net
-DESCRIPTION:Open hour meeting\, hosted by the sig-security team of the cate
- na-x association. The goal of the meeting is to follow-up on security inci
- dents\, request review and assignments\, and progress through security too
- ls and procedures.\n\n\n\n________________________________________________
- ________________________________\nMicrosoft Teams meeting\nJoin on your co
- mputer\, mobile app or room device\nClick here to join the meeting<https:/
- /teams.microsoft.com/l/meetup-join/19%3ameeting_MzYzMzVhODMtYWQyOC00NWVlLW
- EyMjMtNjVlZmY2NTlkNTdk%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f
- 08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f8
- 93d8aaf6%22%7d>\nMeeting ID: 315 482 131 546\nPasscode: 6uueMF\nDownload T
- eams<https://www.microsoft.com/en-us/microsoft-teams/download-app> | Join 
- on the web<https://www.microsoft.com/microsoft-teams/join-a-meeting>\nLear
- n More<https://aka.ms/JoinTeamsMeeting> | Meeting options<https://teams.mi
- crosoft.com/meetingOptions/?organizerId=a8b7a5ee-66ff-4695-afa2-08f893d8aa
- f6&tenantId=1ad22c6d-2f08-4f05-a0ba-e17f6ce88380&threadId=19_meeting_MzYzM
- zVhODMtYWQyOC00NWVlLWEyMjMtNjVlZmY2NTlkNTdk@thread.v2&messageId=0&language
- =en-GB>\n_________________________________________________________________
- _______________\n
-RRULE:FREQ=WEEKLY;UNTIL=20241230T230000Z;INTERVAL=2;BYDAY=TH;WKST=SU
-UID:040000008200E00074C5B7101A82E008000000006E992617395BDA01000000000000000
- 01000000035F1C31BB4F030428E4B03DF703261C9
+RRULE:FREQ=WEEKLY;UNTIL=20241229T230000Z;INTERVAL=2;BYDAY=TH;WKST=MO
+UID:040000008200E00074C5B7101A82E008000000001FCA7B6BA689DA01000000000000000
+ 01000000091B106F143A50941B72CBC0BABE2F653
 SUMMARY:Security - Office Hour
-DTSTART:20240215T073500Z
-DTEND:20240215T083000Z
+DTSTART:20240411T063500Z
+DTEND:20240411T073000Z
 CLASS:PUBLIC
 PRIORITY:5
-DTSTAMP:20240209T091945Z
+DTSTAMP:20240408T111808Z
 TRANSP:OPAQUE
 STATUS:CONFIRMED
 LOCATION:Microsoft Teams Meeting


### PR DESCRIPTION
## Description

Since we switched to *summer time*, some downloaded meetings are moved for 1 hour. This PR adapts the related ICS files. The blockers are shown correctly now in the calendar.

![image](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/bf664591-6b95-45c0-8627-e0fc3c8fee26)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
