### PR TITLE
doc(open meetings): add new meeting structure for release 2412

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -75,15 +75,78 @@ These are dedicated sync meetings for specific products, as well as open plannin
 
 ## One-time meetings
 
-<MeetingInfo title="Tractus-X Open Planning R24.08"
-             schedule="Occurs on Wednesday 10. Apr 2024 and Thursday 11. Apr 2024 from 08:00 am to 12:00 am CEST"
-             description="Open Planning, hosted by the Network Service Committee of the Catena-X association. The goal for this meeting is planning of the intended work content for the next program increment - which contains also preparation of future release content, refactoring, general architectural work, tool & process improvements and feature planning for the next Tractus-X release. More information (also an agenda) can be found under the Additional Links."
+<MeetingInfo title="Refinement Phase - Release 24.12"
+             schedule="Monday, 24. June 2024 to Sunday, 28. July 2024 (CEST)"
+             description="Please be aware that the Refinement Phase is to keep you aware of the overall timeline during the Release Process and does not constitute an actual meeting. It serves informational purposes only. During this time, the necessary people/groups should come together and work (refine) the future features. Feature authors take care of organising appointments and communicating with the relevant contacts themselves. The Teams Session link can be used. Be aware: The link and the shared content is available to everyone."
              contact="stephan.bauer@catena-x.net"
