### PR TITLE
docs: security office hour meeting minutes 2024-04-11

### DIFF
--- a/blog-meeting-minutes/2024-04-11-security-hour.md
+++ b/blog-meeting-minutes/2024-04-11-security-hour.md
@@ -1,0 +1,15 @@
+---
+slug: security-office-hour-2024-04-11
+title: Security Office Hour 11.04.2024
+authors: 
+    - rohan_krishnamurthy
+tags: [meeting-minutes, community, security]
+---
+
+## Security Office Hour meeting minutes
+
+### Announcements
+
+- SAST: CodeQL workflows seems successfully well integrated
+-	KICS, Trivy, GitGuardian and Dependabot tools will continue as it is.
+-	No new updates


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Adding the security office hour meeting minutes for 2024-04-11.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
