### PR TITLE
chore: rename office hours and align date format

### DIFF
--- a/blog-meeting-minutes/2023-12-06-new-open-meeting-blog.md
+++ b/blog-meeting-minutes/2023-12-06-new-open-meeting-blog.md
@@ -3,7 +3,7 @@ slug: new-open-meeting-blog
 title: New Open Meeting blog
 authors: 
     - sebastian_bezold
-tags: [meeting-minutes, community]
+tags: [meeting-minutes]
 ---
 
 ## New home for open meeting minutes

--- a/blog-meeting-minutes/2024-01-19-community-hour.md
+++ b/blog-meeting-minutes/2024-01-19-community-hour.md
@@ -3,7 +3,7 @@ slug: community-office-hour-2024-01-19
 title: Community Office hour 2024-01-19
 authors: 
     - harald_zierer
-tags: [community-office-hour, meeting-minutes, community]
+tags: [community, meeting-minutes]
 ---
 
 ## office hour meeting minutes

--- a/blog-meeting-minutes/2024-01-26-community-hour.md
+++ b/blog-meeting-minutes/2024-01-26-community-hour.md
@@ -3,7 +3,7 @@ slug: community-office-hour-2024-01-26
 title: Community Office hour 2024-01-26
 authors: 
     - almadi_gabor
-tags: [community-office-hour, meeting-minutes, community]
+tags: [community, meeting-minutes]
 ---
 
 ## office hour meeting minutes

--- a/blog-meeting-minutes/2024-02-02-community-hour.md
+++ b/blog-meeting-minutes/2024-02-02-community-hour.md
@@ -3,7 +3,7 @@ slug: community-office-hour-2024-02-02
 title: Community Office Hour 2024-02-02
 authors: 
     - fabian_gruen
-tags: [community-office-hour, meeting-minutes, community]
+tags: [community, meeting-minutes]
 ---
 
 ## office hour meeting minutes

--- a/blog-meeting-minutes/2024-02-09-community-hour.md
+++ b/blog-meeting-minutes/2024-02-09-community-hour.md
@@ -3,7 +3,7 @@ slug: community-office-hour-2024-02-09
 title: Community Office Hour 2024-02-09
 authors: 
     - tomasz_barwicki
-tags: [community-office-hour, meeting-minutes, community]
+tags: [community, meeting-minutes]
 ---
 
 ## office hour meeting minutes

--- a/blog-meeting-minutes/2024-02-16-community-hour.md
+++ b/blog-meeting-minutes/2024-02-16-community-hour.md
@@ -3,7 +3,7 @@ slug: community-office-hour-2024-02-16
 title: Community Office Hour 2024-02-16
 authors: 
     - sebastian_bezold
-tags: [community-office-hour, meeting-minutes, community]
+tags: [community, meeting-minutes]
 ---
 
 ## Office Hour meeting minutes

--- a/blog-meeting-minutes/2024-02-23-community-hour.md
+++ b/blog-meeting-minutes/2024-02-23-community-hour.md
@@ -3,7 +3,7 @@ slug: community-office-hour-2024-02-23
 title: Community Office Hour 2024-02-23
 authors: 
     - sebastian_bezold
-tags: [community-office-hour, meeting-minutes, community]
+tags: [community, meeting-minutes]
 ---
 
 ## Office Hour meeting minutes

--- a/blog-meeting-minutes/2024-02-29-security-hour.md
+++ b/blog-meeting-minutes/2024-02-29-security-hour.md
@@ -3,7 +3,7 @@ slug: security-office-hour-2024-02-29
 title: Security Office Hour 2024-02-29
 authors: 
     - daniel_dilger
-tags: [meeting-minutes, community, security]
+tags: [security, meeting-minutes]
 ---
 
 ## Security Office Hour meeting minutes

--- a/blog-meeting-minutes/2024-03-01-community-hour.md
+++ b/blog-meeting-minutes/2024-03-01-community-hour.md
@@ -3,7 +3,7 @@ slug: community-office-hour-2024-03-01
 title: Community Office Hour 2024-03-01
 authors: 
     - harald_zierer
