### PR TITLE
doc(news blog): add news blog for open planning 24.12

### DIFF
--- a/blog/2024-07-31-open-planning-r24.12.mdx
+++ b/blog/2024-07-31-open-planning-r24.12.mdx
@@ -1,0 +1,122 @@
+---
+title: Tractus-X Open Planning R24.12
+description: The Eclipse Tractus-X Open Planning Days - Empowering the Catena-X Data Space
+slug: open-planning-r24-12
+date: 2024-04-16T11:00
+hide_table_of_contents: false
+authors:
+  - name: Stephan Bauer
+    title: Platform Domain Manager
+    url: https://github.com/stephanbcbauer
+    image_url: https://github.com/stephanbcbauer.png
+    email: stephan.bauer@catena-x.net
+---
+
+![eclipse tractus x logo](@site/static/img/Tractus-X_openplanning.png)
+
+Dear Tractus-X Community Members 🎉,
+
+we are excited to extend this invitation to you for our upcoming Tractus-X meetings. These meetings are a great opportunity for both business stakeholders and developers to contribute and collaborate on the future of Tractus-X.
+Please feel free to forward this post to anyone interested in contributing, whether in planning or development.
+
+## Open Meetings
+
+- **[Refinement Phase - Release 24.12](./open-planning-r24-12#refinement-phase---release-2412)**
+- **[Refinement Day 1 - Release 24.12](./open-planning-r24-12#refinement-day-1---release-2412)**
+- **[Draft Feature Freeze - Release 24.12](./open-planning-r24-12#draft-feature-freeze---release-2412)**
+- **[Refinement Day 2 - Release 24.12](./open-planning-r24-12#refinement-day-2---release-2412)**
+- **[Open Planning Days - Release 24.12](./open-planning-r24-12#open-planning-days---release-2412)**
+
+
+<!--truncate-->
+
+### Refinement Phase - Release 24.12
+
+Please be aware that the Refinement Phase is to keep you aware of the overall timeline during the Release Process and does not constitute an actual meeting. It serves informational
+purposes only. During this time, the necessary people/groups should come together and work (refine) the future features. Feature authors take care of organising appointments and
+communicating with the relevant contacts themselves. The Teams Session link can be used. Be aware: The link and the shared content is available to everyone.
+
+- *Monday, 24. June 2024 to Sunday, 28. July 2024 (CEST)*
+- [open meeting](https://eclipse-tractusx.github.io/community/open-meetings/#Refinement%20Phase%20-%20Release%2024.12)
+
+:::info
+The detailed agenda will follow as soon as possible
+:::
+
+### Refinement Day 1 - Release 24.12
+
+This event is organised and moderated by the Catena-X Association. Based on a predefined agenda (depending on the features on the board), individual dependencies are discussed and
+also documented directly on the feature. If the refinement of the features has already been carried out 'in the refinement phase' and the Definition of Entry (DoE) has already reached,
+this meeting can also be used as synchronisation.
+
+- *Monday, 1. July 2024 from 09:05 to 12:00 (CEST)*
+- [open meeting](https://eclipse-tractusx.github.io/community/open-meetings/#Refinement%20Day%201%20-%20Release%2024.12)
+
+:::info
+The detailed agenda will follow as soon as possible
+:::
+
+### Draft Feature Freeze - Release 24.12
+
+This event is organised and moderated by the Catena-X Association. Until this date, feature proposal can be submitted to the planning board (in GitHub). The current status (as an
+interim status in the refinement phase) of the previous feature proposals will also be discussed at this meeting.
+
+- *Friday, 12. July 2024 from 09:05 to 12:00 (CEST)*
+- [open meeting](https://eclipse-tractusx.github.io/community/open-meetings/#Draft%20Feature%20Freeze%20-%20Release%2024.12)
+
+:::info
+The detailed agenda will follow as soon as possible
+:::
+
+### Refinement Day 2 - Release 24.12
+
+This event is organised and moderated by the Catena-X Association. Based on a predefined agenda (depending on the features on the board), individual dependencies are discussed and
+also documented directly on the feature. If the refinement of the features has already been carried out 'in the refinement phase' and the Definition of Entry (DoE) has already reached,
+this meeting can also be used as synchronisation.
+
+- *Monday, 22. July 2024 from 09:05 to 12:00 (CEST)*
+- [open meeting](https://eclipse-tractusx.github.io/community/open-meetings/#Refinement%20Day%202%20-%20Release%2024.12)
+
+:::info
+The detailed agenda will follow as soon as possible
+:::
+
+### Open Planning Days - Release 24.12
+
+Open Planning, hosted by the Catena-X association. The goal for this meeting is planning of the intended work content for the next release - which contains also preparation of future
+release content, refactoring, general architectural work, tool & process improvements and feature planning for the next Tractus-X release.
+
+- *Wednesday, 31. Jul 2024 and Thursday, 01. Aug 2024 from 08:05 to 12:00 (CEST)*
+- [open meeting](https://eclipse-tractusx.github.io/community/open-meetings/#Open%20Planning%20Days%20-%20Release%2024.12)
+
+:::info
+The detailed agenda will follow as soon as possible
+:::
+
+## Staying Informed
+
+To stay updated on any changes or additional information, please subscribe to our mailing list. A great way to keep informed is through the provided [Tractus-X Development Mailing List RSS Feed](https://www.eclipse.org/lists/tractusx-dev/maillist.rss).
+
+:::tip
+
+Here, you can also find previous messages for reference.
+
+:::
+
+## Further Information
+
+For more details about the planning process and what these meetings entail, please refer to our guide on [Open Refinement and Planning in Open Source Communities](https://github.com/eclipse-tractusx/sig-release/blob/main/docs/open-refinement-and-planning.md)
+ and of course the sig-release [README](https://github.com/eclipse-tractusx/sig-release/blob/main/README.md)
+
+## Stay Connected
+
+Follow our [news section](https://eclipse-tractusx.github.io/blog) and join our [Tractus-X mailing list](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute/#dev-mailinglist)
+and be part of our [Matrix Chat from Eclipse Tractus-X](https://chat.eclipse.org/#/room/#tools.tractus-x:matrix.eclipse.org)
+
+For more details about Tractus-X, visit the official [Eclipse Tractus-X Project Page](https://projects.eclipse.org/projects/automotive.tractusx).
+
+---
+
+We look forward to your participation and contributions in shaping the future of Tractus-X.
+
+🚀 **The Tractus-X Team**

--- a/blog/2024-07-31-open-planning-r24.12.mdx
+++ b/blog/2024-07-31-open-planning-r24.12.mdx
@@ -39,15 +39,15 @@ communicating with the relevant contacts themselves. The Teams Session link can 
 - *Monday, 24. June 2024 to Sunday, 28. July 2024 (CEST)*
 - [open meeting](https://eclipse-tractusx.github.io/community/open-meetings/#Refinement%20Phase%20-%20Release%2024.12)
 
-:::info
-The detailed agenda will follow as soon as possible
-:::
-
 ### Refinement Day 1 - Release 24.12
 
 This event is organised and moderated by the Catena-X Association. Based on a predefined agenda (depending on the features on the board), individual dependencies are discussed and
 also documented directly on the feature. If the refinement of the features has already been carried out 'in the refinement phase' and the Definition of Entry (DoE) has already reached,
 this meeting can also be used as synchronisation.
+
+:::info
+Both dates "Refinement Day 1 and 2" will take place.
+:::
 
 - *Monday, 1. July 2024 from 09:05 to 12:00 (CEST)*
 - [open meeting](https://eclipse-tractusx.github.io/community/open-meetings/#Refinement%20Day%201%20-%20Release%2024.12)
@@ -59,7 +59,7 @@ The detailed agenda will follow as soon as possible
 ### Draft Feature Freeze - Release 24.12
 
 This event is organised and moderated by the Catena-X Association. Until this date, feature proposal can be submitted to the planning board (in GitHub). The current status (as an
-interim status in the refinement phase) of the previous feature proposals will also be discussed at this meeting.
+interim status in the refinement phase) of the previous feature proposals will also be discussed during this meeting.
 
 - *Friday, 12. July 2024 from 09:05 to 12:00 (CEST)*
 - [open meeting](https://eclipse-tractusx.github.io/community/open-meetings/#Draft%20Feature%20Freeze%20-%20Release%2024.12)
@@ -74,6 +74,10 @@ This event is organised and moderated by the Catena-X Association. Based on a pr
 also documented directly on the feature. If the refinement of the features has already been carried out 'in the refinement phase' and the Definition of Entry (DoE) has already reached,
 this meeting can also be used as synchronisation.
 
+:::info
+Both dates "Refinement Day 1 and 2" will take place.
+:::
+
 - *Monday, 22. July 2024 from 09:05 to 12:00 (CEST)*
 - [open meeting](https://eclipse-tractusx.github.io/community/open-meetings/#Refinement%20Day%202%20-%20Release%2024.12)
 
@@ -83,7 +87,7 @@ The detailed agenda will follow as soon as possible
 
 ### Open Planning Days - Release 24.12
 
-Open Planning, hosted by the Catena-X association. The goal for this meeting is planning of the intended work content for the next release - which contains also preparation of future
+Open Planning, hosted by the Catena-X Association. The goal for this meeting is planning of the intended work content for the next release - which contains also preparation of future
 release content, refactoring, general architectural work, tool & process improvements and feature planning for the next Tractus-X release.
 
 - *Wednesday, 31. Jul 2024 and Thursday, 01. Aug 2024 from 08:05 to 12:00 (CEST)*
@@ -95,13 +99,7 @@ The detailed agenda will follow as soon as possible
 
 ## A great way to STAY informed
 
-To stay updated on any changes or additional information, please subscribe to our mailing list. A great way to keep informed is through the provided [Tractus-X Development Mailing List RSS Feed](https://www.eclipse.org/lists/tractusx-dev/maillist.rss).
-
-:::tip
-
-Here, you can also find previous messages for reference.
-
-:::
+To stay updated on any changes or additional information, please subscribe to our mailing list. A great way to stay informed is through the provided [Tractus-X Development Mailing List RSS Feed](https://www.eclipse.org/lists/tractusx-dev/maillist.rss) (Here, you can also find previous messages for reference.).
 
 ## Further Information
 

--- a/blog/2024-07-31-open-planning-r24.12.mdx
+++ b/blog/2024-07-31-open-planning-r24.12.mdx
@@ -12,7 +12,7 @@ authors:
     email: stephan.bauer@catena-x.net
 ---
 
-![eclipse tractus x logo](@site/static/img/Tractus-X_openplanning.png)
+![eclipse tractus x logo](/img/Tractus-X_openplanning.png)
 
 Dear Tractus-X Community Members 🎉,
 
@@ -21,11 +21,11 @@ Please feel free to forward this post to anyone interested in contributing, whet
 
 ## Open Meetings
 
-- **[Refinement Phase - Release 24.12](./open-planning-r24-12#refinement-phase---release-2412)**
-- **[Refinement Day 1 - Release 24.12](./open-planning-r24-12#refinement-day-1---release-2412)**
-- **[Draft Feature Freeze - Release 24.12](./open-planning-r24-12#draft-feature-freeze---release-2412)**
-- **[Refinement Day 2 - Release 24.12](./open-planning-r24-12#refinement-day-2---release-2412)**
-- **[Open Planning Days - Release 24.12](./open-planning-r24-12#open-planning-days---release-2412)**
+- **[Refinement Phase - Release 24.12](#refinement-phase---release-2412)**
+- **[Refinement Day 1 - Release 24.12](#refinement-day-1---release-2412)**
+- **[Draft Feature Freeze - Release 24.12](#draft-feature-freeze---release-2412)**
+- **[Refinement Day 2 - Release 24.12](#refinement-day-2---release-2412)**
+- **[Open Planning Days - Release 24.12](#open-planning-days---release-2412)**
 
 
 <!--truncate-->
@@ -93,7 +93,7 @@ release content, refactoring, general architectural work, tool & process improve
 The detailed agenda will follow as soon as possible
 :::
 
-## Staying Informed
+## A great way to STAY informed
 
 To stay updated on any changes or additional information, please subscribe to our mailing list. A great way to keep informed is through the provided [Tractus-X Development Mailing List RSS Feed](https://www.eclipse.org/lists/tractusx-dev/maillist.rss).
 

--- a/utils/newsTitles.js
+++ b/utils/newsTitles.js
@@ -1,5 +1,10 @@
 export const newsTitles = [
   {
+    date: "31.07.2024",
+    title: "Tractus-X Open Planning R24.12",
+    blogLink: "/blog/open-planning-r24-12"
+  },
+  {
     date: "08.03.2024",
     title: "Tractus-X 24.03 available now",
     blogLink: "/blog/new-release-2403"


### PR DESCRIPTION
## Description

This PR adds the new entry for our open planing for release 24.12. The agenda for each meeting is not included because it is dependent on the features on the Release Planning Board (GitHub).

<img width="1919" alt="image" src="https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/669e852a-8155-4661-b53f-9343dc83f9cb">

<img width="1920" alt="image" src="https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/c5c5493a-aa7b-4537-96ee-eb1a80f64501">

<img width="1920" alt="image" src="https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/assets/84396022/adc1cf8a-9a38-4a41-a1f9-91c15ad1702f">

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
