### PR TITLE
doc(open planning): adapt the agenda for open planning

### DIFF
--- a/blog/2024-04-10-open-planning-r24.08.mdx
+++ b/blog/2024-04-10-open-planning-r24.08.mdx
@@ -55,14 +55,10 @@ The detailed agenda is only filtered by `label`not by status. As a prequisite, t
 | ---- | ----- | ------------- | ---- |
 | 09:15 - 09:35 | golden record, business partner | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22golden+record%22%2C%22business+partner%22) | 7 |
 | 09:35 - 09:55 | portal | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22++label%3A%22portal%22+) | 8 |
-| 09:55 - 10:05 | miw | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22miw%22) | 3 |
-| 10:05 - 10:35 | edc | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22edc%22) | 15 |
 | 10:35 - 10:40 | data sovereignty | [features](https://github.com/eclipse-tractusx/sig-release/issues?q=is%3Aissue+is%3Aopen+issue%3A+584+583+581) | 3 |
 | 10:40 - 10:50 | digital twin registry, discovery finder, discovery service, semantic hub | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22digital+twin+registry%22%2C%22discovery+finder%22%2C%22discovery+service%22%2C%22semantic+hub%22) | 4 |
 | 10:50 - 10:55 | knowledge agent | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22knowledge+agent%22+) | 2 |
-| 10:55 - 11:00 | sde | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22sde%22) | 1 |
-| 11:00 - 11:05 | sd factory | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22sd+factory%22) | 2 |
-| 11:05 - 11:15 | irs | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22irs%22) | 1 |
+
 
 #### Business Domain PQR
 
@@ -77,6 +73,29 @@ The detailed agenda is only filtered by `label`not by status. As a prequisite, t
 - **10:30 - 11:00** - Release 24.08 Confidence Vote
 - **11:00 - 11:30** - Feedback / Retro
 - **11:30 - 12:00** - Open Planning Wrap-Up / Summary
+
+#### Platform Domain
+
+| Time | Topic / Labels | Link | Number of features |
+| ---- | ----- | ------------- | ---- |
+| 09:00 - 09:15 | miw | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22miw%22) | 3 |
+| 09:15 - 09:30 | edc | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22edc%22) | 15 |
+| 09:30 - 09:35 | sde | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22sde%22) | 1 |
+| 09:35 - 09:45 | sd factory | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22sd+factory%22) | 2 |
+| 09:45 - 09:55 | irs | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22irs%22) | 1 |
+| 09:45 - 09:55 | trace-x | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22trace-x%22+) | 4 |
+
+#### Business Domain PQR
+
+| Time | Topic / Labels | Link | Number of features |
+| ---- | ----- | ------------- | ---- |
+| 09:55 - 10:15 | dcm, puris, osim | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?filterQuery=label%3A%22Prep-PI13%22+label%3A%22osim%22%2C%22puris%22%2C%22dcm%22+) | 8 |
+
+#### Left over
+
+| Time | Topic / Labels | Link | Number of features |
+| ---- | ----- | ------------- | ---- |
+| 10:15 - 10:30 | open decision  | [features](https://github.com/orgs/eclipse-tractusx/projects/26/views/23?sliceBy%5Bvalue%5D=open+decision) | 7 |
 
 ## Staying Informed
 


### PR DESCRIPTION
## Description

Since we were unable to discuss all the features… this, Pr prepares the agenda for the second planning day

![image](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/6da8a59a-2158-4419-81d5-dbf406baa847)

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