-             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NzlmMTQzMjktMmQ4YS00ODAxLWIwMjktZmZmZmZiOGY2ZDYy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
-             meetingLink="/meetings/open-planning-r2408.ics"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZTQ5ZWMzNDUtMWQ0My00MDFhLWIxZmYtZjRlNTU2NzFmYmFk%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
+             meetingLink="/meetings/refinement-phase-r2412.ics"
              additionalLinks={
                 [
-                    {title: 'open planning news', url: 'https://eclipse-tractusx.github.io/blog/open-planning-r24-08'},
+                    {title: 'Open Planning News', url: 'https://eclipse-tractusx.github.io/blog/open-planning-r24-12'},
+                    {title: 'Working Board (Miro)', url: 'https://miro.com/app/board/uXjVKTxFyW0=/?share_link_id=753562836761'},
+                    {title: 'Release Planning Board (GitHub)', url: 'https://github.com/orgs/eclipse-tractusx/projects/26'},
+                    {title: 'Readme sig-release (GitHub)', url: 'https://github.com/orgs/eclipse-tractusx/projects/26'},
+                    {title: 'Working Model (Catena-X Association)', url: 'https://catenax-ev.github.io/docs/next/working-model/process-from-idea-to-production/03-01-process-from-idea-to-production'},
+                ]
+             }
+/>
+
+<MeetingInfo title="Refinement Day 1 - Release 24.12"
+             schedule="Monday, 1. July 2024 from 09:05 to 12:00 (CEST)"
+             description="This event is organised and moderated by the Catena-X Association. Based on a predefined agenda (depending on the features on the board), individual dependencies are discussed and also documented directly on the feature. If the refinement of the features has already been carried out 'in the refinement phase' and the Definition of Entry (DoE) has already reached, this meeting can also be used as synchronisation."
+             contact="stephan.bauer@catena-x.net"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_OWE3ZjJmZTItN2ZlYi00YjFkLWIwMGQtNDBmMTBiOTdiZTE2%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
+             meetingLink="/meetings/refinement-day-1-r2412.ics"
+             additionalLinks={
+                [
+                    {title: 'Open Planning News', url: 'https://eclipse-tractusx.github.io/blog/open-planning-r24-12'},
+                    {title: 'Working Board (Miro)', url: 'https://miro.com/app/board/uXjVKTxFyW0=/?share_link_id=753562836761'},
+                ]
+             }
+/>
+
+<MeetingInfo title="Draft Feature Freeze - Release 24.12"
+             schedule="Friday, 12. July 2024 from 09:05 to 12:00 (CEST)"
+             description="This event is organised and moderated by the Catena-X Association. Until this date, feature proposal can be submitted to the planning board (in GitHub). The current status (as an interim status in the refinement phase) of the previous feature proposals will also be discussed at this meeting."
+             contact="stephan.bauer@catena-x.net"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_YmRhMWViMmUtOTAzYS00YjNmLTgwMDMtMDJhOGZiOGUwOWQ0%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
+             meetingLink="/meetings/draft-feature-freeze-r2412.ics"
+             additionalLinks={
+                [
+                    {title: 'Open Planning News', url: 'https://eclipse-tractusx.github.io/blog/open-planning-r24-12'},
+                    {title: 'Working Board (Miro)', url: 'https://miro.com/app/board/uXjVKTxFyW0=/?share_link_id=753562836761'},
+                ]
+             }
+/>
+
+<MeetingInfo title="Refinement Day 2 - Release 24.12"
+             schedule="Monday, 22. July 2024 from 09:05 to 12:00 (CEST)"
+             description="This event is organised and moderated by the Catena-X Association. Based on a predefined agenda (depending on the features on the board), individual dependencies are discussed and also documented directly on the feature. If the refinement of the features has already been carried out 'in the refinement phase' and the Definition of Entry (DoE) has already reached, this meeting can also be used as synchronisation."
+             contact="stephan.bauer@catena-x.net"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDFjMWQzNmYtZGZkOS00MDFmLWI5ZjYtNDRhNDRjZjIxNDQ4%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
+             meetingLink="/meetings/refinement-day-2-r2412.ics"
+             additionalLinks={
+                [
+                    {title: 'Open Planning News', url: 'https://eclipse-tractusx.github.io/blog/open-planning-r24-12'},
+                    {title: 'Working Board (Miro)', url: 'https://miro.com/app/board/uXjVKTxFyW0=/?share_link_id=753562836761'},
+                ]
+             }
+/>
+
+<MeetingInfo title="Open Planning Days - Release 24.12"
+             schedule="Wednesday, 31. Jul 2024 and Thursday, 01. Aug 2024 from 08:05 to 12:00 (CEST)"
+             description="Open Planning, hosted by the Catena-X association. The goal for this meeting is planning of the intended work content for the next release - which contains also preparation of future release content, refactoring, general architectural work, tool & process improvements and feature planning for the next Tractus-X release. More information (also an agenda) can be found under the Additional Links."
+             contact="stephan.bauer@catena-x.net"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZWY0ODI3ZmYtNjFiOS00OTI1LTlmNWMtZGUzNTFhNzg2OWI3%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
+             meetingLink="/meetings/open-planning-r2412.ics"
+             additionalLinks={
+                [
+                    {title: 'Open Planning News', url: 'https://eclipse-tractusx.github.io/blog/open-planning-r24-12'},
+                    {title: 'Working Board (Miro)', url: 'https://miro.com/app/board/uXjVKTxFyW0=/?share_link_id=753562836761'},
+                    {title: 'Release Planning Board (GitHub)', url: 'https://github.com/orgs/eclipse-tractusx/projects/26'},
+                    {title: 'Readme sig-release (GitHub)', url: 'https://github.com/orgs/eclipse-tractusx/projects/26'},
+                    {title: 'Working Model (Catena-X Association)', url: 'https://catenax-ev.github.io/docs/next/working-model/process-from-idea-to-production/03-01-process-from-idea-to-production'},
                 ]
              }
 />

