### PR TITLE
doc(news blog): agenda for open planning R24.08

### DIFF
--- a/blog/2024-04-10-open-planning-r24.08.mdx
+++ b/blog/2024-04-10-open-planning-r24.08.mdx
@@ -15,29 +15,69 @@ authors:
 ![eclipse tractus x logo](@site/static/img/Tractus-X_openplanning.png)
 
 Dear Tractus-X Community Members 🎉,
- 
+
 we are excited to extend this invitation to you for our upcoming Tractus-X meetings. These meetings are a great opportunity for both business stakeholders and developers to contribute and collaborate on the future of Tractus-X.
 Please feel free to forward this post to anyone interested in contributing, whether in planning or development.
- 
-**Agenda:**
 
-- **Tractus-X Open Planning R24.08**
-  - Date: 10th April and 11th April 2024
-  - Time: 08:00 - 12:00
-  - Please see the [Open Meetings page](https://eclipse-tractusx.github.io/community/open-meetings) for downloadable ICS dile and session link
+## Agenda
+
+- **Date:** 10th April and 11th April 2024
+- **Time:** 08:00 - 12:00
+- Please see the [Open Meetings page](https://eclipse-tractusx.github.io/community/open-meetings) for downloadable ICS file and session link
+- [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26/views/23)
 
 <!--truncate-->
 
+### Wednesday, 10th April 2024
+
+- **08:00 - 08:30** - Open Planning Vision & Intro
+- **08:30 - 09:00** - Open Planning Vision Deep Dive Tractus-X
+- **09:00 - 11:30** - Joint Open Planning (all teams)
+  - **09:00 - 11:00** - Platform Domain
+  - **11:00 - 11:15** - Business Domain SUS
+  - **11:15 - 11:30** - Business Domain PQR
+- **11:30 - 12:00** - Open Planning Wrap-Up / Summary Day 1
+
 :::info
-
-Will be published as soon as possible.
-
+The detailed agenda is only filtered by `label`not by status. As a prequisite, the issues need to be in status `Backlog`.
 :::
 
+#### Platform Domain
 
+| Time | Topic / Labels | Link | Number of features |
+| ---- | ----- | ------------- | ---- |
+| 09:00 - 09:20 | golden record, business partner | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22golden+record%22%2C%22business+partner%22) | 7 |
+| 09:20 - 09:40 | portal | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22++label%3A%22portal%22+) | 8 |
+| 09:40 - 09:50 | miw | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22miw%22) | 3 |
+| 09:50 - 10:25 | edc | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22edc%22) | 15 |
+| 10:25 - 10:35 | digital twin registry, discovery finder, discovery service, semantic hub | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22digital+twin+registry%22%2C%22discovery+finder%22%2C%22discovery+service%22%2C%22semantic+hub%22) | 4 |
+| 10:35 - 10:40 | knowledge agent | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22knowledge+agent%22+) | 2 |
+| 10:40 - 10:45 | sde | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22sde%22) | 1 |
+| 10:45 - 10:50 | sd factory | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22sd+factory%22) | 2 |
+| 10:50 - 10:55 | irs | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22irs%22) | 1 |
+
+#### Business Domain SUS
+
+| Time | Topic / Labels | Link | Number of features |
+| ---- | ----- | ------------- | ---- |
+| 11:00 - 11:15 | pcf, circularity, eco pass | [TBD](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?sliceBy%5Bvalue%5D=dcm) | 0 |
+
+#### Business Domain PQR
+
+| Time | Topic / Labels | Link | Number of features |
+| ---- | ----- | ------------- | ---- |
+| 11:15 - 11:30 | dcm | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?sliceBy%5Bvalue%5D=dcm) | 4 |
+
+### Thursday, 11th April 2024
+
+- **08:00 - 09:00** - Open Planning Draft Plan Review
+- **09:00 - 10:30** - Joint Open Planning (all teams)
+- **10:30 - 11:00** - Release 24.08 Confidence Vote
+- **11:00 - 11:30** - Feedback / Retro
+- **11:30 - 12:00** - Open Planning Wrap-Up / Summary
 
 ## Staying Informed
