### PR TITLE
fix: adapt Trace-X repo links after merging to monorepo

### DIFF
--- a/utils/products.js
+++ b/utils/products.js
@@ -109,8 +109,7 @@ export const products = [
     productName: "Trace-X",
     productDescription: "The project provides a business application for tracking parts along the supply chain. A high level of transparency across the supplier network enables faster intervention based on a recorded event in the supply chain.",
     githubRepo: [
-      "https://github.com/eclipse-tractusx/traceability-foss-backend",
-      "https://github.com/eclipse-tractusx/traceability-foss-frontend"
+      "https://github.com/eclipse-tractusx/traceability-foss",
     ],
     committers: [
       "https://github.com/ds-mkanal"


### PR DESCRIPTION
## Description

This PR updates the Trace-X information used in our products overview shown in "Community".
Before it referenced the now archived -frontend and -backend repositories.
Frontend and Backend have been merge to a monorepo and archived. 

Fixes #847 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