--- a/static/meetings/draft-feature-freeze-r2412.ics
+++ b/static/meetings/draft-feature-freeze-r2412.ics
@@ -1,0 +1,71 @@
+BEGIN:VCALENDAR
+METHOD:PUBLISH
+PRODID:Microsoft Exchange Server 2010
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:tzone://Microsoft/Utc
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+ORGANIZER;CN=Stephan Bauer:mailto:stephan.bauer@catena-x.net
+DESCRIPTION:Please have a look at https://eclipse-tractusx.github.io/blog f
+ or detailed information about the Release Planning for 24.12\n\n__________
+ ______________________________________________________________________\nMi
+ crosoft Teams Benötigen Sie Hilfe?<https://aka.ms/JoinTeamsMeeting?omkt=d
+ e-DE>\nJetzt an der Besprechung teilnehmen<https://teams.microsoft.com/l/m
+ eetup-join/19%3ameeting_YmRhMWViMmUtOTAzYS00YjNmLTgwMDMtMDJhOGZiOGUwOWQ0%4
+ 0thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce8838
+ 0%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d>\nBesprec
+ hungs-ID: 339 266 968 799\nKennung: oGwMWP\n______________________________
+ __\nFür Organisatoren: Besprechungsoptionen<https://teams.microsoft.com/m
+ eetingOptions/?organizerId=a8b7a5ee-66ff-4695-afa2-08f893d8aaf6&tenantId=1
+ ad22c6d-2f08-4f05-a0ba-e17f6ce88380&threadId=19_meeting_YmRhMWViMmUtOTAzYS
+ 00YjNmLTgwMDMtMDJhOGZiOGUwOWQ0@thread.v2&messageId=0&language=de-DE> | Ein
+ wahl-PIN zurücksetzen<https://dialin.teams.microsoft.com/usp/pstnconferen
+ cing>\n___________________________________________________________________
+ _____________\n
+UID:040000008200E00074C5B7101A82E008000000002F6D5A2FD08FDA01000000000000000
+ 01000000009C8655129D2E84B811AD33D4B685D9A
+SUMMARY:Draft Feature Freeze - Release 24.12
+DTSTART:20240712T070500Z
+DTEND:20240712T100000Z
+CLASS:PUBLIC
+PRIORITY:5
+DTSTAMP:20240416T073210Z
+TRANSP:OPAQUE
+STATUS:CONFIRMED
+LOCATION:Microsoft Teams Meeting
+X-MICROSOFT-CDO-BUSYSTATUS:BUSY
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+X-MICROSOFT-CDO-ALLDAYEVENT:FALSE
+X-MICROSOFT-CDO-IMPORTANCE:1
+X-MICROSOFT-CDO-INSTTYPE:0
+X-MICROSOFT-SKYPETEAMSMEETINGURL:https://teams.microsoft.com/l/meetup-join/
+ 19%3ameeting_YmRhMWViMmUtOTAzYS00YjNmLTgwMDMtMDJhOGZiOGUwOWQ0%40thread.v2/
+ 0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22O
+ id%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d
+X-MICROSOFT-SKYPETEAMSPROPERTIES:{"cid":"19:meeting_YmRhMWViMmUtOTAzYS00YjN
+ mLTgwMDMtMDJhOGZiOGUwOWQ0@thread.v2"\,"rid":0\,"mid":0\,"uid":null\,"priva
+ te":true\,"type":0}
+X-MICROSOFT-ONLINEMEETINGEXTERNALLINK:
+X-MICROSOFT-ONLINEMEETINGINFORMATION:{"OnlineMeetingChannelId":null\,"Onlin
+ eMeetingProvider":3}
+X-MICROSOFT-DONOTFORWARDMEETING:FALSE
+X-MICROSOFT-DISALLOW-COUNTER:FALSE
+X-MICROSOFT-LOCATIONDISPLAYNAME:Microsoft Teams Meeting
+BEGIN:VALARM
+DESCRIPTION:REMINDER
+TRIGGER;RELATED=START:-PT15M
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/static/meetings/open-planning-r2412.ics
+++ b/static/meetings/open-planning-r2412.ics
@@ -1,0 +1,72 @@
+BEGIN:VCALENDAR
+METHOD:PUBLISH
+PRODID:Microsoft Exchange Server 2010
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:tzone://Microsoft/Utc
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+ORGANIZER;CN=Stephan Bauer:mailto:stephan.bauer@catena-x.net
+DESCRIPTION:Please have a look at https://eclipse-tractusx.github.io/blog f
+ or detailed information about the Release Planning for 24.12\n\n__________
+ ______________________________________________________________________\nMi
+ crosoft Teams Benötigen Sie Hilfe?<https://aka.ms/JoinTeamsMeeting?omkt=d
+ e-DE>\nJetzt an der Besprechung teilnehmen<https://teams.microsoft.com/l/m
+ eetup-join/19%3ameeting_ZWY0ODI3ZmYtNjFiOS00OTI1LTlmNWMtZGUzNTFhNzg2OWI3%4
+ 0thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce8838
+ 0%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d>\nBesprec
+ hungs-ID: 344 731 276 68\nKennung: abwjeM\n_______________________________
+ _\nFür Organisatoren: Besprechungsoptionen<https://teams.microsoft.com/me
+ etingOptions/?organizerId=a8b7a5ee-66ff-4695-afa2-08f893d8aaf6&tenantId=1a
+ d22c6d-2f08-4f05-a0ba-e17f6ce88380&threadId=19_meeting_ZWY0ODI3ZmYtNjFiOS0
+ 0OTI1LTlmNWMtZGUzNTFhNzg2OWI3@thread.v2&messageId=0&language=de-DE> | Einw
+ ahl-PIN zurücksetzen<https://dialin.teams.microsoft.com/usp/pstnconferenc
+ ing>\n____________________________________________________________________
+ ____________\n
+RRULE:FREQ=WEEKLY;UNTIL=20240803T220000Z;INTERVAL=1;BYDAY=WE,TH;WKST=MO
+UID:040000008200E00074C5B7101A82E00800000000E9AAEA0ECF8FDA01000000000000000
+ 010000000FAD04F6D310F94499D61486CCD2FBA1D
+SUMMARY:Open Planning Days - Release 24.12
+DTSTART:20240731T060500Z
+DTEND:20240731T100000Z
+CLASS:PUBLIC
+PRIORITY:5
+DTSTAMP:20240416T101617Z
+TRANSP:OPAQUE
+STATUS:CONFIRMED
+LOCATION:Microsoft Teams Meeting
+X-MICROSOFT-CDO-BUSYSTATUS:BUSY
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+X-MICROSOFT-CDO-ALLDAYEVENT:FALSE
+X-MICROSOFT-CDO-IMPORTANCE:1
+X-MICROSOFT-CDO-INSTTYPE:1
+X-MICROSOFT-SKYPETEAMSMEETINGURL:https://teams.microsoft.com/l/meetup-join/
+ 19%3ameeting_ZWY0ODI3ZmYtNjFiOS00OTI1LTlmNWMtZGUzNTFhNzg2OWI3%40thread.v2/
+ 0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22O
+ id%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d
+X-MICROSOFT-SKYPETEAMSPROPERTIES:{"cid":"19:meeting_ZWY0ODI3ZmYtNjFiOS00OTI
+ 1LTlmNWMtZGUzNTFhNzg2OWI3@thread.v2"\,"rid":0\,"mid":0\,"uid":null\,"priva
+ te":true\,"type":0}
+X-MICROSOFT-ONLINEMEETINGEXTERNALLINK:
+X-MICROSOFT-ONLINEMEETINGINFORMATION:{"OnlineMeetingChannelId":null\,"Onlin
+ eMeetingProvider":3}
+X-MICROSOFT-DONOTFORWARDMEETING:FALSE
+X-MICROSOFT-DISALLOW-COUNTER:FALSE
+X-MICROSOFT-LOCATIONDISPLAYNAME:Microsoft Teams Meeting
+BEGIN:VALARM
+DESCRIPTION:REMINDER
+TRIGGER;RELATED=START:-PT15M
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/static/meetings/refinement-day-1-r2412.ics
+++ b/static/meetings/refinement-day-1-r2412.ics
@@ -1,0 +1,71 @@
+BEGIN:VCALENDAR
+METHOD:PUBLISH
+PRODID:Microsoft Exchange Server 2010
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:tzone://Microsoft/Utc
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+ORGANIZER;CN=Stephan Bauer:mailto:stephan.bauer@catena-x.net
+DESCRIPTION:Please have a look at https://eclipse-tractusx.github.io/blog f
+ or detailed information about the Release Planning for 24.12\n\n\n________
+ ________________________________________________________________________\n
+ Microsoft Teams Benötigen Sie Hilfe?<https://aka.ms/JoinTeamsMeeting?omkt
+ =de-DE>\nJetzt an der Besprechung teilnehmen<https://teams.microsoft.com/l
+ /meetup-join/19%3ameeting_OWE3ZjJmZTItN2ZlYi00YjFkLWIwMGQtNDBmMTBiOTdiZTE2
+ %40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88
+ 380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d>\nBespr
+ echungs-ID: 329 979 340 528\nKennung: ytFAeo\n____________________________
+ ____\nFür Organisatoren: Besprechungsoptionen<https://teams.microsoft.com
+ /meetingOptions/?organizerId=a8b7a5ee-66ff-4695-afa2-08f893d8aaf6&tenantId
+ =1ad22c6d-2f08-4f05-a0ba-e17f6ce88380&threadId=19_meeting_OWE3ZjJmZTItN2Zl
+ Yi00YjFkLWIwMGQtNDBmMTBiOTdiZTE2@thread.v2&messageId=0&language=de-DE> | E
+ inwahl-PIN zurücksetzen<https://dialin.teams.microsoft.com/usp/pstnconfer
+ encing>\n_________________________________________________________________
+ _______________\n
+UID:040000008200E00074C5B7101A82E008000000009BE2FFB5CF8FDA01000000000000000
+ 010000000E4546C4CCB105D4694A4BFD0F2DA1383
+SUMMARY:Refinement Day 1 - Release 24.12
+DTSTART:20240701T070500Z
+DTEND:20240701T100000Z
+CLASS:PUBLIC
+PRIORITY:5
+DTSTAMP:20240416T073434Z
+TRANSP:OPAQUE
+STATUS:CONFIRMED
+LOCATION:Microsoft Teams Meeting
+X-MICROSOFT-CDO-BUSYSTATUS:BUSY
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+X-MICROSOFT-CDO-ALLDAYEVENT:FALSE
+X-MICROSOFT-CDO-IMPORTANCE:1
+X-MICROSOFT-CDO-INSTTYPE:0
+X-MICROSOFT-SKYPETEAMSMEETINGURL:https://teams.microsoft.com/l/meetup-join/
+ 19%3ameeting_OWE3ZjJmZTItN2ZlYi00YjFkLWIwMGQtNDBmMTBiOTdiZTE2%40thread.v2/
+ 0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22O
+ id%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d
+X-MICROSOFT-SKYPETEAMSPROPERTIES:{"cid":"19:meeting_OWE3ZjJmZTItN2ZlYi00YjF
+ kLWIwMGQtNDBmMTBiOTdiZTE2@thread.v2"\,"rid":0\,"mid":0\,"uid":null\,"priva
+ te":true\,"type":0}
+X-MICROSOFT-ONLINEMEETINGEXTERNALLINK:
+X-MICROSOFT-ONLINEMEETINGINFORMATION:{"OnlineMeetingChannelId":null\,"Onlin
+ eMeetingProvider":3}
+X-MICROSOFT-DONOTFORWARDMEETING:FALSE
+X-MICROSOFT-DISALLOW-COUNTER:FALSE
+X-MICROSOFT-LOCATIONDISPLAYNAME:Microsoft Teams Meeting
+BEGIN:VALARM
+DESCRIPTION:REMINDER
+TRIGGER;RELATED=START:-PT15M
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/static/meetings/refinement-day-2-r2412.ics
+++ b/static/meetings/refinement-day-2-r2412.ics
@@ -1,0 +1,71 @@
+BEGIN:VCALENDAR
+METHOD:PUBLISH
+PRODID:Microsoft Exchange Server 2010
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:tzone://Microsoft/Utc
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+ORGANIZER;CN=Stephan Bauer:mailto:stephan.bauer@catena-x.net
+DESCRIPTION:Please have a look at https://eclipse-tractusx.github.io/blog f
+ or detailed information about the Release Planning for 24.12\n\n\n________
+ ________________________________________________________________________\n
+ Microsoft Teams Benötigen Sie Hilfe?<https://aka.ms/JoinTeamsMeeting?omkt
+ =de-DE>\nJetzt an der Besprechung teilnehmen<https://teams.microsoft.com/l
+ /meetup-join/19%3ameeting_ZDFjMWQzNmYtZGZkOS00MDFmLWI5ZjYtNDRhNDRjZjIxNDQ4
+ %40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88
+ 380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d>\nBespr
+ echungs-ID: 370 799 059 313\nKennung: UqYpeW\n____________________________
+ ____\nFür Organisatoren: Besprechungsoptionen<https://teams.microsoft.com
+ /meetingOptions/?organizerId=a8b7a5ee-66ff-4695-afa2-08f893d8aaf6&tenantId
+ =1ad22c6d-2f08-4f05-a0ba-e17f6ce88380&threadId=19_meeting_ZDFjMWQzNmYtZGZk
+ OS00MDFmLWI5ZjYtNDRhNDRjZjIxNDQ4@thread.v2&messageId=0&language=de-DE> | E
+ inwahl-PIN zurücksetzen<https://dialin.teams.microsoft.com/usp/pstnconfer
+ encing>\n_________________________________________________________________
+ _______________\n
+UID:040000008200E00074C5B7101A82E00800000000994F3CFBCF8FDA01000000000000000
+ 0100000001866A3188EE8ED4EB0B0FAA5D2791049
+SUMMARY:Refinement Day 2 - Release 24.12
+DTSTART:20240722T070500Z
+DTEND:20240722T100000Z
+CLASS:PUBLIC
+PRIORITY:5
+DTSTAMP:20240416T073242Z
+TRANSP:OPAQUE
+STATUS:CONFIRMED
+LOCATION:Microsoft Teams Meeting
+X-MICROSOFT-CDO-BUSYSTATUS:BUSY
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+X-MICROSOFT-CDO-ALLDAYEVENT:FALSE
+X-MICROSOFT-CDO-IMPORTANCE:1
+X-MICROSOFT-CDO-INSTTYPE:0
+X-MICROSOFT-SKYPETEAMSMEETINGURL:https://teams.microsoft.com/l/meetup-join/
+ 19%3ameeting_ZDFjMWQzNmYtZGZkOS00MDFmLWI5ZjYtNDRhNDRjZjIxNDQ4%40thread.v2/
+ 0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22O
+ id%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d
+X-MICROSOFT-SKYPETEAMSPROPERTIES:{"cid":"19:meeting_ZDFjMWQzNmYtZGZkOS00MDF
+ mLWI5ZjYtNDRhNDRjZjIxNDQ4@thread.v2"\,"rid":0\,"mid":0\,"uid":null\,"priva
+ te":true\,"type":0}
+X-MICROSOFT-ONLINEMEETINGEXTERNALLINK:
+X-MICROSOFT-ONLINEMEETINGINFORMATION:{"OnlineMeetingChannelId":null\,"Onlin
+ eMeetingProvider":3}
+X-MICROSOFT-DONOTFORWARDMEETING:FALSE
+X-MICROSOFT-DISALLOW-COUNTER:FALSE
+X-MICROSOFT-LOCATIONDISPLAYNAME:Microsoft Teams Meeting
+BEGIN:VALARM
+DESCRIPTION:REMINDER
+TRIGGER;RELATED=START:-PT15M
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/static/meetings/refinement-phase-r2412.ics
+++ b/static/meetings/refinement-phase-r2412.ics
@@ -1,0 +1,71 @@
+BEGIN:VCALENDAR
+METHOD:PUBLISH
+PRODID:Microsoft Exchange Server 2010
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:tzone://Microsoft/Utc
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:16010101T000000
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+ORGANIZER;CN=Stephan Bauer:mailto:stephan.bauer@catena-x.net
+DESCRIPTION:Please have a look at https://eclipse-tractusx.github.io/blog f
+ or detailed information about the Release Planning for 24.12\n\n__________
+ ______________________________________________________________________\nMi
+ crosoft Teams Benötigen Sie Hilfe?<https://aka.ms/JoinTeamsMeeting?omkt=d
+ e-DE>\nJetzt an der Besprechung teilnehmen<https://teams.microsoft.com/l/m
+ eetup-join/19%3ameeting_ZTQ5ZWMzNDUtMWQ0My00MDFhLWIxZmYtZjRlNTU2NzFmYmFk%4
+ 0thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce8838
+ 0%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d>\nBesprec
+ hungs-ID: 336 486 915 461\nKennung: bpiHcy\n______________________________
+ __\nFür Organisatoren: Besprechungsoptionen<https://teams.microsoft.com/m
+ eetingOptions/?organizerId=a8b7a5ee-66ff-4695-afa2-08f893d8aaf6&tenantId=1
+ ad22c6d-2f08-4f05-a0ba-e17f6ce88380&threadId=19_meeting_ZTQ5ZWMzNDUtMWQ0My
+ 00MDFhLWIxZmYtZjRlNTU2NzFmYmFk@thread.v2&messageId=0&language=de-DE> | Ein
+ wahl-PIN zurücksetzen<https://dialin.teams.microsoft.com/usp/pstnconferen
+ cing>\n___________________________________________________________________
+ _____________\n
+UID:040000008200E00074C5B7101A82E00800000000CDCE013FCE8FDA01000000000000000
+ 010000000F897806F026016449F59ADEC647D3FB5
+SUMMARY:Refinement Phase - Release 24.12
+DTSTART;VALUE=DATE:20240624
+DTEND;VALUE=DATE:20240729
+CLASS:PUBLIC
+PRIORITY:5
+DTSTAMP:20240416T072529Z
+TRANSP:TRANSPARENT
+STATUS:CONFIRMED
+LOCATION:Microsoft Teams Meeting
+X-MICROSOFT-CDO-BUSYSTATUS:FREE
+X-MICROSOFT-CDO-INTENDEDSTATUS:BUSY
+X-MICROSOFT-CDO-ALLDAYEVENT:TRUE
+X-MICROSOFT-CDO-IMPORTANCE:1
+X-MICROSOFT-CDO-INSTTYPE:0
+X-MICROSOFT-SKYPETEAMSMEETINGURL:https://teams.microsoft.com/l/meetup-join/
+ 19%3ameeting_ZTQ5ZWMzNDUtMWQ0My00MDFhLWIxZmYtZjRlNTU2NzFmYmFk%40thread.v2/
+ 0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22O
+ id%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d
+X-MICROSOFT-SKYPETEAMSPROPERTIES:{"cid":"19:meeting_ZTQ5ZWMzNDUtMWQ0My00MDF
+ hLWIxZmYtZjRlNTU2NzFmYmFk@thread.v2"\,"rid":0\,"mid":0\,"uid":null\,"priva
+ te":true\,"type":0}
+X-MICROSOFT-ONLINEMEETINGEXTERNALLINK:
+X-MICROSOFT-ONLINEMEETINGINFORMATION:{"OnlineMeetingChannelId":null\,"Onlin
+ eMeetingProvider":3}
+X-MICROSOFT-DONOTFORWARDMEETING:FALSE
+X-MICROSOFT-DISALLOW-COUNTER:FALSE
+X-MICROSOFT-LOCATIONDISPLAYNAME:Microsoft Teams Meeting
+BEGIN:VALARM
+DESCRIPTION:REMINDER
+TRIGGER;RELATED=START:-PT18H
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+END:VCALENDAR


### PR DESCRIPTION
## Description

This PR adds the new meetings for the Release Planning 24.12 to our open meeting page. After this PR is merged ... another PR will be created which includes the news blog section.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