- 
+
 To stay updated on any changes or additional information, please subscribe to our mailing list. A great way to keep informed is through the provided [Tractus-X Development Mailing List RSS Feed](https://www.eclipse.org/lists/tractusx-dev/maillist.rss).
 
 :::tip
@@ -45,16 +85,16 @@ To stay updated on any changes or additional information, please subscribe to ou
 Here, you can also find previous messages for reference.
 
 :::
- 
+
 ## Further Information
- 
+
 For more details about the planning process and what these meetings entail, please refer to our guide on [Open Refinement and Planning in Open Source Communities](https://github.com/eclipse-tractusx/sig-release/blob/main/docs/open-refinement-and-planning.md)
  and of course the sig-release [README](https://github.com/eclipse-tractusx/sig-release/blob/main/README.md)
 
 ## Stay Connected
 
 Follow our [news section](https://eclipse-tractusx.github.io/blog) and join our [Tractus-X mailing list](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute/#dev-mailinglist)
-and be part of our [Matrix Chat from Eclipse Tractus-X](https://chat.eclipse.org/#/room/#tools.tractus-x:matrix.eclipse.org) 
+and be part of our [Matrix Chat from Eclipse Tractus-X](https://chat.eclipse.org/#/room/#tools.tractus-x:matrix.eclipse.org)
 
 For more details about Tractus-X, visit the official [Eclipse Tractus-X Project Page](https://projects.eclipse.org/projects/automotive.tractusx).
 

--- a/blog/2024-04-10-open-planning-r24.08.mdx
+++ b/blog/2024-04-10-open-planning-r24.08.mdx
@@ -46,7 +46,7 @@ The detailed agenda is only filtered by `label`not by status. As a prequisite, t
 
 | Time | Topic / Labels | Link | Number of features |
 | ---- | ----- | ------------- | ---- |
-| 09:00 - 09:15 | pcf, circularity, eco pass | [TBD](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?sliceBy%5Bvalue%5D=dcm) | 0 |
+| 09:00 - 09:15 | pcf, circularity, eco pass | [features](https://github.com/eclipse-tractusx/sig-release/issues?q=is%3Aissue+is%3Aopen+issue%3A+628+591+632+638) | 4 |
 
 #### Platform Domain
 
@@ -55,7 +55,8 @@ The detailed agenda is only filtered by `label`not by status. As a prequisite, t
 | 09:15 - 09:35 | golden record, business partner | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22golden+record%22%2C%22business+partner%22) | 7 |
 | 09:35 - 09:55 | portal | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22++label%3A%22portal%22+) | 8 |
 | 09:55 - 10:05 | miw | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22miw%22) | 3 |
-| 10:05 - 10:40 | edc | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22edc%22) | 15 |
+| 10:05 - 10:35 | edc | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22edc%22) | 15 |
+| 10:35 - 10:40 | data sovereignty | [features](https://github.com/eclipse-tractusx/sig-release/issues?q=is%3Aissue+is%3Aopen+issue%3A+584+583+581) | 3 |
 | 10:40 - 10:50 | digital twin registry, discovery finder, discovery service, semantic hub | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22digital+twin+registry%22%2C%22discovery+finder%22%2C%22discovery+service%22%2C%22semantic+hub%22) | 4 |
 | 10:50 - 10:55 | knowledge agent | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22knowledge+agent%22+) | 2 |
 | 10:55 - 11:00 | sde | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22sde%22) | 1 |

--- a/blog/2024-04-10-open-planning-r24.08.mdx
+++ b/blog/2024-04-10-open-planning-r24.08.mdx
@@ -33,8 +33,8 @@ Please feel free to forward this post to anyone interested in contributing, whet
 - **08:00 - 08:30** - Open Planning Vision & Intro
 - **08:30 - 09:00** - Open Planning Vision Deep Dive Tractus-X
 - **09:00 - 11:30** - Joint Open Planning (all teams)
-  - **09:00 - 11:00** - Platform Domain
-  - **11:00 - 11:15** - Business Domain SUS
+  - **09:00 - 09:15** - Business Domain SUS
+  - **09:15 - 11:15** - Platform Domain
   - **11:15 - 11:30** - Business Domain PQR
 - **11:30 - 12:00** - Open Planning Wrap-Up / Summary Day 1
 
@@ -42,25 +42,25 @@ Please feel free to forward this post to anyone interested in contributing, whet
 The detailed agenda is only filtered by `label`not by status. As a prequisite, the issues need to be in status `Backlog`.
 :::
 
-#### Platform Domain
-
-| Time | Topic / Labels | Link | Number of features |
-| ---- | ----- | ------------- | ---- |
-| 09:00 - 09:20 | golden record, business partner | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22golden+record%22%2C%22business+partner%22) | 7 |
-| 09:20 - 09:40 | portal | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22++label%3A%22portal%22+) | 8 |
-| 09:40 - 09:50 | miw | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22miw%22) | 3 |
-| 09:50 - 10:25 | edc | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22edc%22) | 15 |
-| 10:25 - 10:35 | digital twin registry, discovery finder, discovery service, semantic hub | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22digital+twin+registry%22%2C%22discovery+finder%22%2C%22discovery+service%22%2C%22semantic+hub%22) | 4 |
-| 10:35 - 10:40 | knowledge agent | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22knowledge+agent%22+) | 2 |
-| 10:40 - 10:45 | sde | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22sde%22) | 1 |
-| 10:45 - 10:50 | sd factory | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22sd+factory%22) | 2 |
-| 10:50 - 10:55 | irs | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22irs%22) | 1 |
-
 #### Business Domain SUS
 
 | Time | Topic / Labels | Link | Number of features |
 | ---- | ----- | ------------- | ---- |
-| 11:00 - 11:15 | pcf, circularity, eco pass | [TBD](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?sliceBy%5Bvalue%5D=dcm) | 0 |
+| 09:00 - 09:15 | pcf, circularity, eco pass | [TBD](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?sliceBy%5Bvalue%5D=dcm) | 0 |
+
+#### Platform Domain
+
+| Time | Topic / Labels | Link | Number of features |
+| ---- | ----- | ------------- | ---- |
+| 09:15 - 09:35 | golden record, business partner | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22golden+record%22%2C%22business+partner%22) | 7 |
+| 09:35 - 09:55 | portal | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22++label%3A%22portal%22+) | 8 |
+| 09:55 - 10:05 | miw | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22miw%22) | 3 |
+| 10:05 - 10:40 | edc | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22edc%22) | 15 |
+| 10:40 - 10:50 | digital twin registry, discovery finder, discovery service, semantic hub | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22digital+twin+registry%22%2C%22discovery+finder%22%2C%22discovery+service%22%2C%22semantic+hub%22) | 4 |
+| 10:50 - 10:55 | knowledge agent | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22knowledge+agent%22+) | 2 |
+| 10:55 - 11:00 | sde | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22sde%22) | 1 |
+| 11:00 - 11:05 | sd factory | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22sd+factory%22) | 2 |
+| 11:05 - 11:15 | irs | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22irs%22) | 1 |
 
 #### Business Domain PQR
 


### PR DESCRIPTION
## Description

This pr add the agenda and also a detailed one for the open planning for release 24.08

<img width="1903" alt="image" src="https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/8b7a62bf-4c48-4b41-a796-c0653534de19">

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