-tags: [community-office-hour, meeting-minutes, community]
+tags: [community, meeting-minutes]
 ---
 
 ## Tractus-X Office Hour meeting minutes

--- a/blog-meeting-minutes/2024-03-08-community-hour.md
+++ b/blog-meeting-minutes/2024-03-08-community-hour.md
@@ -3,7 +3,7 @@ slug: community-office-hour-2024-03-08
 title: Community Office Hour 2024-03-08
 authors: 
     - almadi_gabor
-tags: [community-office-hour, meeting-minutes, community]
+tags: [community, meeting-minutes]
 ---
 
 ## Office Hour meeting minutes

--- a/blog-meeting-minutes/2024-03-14-security-hour.md
+++ b/blog-meeting-minutes/2024-03-14-security-hour.md
@@ -3,7 +3,7 @@ slug: security-office-hour-2024-03-14
 title: Security Office Hour 2024-03-14
 authors: 
     - daniel_dilger
-tags: [meeting-minutes, community, security]
+tags: [security, meeting-minutes]
 ---
 
 ## Security Office Hour meeting minutes

--- a/blog-meeting-minutes/2024-03-15-community-hour.md
+++ b/blog-meeting-minutes/2024-03-15-community-hour.md
@@ -3,7 +3,7 @@ slug: community-office-hour-2024-03-15
 title: Community Office Hour 2024-03-15
 authors:
     - fabian_gruen
-tags: [community-office-hour, meeting-minutes, community]
+tags: [community, meeting-minutes]
 ---
 
 ## Office Hour meeting minutes

--- a/blog-meeting-minutes/2024-03-22-community-hour.md
+++ b/blog-meeting-minutes/2024-03-22-community-hour.md
@@ -3,7 +3,7 @@ slug: community-office-hour-2024-03-22
 title: Community Office Hour 2024-03-22
 authors:
     - sebastian_bezold
-tags: [community-office-hour, meeting-minutes, community]
+tags: [community, meeting-minutes]
 ---
 
 ## Office Hour meeting minutes

--- a/blog-meeting-minutes/2024-03-28-security-hour.md
+++ b/blog-meeting-minutes/2024-03-28-security-hour.md
@@ -3,7 +3,7 @@ slug: security-office-hour-2024-03-28
 title: Security Office Hour 2024-03-28
 authors: 
     - rohan_krishnamurthy
-tags: [meeting-minutes, community, security]
+tags: [security, meeting-minutes]
 ---
 
 ## Security Office Hour meeting minutes

--- a/blog-meeting-minutes/2024-04-05-community-hour.md
+++ b/blog-meeting-minutes/2024-04-05-community-hour.md
@@ -3,7 +3,7 @@ slug: community-office-hour-2024-04-05
 title: Community Office Hour 2024-04-05
 authors:
   - sebastian_bezold
-tags: [community-office-hour, meeting-minutes, community]
+tags: [community, meeting-minutes]
 
 ---
 

--- a/blog-meeting-minutes/2024-04-11-security-hour.md
+++ b/blog-meeting-minutes/2024-04-11-security-hour.md
@@ -3,7 +3,7 @@ slug: security-office-hour-2024-04-11
 title: Security Office Hour 2024-04-11
 authors: 
     - rohan_krishnamurthy
-tags: [meeting-minutes, community, security]
+tags: [meeting-minutes, security]
 ---
 
 ## Security Office Hour meeting minutes

--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -23,7 +23,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
              meetingLink="/meetings/office-hour.ics"
              additionalLinks={
                 [
-                    {title: 'meeting minutes', url: 'https://eclipse-tractusx.github.io/community/meeting-minutes/tags/community-office-hour'},
+                    {title: 'meeting minutes', url: 'https://eclipse-tractusx.github.io/community/meeting-minutes/tags/community'},
                 ]
              }
 />


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Please describe your PR: 
- renamed the "Office hour" to "Community office hour" as the name was ambiguous in the meantime
- renamed the community office hour files accordingly
- adjusted all dates to the international date format (YYYY-MM-DD) to avoid confusions

preview:
![image](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/101179191/658270fb-df4f-4b1d-a680-f3e825a289bc)


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
