### PR TITLE
remove release infos for consolideration

### DIFF
--- a/src/pages/release-information.md
+++ b/src/pages/release-information.md
@@ -1,71 +1,10 @@
 # Release Information
 
-## Introduction
+[Catena-X Standards](https://catena-x.net/de/standard-library) are the foundation for certifying any software product operating in the Catena-X data space. Those standards are the binding reference to obtain a valid certificate. To make adopting the latest Catena-X standards easier, reference implementations are provided through the Eclipse Tractus-X Project. Those Releases are published in a periodic cadence.
 
-[Catena-X Standards](https://catena-x.net/de/standard-library) are the foundation for certifying any software component operating in the Catena-X data space. Those standards are the binding reference to obtain a valid certificate.
+We recommend you to visit the [sig-release repo](https://github.com/eclipse-tractusx/sig-release) and start with the [README.md](https://github.com/eclipse-tractusx/sig-release/blob/main/README.md) for a consolidated package on Release-relevant information.
+In addition you may want to check the recent releases for content which was published so far, and check the Change Log(s) for features, known knowns and compatibility.
 
-To make adopting the latest Catena-X standards easier, reference implementations are provided through the Elipse Tractus-X Project. Releases of these reference implementations happen four times a year using a [calendar versioning](https://calver.org/) scheme, and include the operating system consisting of core services, enablement services, and KITs.
+Goto [sig-release/README.md](https://github.com/eclipse-tractusx/sig-release/blob/main/README.md) for a consolidated package on Release-relevant information.
 
-Please check the [Change Log](/CHANGELOG) for content, known knowns, and backward compatibility since the calendar versioning scheme readily shows the year and month of release.
-
-![Release information cycles chart](@site/static/img/release-information-cycles.png)
-
-## Release Cycle
-
-### Feature Definition (2 Weeks)
-
-- Feature discussions per product team (ongoing through the year)
-- Selection of features targeting for a given release
-- Feature readiness latest by alignment and planing meetings
-
-**Milestone:** Enhancements Freeze (in week 2)
-
-### Feature Work (ca. 10 weeks)
-
-- Feature development and reviews (in sprints / iterations)
-- Unit and integration tests
-
-**Milestone:** Feature / Code Freeze (in week 12)
-
-### Test & Bug Fixing (ca. 4 Weeks)
-
-- System and (E2E) acceptance tests
-- Bug fixing and testing (iterative)
-
-Release Freeze (in week 16 )
-
-### Release
-
-- Enhancement pass all relevant release gates
-- Release communication (e.g. update of change log / release notes)
-
-Release (in week 20)
-
-## The next two Release Cycles in detail
-
-```mermaid
-gantt
-    title Next Release Cycles
-    dateFormat  DD-MM-YYYY
-    todayMarker off
-    
-    section Release v23.12
-    Feature Definition           :a1, 15-07-2023, 07-08-2023
-    Feature Enhancement 07/08/23 :milestone, after a1, 0d
-    Feature Work                 :a2, 07-08-2023, 13-10-2023
-    Feature Freeze 13/10/23      :milestone, 13-10-2023, 0d
-    Test & Bug Fixing            :a3, 13-10-2023, 06-11-2023
-    Release Freeze 06/11/23      :milestone, 06-11-2023, 0d
-    Release                      :a4, 06-11-2023, 08-12-2023
-    Release 08/12/23             :milestone, 08-12-2023, 0d
-    
-    section Release v24.02
-    Feature Definition           :b1, 10-10-2023, 30-10-2023
-    Feature Ready 30/10/23       :milestone, after b1, 0d
-    Feature Work                 :b2, after b1, 08-12-2023
-    Feature Freeze 08/12/23      :milestone, after b2, 0d
-    Test & Bug Fixing            :b3, after b2, 26-01-2024
-    Release Freeze 26/01/24      :milestone, after b3, 0d
-    Release                      :b4, after b3, 23-02-2024
-    Release 23/02/24             :milestone, after b4, 0d
-```
+Visit [tractus-x-release/CHANGELOG.md](https://github.com/eclipse-tractusx/tractus-x-release/blob/main/CHANGELOG.md) for our periodic release info.


### PR DESCRIPTION
We are aligning the information about releases into sig-release. This removes/minimalizes the infos and references the future source of truth.

fixes https://github.com/eclipse-tractusx/sig-release/issues/572

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
