### PR TITLE
docs: add TRG for UX/UI styleguide

### DIFF
--- a/docs/release/trg-0/trg-1-09.md
+++ b/docs/release/trg-0/trg-1-09.md
@@ -3,39 +3,59 @@ title: TRG 1.09 - UX consistency / Styleguide for UI
 sidebar_position: 1
 ---
 
-:::caution
-Proposed release date: 15th of January 2024
-:::
+### Introduction
+This document outlines the criteria for a release gateway focused on ensuring that business applications with user interfaces adhere to the established UI/UX styleguide. The gateway serves as a quality checkpoint before the application is released to production or moved to the next stage of deployment.
+
+### Objective
+To ensure consistency, usability, and adherence to design standards across all user interfaces within the business application.
+
+### Change History
 
 | Status | Created     | Post-History                                          |
 |--------|-------------|-------------------------------------------------------|
 | Draft  | 10-Jan-2024 | Transferred from Release Acceptance Criteria into TRG |
+| Draft  | 25-April-2024 | Added new styleguide gateway criterias - initial version |
 
-## Why
 
-Ensuring UX consistency through a style guideline is essential for a unified and user-friendly experience across front end modules.
+### Criteria for Release Gateway (Basic)
 
-## Description
+1. **Styleguide Compliance**:
+- [ ] All user interface elements must match the predefined styles set in the UI/UX styleguide. This includes fonts, colors, button styles, input fields, and layout grids.
+- [ ] Icons and imagery should be consistent with the styleguide specifications. (note that images and icons must be open source compliant and license files are needed. Find more details under xxxxxx)
 
-- User Interfaces **should** align with the Tractus-X Style Guidelines
+2. **Responsiveness and Compatibility**:
+- [ ] The application must be fully responsive and provide a seamless experience across different devices and screen sizes.
+- [ ] The application must be tested with mutliple browser - in case any browsers are not supported the same must be documented.
 
-> User interface style review has been executed.
-> Review feedback (if existing) got incorporated.
-> All findings are assessed.
-> All findings (high/very high) are fixed or cleaned up (evidence by re-review).
-> Approval of the application CX Style conformity is available (given by the review owner).
+3. **Accessibility**:
+- [ ] The application must meet the minimum accessibility standards (e.g., WCAG 2.1) as defined in the styleguide.
+- [ ] Optional: All user interface components must be navigable and usable with keyboard-only controls.
+- [ ] Optional: Screen reader compatibility must be tested and ensured.
 
-## Best Practice
+4. **User Experience**:
+- [ ] The application's user flow must align with the user experience outlined in the styleguide.
+- [ ] Interactive elements must provide feedback to the user, such as hover states, active states, and disabled states, as per the styleguide.
+- [ ] The application must have a user help area which is linked to the current deployed application version.
+- [ ] The Application must have a loading state or spinner component that indicates when data is being fetched or processed.
+- [ ] The application must have notification or alert component that displays important messages or updates to the user. (success as well as errors)
 
-- Obtain approval from the Style Guideline Owner, prior to Gate review
-- Get in contact with Style Guideline Owner and expect a review loop
+5. **Typography and Readability**:
+- [ ] Text must adhere to the styleguide's typography standards, including font sizes, line heights, and font weights.
+- [ ] Text contrast must meet the minimum contrast ratios for readability.
 
-Style Components:
+6. **Localization and Internationalization**:
+- [ ] The application/user interface must support multiple languages, allowing users to switch between different language options.
+- [ ] Text in the user interface must be properly localized and displayed in the correct format for the target audience.
 
-- LINK to Style Guideline
-- LINK to FrontEnd validations (will be added asap)
+7. **Animation and Transitions**:
+- [ ] Any animations or transitions must be smooth, enhance the user experience, and conform to the styleguide's principles.
 
-> EXTERNAL LINKS
+8. **Others**:
+- [ ] The application should include a footer component that contains important links, such as terms of service, privacy policy, and contact information
+
+---
+
+### EXTERNAL LINKS
 > CX references
 > Offical style guide accessible on Catena-X website
 

--- a/docs/release/trg-0/trg-1-09.md
+++ b/docs/release/trg-0/trg-1-09.md
@@ -4,59 +4,69 @@ sidebar_position: 1
 ---
 
 ### Introduction
-This document outlines the criteria for a release gateway focused on ensuring that business applications with user interfaces adhere to the established UI/UX styleguide. The gateway serves as a quality checkpoint before the application is released to production or moved to the next stage of deployment.
+The purpose of this TRG (Technical Requirements Guide) is to ensure that business applications with user interfaces adhere to the established UI/UX styleguide. It outlines all the relevant criteria that must be checked when releasing a new GitHub version. A crosscheck with every PullRequest is not just optional, but it is a "MUST" criteria to ensure the quality and consistency of the user interfaces of each product/component. This step is crucial in maintaining the overall standard and enhancing as well as standardizing the user experience.
 
 ### Objective
 To ensure consistency, usability, and adherence to design standards across all user interfaces within the business application.
 
 ### Change History
-
 | Status | Created     | Post-History                                          |
 |--------|-------------|-------------------------------------------------------|
 | Draft  | 10-Jan-2024 | Transferred from Release Acceptance Criteria into TRG |
 | Draft  | 25-April-2024 | Added new styleguide gateway criterias - initial version |
 
 
-### Criteria for Release Gateway (Basic)
+# TRG Document - Release Gateway Criteria
+## Introduction
+This document outlines the criteria for a release gateway focused on ensuring that business applications with user interfaces adhere to the established UI/UX styleguide. The gateway serves as a quality checkpoint before the application is released to production or moved to the next stage of deployment.
 
-1. **Styleguide Compliance**:
-- [ ] All user interface elements must match the predefined styles set in the UI/UX styleguide. This includes fonts, colors, button styles, input fields, and layout grids.
-- [ ] Icons and imagery should be consistent with the styleguide specifications. (note that images and icons must be open source compliant and license files are needed. Find more details under xxxxxx)
+## Objective
+The objective of the release gateway is to ensure consistency, usability, and adherence to design standards across all user interfaces within the business application.
 
-2. **Responsiveness and Compatibility**:
-- [ ] The application must be fully responsive and provide a seamless experience across different devices and screen sizes.
-- [ ] The application must be tested with mutliple browser - in case any browsers are not supported the same must be documented.
+## Criteria for Release Gateway (Basic)
 
-3. **Accessibility**:
-- [ ] The application must meet the minimum accessibility standards (e.g., WCAG 2.1) as defined in the styleguide.
-- [ ] Optional: All user interface components must be navigable and usable with keyboard-only controls.
-- [ ] Optional: Screen reader compatibility must be tested and ensured.
+### Styleguide Compliance
+- All user interface elements must match the predefined styles set in the UI/UX styleguide. This includes fonts, colors, button styles, input fields, and layout grids.
+- Icons and imagery should be consistent with the styleguide specifications. (note that images and icons must be open source compliant and license files are needed)
+  - https://github.com/catenax-ng/tx-portal-assets/blob/main/docs/developer/Technical%20Documentation/Others/Images%2C%20Graphics%20and%20Diagrams.md
 
-4. **User Experience**:
-- [ ] The application's user flow must align with the user experience outlined in the styleguide.
-- [ ] Interactive elements must provide feedback to the user, such as hover states, active states, and disabled states, as per the styleguide.
-- [ ] The application must have a user help area which is linked to the current deployed application version.
-- [ ] The Application must have a loading state or spinner component that indicates when data is being fetched or processed.
-- [ ] The application must have notification or alert component that displays important messages or updates to the user. (success as well as errors)
+### Responsiveness and Compatibility
+- The application must be fully responsive and provide a seamless experience across different devices and screen sizes.
+- The application must be tested with multiple browsers - in case any browsers are not supported, the same must be documented.
 
-5. **Typography and Readability**:
-- [ ] Text must adhere to the styleguide's typography standards, including font sizes, line heights, and font weights.
-- [ ] Text contrast must meet the minimum contrast ratios for readability.
+### Accessibility
+- The application must meet the minimum accessibility standards (e.g., WCAG 2.1) as defined in the styleguide.
+- Optional: All user interface components must be navigable and usable with keyboard-only controls.
+- Optional: Screen reader compatibility must be tested and ensured.
 
-6. **Localization and Internationalization**:
-- [ ] The application/user interface must support multiple languages, allowing users to switch between different language options.
-- [ ] Text in the user interface must be properly localized and displayed in the correct format for the target audience.
+### User Experience
+- The application's user flow must align with the user experience outlined in the styleguide.
+- Interactive elements must provide feedback to the user, such as hover states, active states, and disabled states, as per the styleguide.
+- The application must have a user help area which is linked to the current deployed application version.
+- The application must have a loading state or spinner component that indicates when data is being fetched or processed.
+- The application must have a mechanism in place to prevent the user interface from being triggered a second time by the user while running loading processes (POST Data). This is important to avoid any unintended actions or disruptions caused by multiple triggers. By implementing this safeguard, the application can ensure a smooth and reliable user experience during loading processes.
+- The application must have a notification or alert component that displays important messages or updates to the user (success as well as errors).
 
-7. **Animation and Transitions**:
-- [ ] Any animations or transitions must be smooth, enhance the user experience, and conform to the styleguide's principles.
+### Typography and Readability
+- Text must adhere to the styleguide's typography standards, including font sizes, line heights, and font weights.
+- Text contrast must meet the minimum contrast ratios for readability.
 
-8. **Others**:
-- [ ] The application should include a footer component that contains important links, such as terms of service, privacy policy, and contact information
+### Localization and Internationalization
+- The application/user interface must support multiple languages, allowing users to switch between different language options.
+- Text in the user interface must be properly localized and displayed in the correct format for the target audience.
+
+### Animation and Transitions
+- Any animations or transitions must be smooth, enhance the user experience, and conform to the styleguide's principles.
+
+### Others
+- The application should include a footer component that contains important links, such as terms of service, privacy policy, and contact information.
 
 ---
 
 ### EXTERNAL LINKS
-> CX references
-> Offical style guide accessible on Catena-X website
+> Source code: https://github.com/eclipse-tractusx/portal-shared-components.git  
+> NPM library: https://www.npmjs.com/package/@catena-x/portal-shared-components  
+> Storybook: https://eclipse-tractusx.github.io/portal-shared-components/  
+> Image, Graphics & Diagrams: https://github.com/catenax-ng/tx-portal-assets/blob/main/docs/developer/Technical%20Documentation/Others/Images%2C%20Graphics%20and%20Diagrams.md  
 
 Please note, you can use the official public available CX shared component library (react supported) to easily develop applications that are in-line with the CX style guidelines.

--- a/docs/release/trg-9/_category_.json
+++ b/docs/release/trg-9/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "TRG 9 - UX/UX Styleguide"
+}

--- a/docs/release/trg-9/trg-9-01.md
+++ b/docs/release/trg-9/trg-9-01.md
@@ -6,12 +6,12 @@ sidebar_position: 1
 | Status | Created       | Post-History                                             |
 |--------|---------------|----------------------------------------------------------|
 | Active | 22-Jul-2024   | Finalize TRG                                             |
-| Draft  | 10-Jan-2024   | Transferred from Release Acceptance Criteria into TRG    |
 | Draft  | 25-April-2024 | Added new styleguide criteria - initial version          |
+| Draft  | 10-Jan-2024   | Transferred from Release Acceptance Criteria into TRG    |
 
 ## Introduction
 
-The purpose of this guideline is to ensure that business applications with user interfaces adhere to the established UI/UX styleguide. It outlines all the relevant criteria that must be checked when releasing a new product version. A crosscheck with every pull request is not just optional, but it is a "MUST" criteria to ensure the quality and consistency of the user interfaces of each product/component. This step is crucial in maintaining the overall standard and enhancing as well as standardizing the user experience.
+The purpose of this guideline is to ensure that business applications with user interfaces adhere to the established UI/UX styleguide which is collected in the [Portal Shared Components](https://github.com/eclipse-tractusx/portal-shared-components.git). It outlines all the relevant criteria that must be checked when releasing a new product version. A crosscheck with every pull request is not just optional, but it is a "MUST" criteria to ensure the quality and consistency of the user interfaces of each product/component. This step is crucial in maintaining the overall standard and enhancing as well as standardizing the user experience.
 
 ## Objective
 
@@ -21,8 +21,9 @@ The objective is to ensure consistency, usability, and adherence to design stand
 
 ### Styleguide Compliance
 
-- All user interface elements must match the predefined styles set in the UI/UX styleguide. This includes fonts, colors, button styles, input fields, and layout grids.
-- Icons and imagery should be consistent with the styleguide specifications. (note that images and icons must be open source compliant and license files are needed)
+- All user interface elements must match the predefined styles. This includes fonts, colors, button styles, input fields, and layout grids.
+  - [Storybook](https://eclipse-tractusx.github.io/portal-shared-components)
+- Icons and imagery should be consistent (note that images and icons must be open source compliant and license files are needed)
   - [Image, Graphics & Diagrams](https://github.com/eclipse-tractusx/portal-assets/blob/v2.0.0/docs/developer/Technical%20Documentation/Others/Images%2C%20Graphics%20and%20Diagrams.md)
 
 ### Responsiveness and Compatibility
@@ -32,7 +33,7 @@ The objective is to ensure consistency, usability, and adherence to design stand
 
 ### Accessibility
 
-- The application must meet the minimum accessibility standards (e.g., WCAG 2.1) as defined in the styleguide.
+- The application must meet the minimum accessibility standards (e.g., WCAG 2.1).
 - Optional: All user interface components must be navigable and usable with keyboard-only controls.
 - Optional: Screen reader compatibility must be tested and ensured.
 
@@ -65,11 +66,11 @@ The objective is to ensure consistency, usability, and adherence to design stand
 
 ---
 
-### EXTERNAL LINKS
+### STYLEGUIDE RELATED LINKS
 
-> - [Source code](https://github.com/eclipse-tractusx/portal-shared-components.git)
-> - [NPM library](https://www.npmjs.com/package/@catena-x/portal-shared-components)
 > - [Storybook](https://eclipse-tractusx.github.io/portal-shared-components)
+> - [NPM library](https://www.npmjs.com/package/@catena-x/portal-shared-components)
+> - [Source code](https://github.com/eclipse-tractusx/portal-shared-components.git)
 > - [Image, Graphics & Diagrams](https://github.com/eclipse-tractusx/portal-assets/blob/v2.0.0/docs/developer/Technical%20Documentation/Others/Images%2C%20Graphics%20and%20Diagrams.md)
 
 Please note, you can use the publicly available [Portal Shared Components NPM library](https://www.npmjs.com/package/@catena-x/portal-shared-components) (React supported) to easily develop applications that are in-line with the Tractus-X style guidelines.

--- a/docs/release/trg-9/trg-9-01.md
+++ b/docs/release/trg-9/trg-9-01.md
@@ -23,6 +23,7 @@ The objective is to ensure consistency, usability, and adherence to design stand
 
 - All user interface elements must match the predefined styles. This includes fonts, colors, button styles, input fields, and layout grids.
   - [Storybook](https://eclipse-tractusx.github.io/portal-shared-components)
+  - You can use the publicly available Portal Shared Components NPM library - React supported - to easily develop applications that are in-line with the Tractus-X style guidelines. If you are using a framework other than React, you should use the Shared Components as a base and adapt their style to match the styleguide.
 - Icons and imagery should be consistent (note that images and icons must be open source compliant and license files are needed)
   - [Image, Graphics & Diagrams](https://github.com/eclipse-tractusx/portal-assets/blob/v2.0.0/docs/developer/Technical%20Documentation/Others/Images%2C%20Graphics%20and%20Diagrams.md)
 
@@ -63,6 +64,7 @@ The objective is to ensure consistency, usability, and adherence to design stand
 ### Others
 
 - The application should include a footer component that contains important links, such as terms of service, privacy policy, and contact information.
+  - The [legal notice for frontend components described in TRG 7.06](../trg-7/trg-7-06.md#frontend-components) must be implemented.
 
 ---
 
@@ -72,5 +74,3 @@ The objective is to ensure consistency, usability, and adherence to design stand
 > - [NPM library](https://www.npmjs.com/package/@catena-x/portal-shared-components)
 > - [Source code](https://github.com/eclipse-tractusx/portal-shared-components.git)
 > - [Image, Graphics & Diagrams](https://github.com/eclipse-tractusx/portal-assets/blob/v2.0.0/docs/developer/Technical%20Documentation/Others/Images%2C%20Graphics%20and%20Diagrams.md)
-
-Please note, you can use the publicly available [Portal Shared Components NPM library](https://www.npmjs.com/package/@catena-x/portal-shared-components) (React supported) to easily develop applications that are in-line with the Tractus-X style guidelines.

--- a/docs/release/trg-9/trg-9-01.md
+++ b/docs/release/trg-9/trg-9-01.md
@@ -1,45 +1,43 @@
 ---
-title: TRG 1.09 - UX consistency / Styleguide for UI
+title: TRG 9.01 - UX consistency / Styleguide for UI
 sidebar_position: 1
 ---
 
-### Introduction
-The purpose of this TRG (Technical Requirements Guide) is to ensure that business applications with user interfaces adhere to the established UI/UX styleguide. It outlines all the relevant criteria that must be checked when releasing a new GitHub version. A crosscheck with every PullRequest is not just optional, but it is a "MUST" criteria to ensure the quality and consistency of the user interfaces of each product/component. This step is crucial in maintaining the overall standard and enhancing as well as standardizing the user experience.
+| Status | Created       | Post-History                                             |
+|--------|---------------|----------------------------------------------------------|
+| Active | 22-Jul-2024   | Finalize TRG                                             |
+| Draft  | 10-Jan-2024   | Transferred from Release Acceptance Criteria into TRG    |
+| Draft  | 25-April-2024 | Added new styleguide criteria - initial version          |
 
-### Objective
-To ensure consistency, usability, and adherence to design standards across all user interfaces within the business application.
-
-### Change History
-| Status | Created     | Post-History                                          |
-|--------|-------------|-------------------------------------------------------|
-| Draft  | 10-Jan-2024 | Transferred from Release Acceptance Criteria into TRG |
-| Draft  | 25-April-2024 | Added new styleguide gateway criterias - initial version |
-
-
-# TRG Document - Release Gateway Criteria
 ## Introduction
-This document outlines the criteria for a release gateway focused on ensuring that business applications with user interfaces adhere to the established UI/UX styleguide. The gateway serves as a quality checkpoint before the application is released to production or moved to the next stage of deployment.
+
+The purpose of this guideline is to ensure that business applications with user interfaces adhere to the established UI/UX styleguide. It outlines all the relevant criteria that must be checked when releasing a new product version. A crosscheck with every pull request is not just optional, but it is a "MUST" criteria to ensure the quality and consistency of the user interfaces of each product/component. This step is crucial in maintaining the overall standard and enhancing as well as standardizing the user experience.
 
 ## Objective
-The objective of the release gateway is to ensure consistency, usability, and adherence to design standards across all user interfaces within the business application.
 
-## Criteria for Release Gateway (Basic)
+The objective is to ensure consistency, usability, and adherence to design standards across all user interfaces within the business application.
+
+## Criteria (Basic)
 
 ### Styleguide Compliance
+
 - All user interface elements must match the predefined styles set in the UI/UX styleguide. This includes fonts, colors, button styles, input fields, and layout grids.
 - Icons and imagery should be consistent with the styleguide specifications. (note that images and icons must be open source compliant and license files are needed)
-  - https://github.com/catenax-ng/tx-portal-assets/blob/main/docs/developer/Technical%20Documentation/Others/Images%2C%20Graphics%20and%20Diagrams.md
+  - [Image, Graphics & Diagrams](https://github.com/eclipse-tractusx/portal-assets/blob/v2.0.0/docs/developer/Technical%20Documentation/Others/Images%2C%20Graphics%20and%20Diagrams.md)
 
 ### Responsiveness and Compatibility
+
 - The application must be fully responsive and provide a seamless experience across different devices and screen sizes.
 - The application must be tested with multiple browsers - in case any browsers are not supported, the same must be documented.
 
 ### Accessibility
+
 - The application must meet the minimum accessibility standards (e.g., WCAG 2.1) as defined in the styleguide.
 - Optional: All user interface components must be navigable and usable with keyboard-only controls.
 - Optional: Screen reader compatibility must be tested and ensured.
 
 ### User Experience
+
 - The application's user flow must align with the user experience outlined in the styleguide.
 - Interactive elements must provide feedback to the user, such as hover states, active states, and disabled states, as per the styleguide.
 - The application must have a user help area which is linked to the current deployed application version.
@@ -48,25 +46,30 @@ The objective of the release gateway is to ensure consistency, usability, and ad
 - The application must have a notification or alert component that displays important messages or updates to the user (success as well as errors).
 
 ### Typography and Readability
+
 - Text must adhere to the styleguide's typography standards, including font sizes, line heights, and font weights.
 - Text contrast must meet the minimum contrast ratios for readability.
 
 ### Localization and Internationalization
+
 - The application/user interface must support multiple languages, allowing users to switch between different language options.
 - Text in the user interface must be properly localized and displayed in the correct format for the target audience.
 
 ### Animation and Transitions
+
 - Any animations or transitions must be smooth, enhance the user experience, and conform to the styleguide's principles.
 
 ### Others
+
 - The application should include a footer component that contains important links, such as terms of service, privacy policy, and contact information.
 
 ---
 
 ### EXTERNAL LINKS
-> Source code: https://github.com/eclipse-tractusx/portal-shared-components.git  
-> NPM library: https://www.npmjs.com/package/@catena-x/portal-shared-components  
-> Storybook: https://eclipse-tractusx.github.io/portal-shared-components/  
-> Image, Graphics & Diagrams: https://github.com/catenax-ng/tx-portal-assets/blob/main/docs/developer/Technical%20Documentation/Others/Images%2C%20Graphics%20and%20Diagrams.md  
 
-Please note, you can use the official public available CX shared component library (react supported) to easily develop applications that are in-line with the CX style guidelines.
+> - [Source code](https://github.com/eclipse-tractusx/portal-shared-components.git)
+> - [NPM library](https://www.npmjs.com/package/@catena-x/portal-shared-components)
+> - [Storybook](https://eclipse-tractusx.github.io/portal-shared-components)
+> - [Image, Graphics & Diagrams](https://github.com/eclipse-tractusx/portal-assets/blob/v2.0.0/docs/developer/Technical%20Documentation/Others/Images%2C%20Graphics%20and%20Diagrams.md)
+
+Please note, you can use the publicly available [Portal Shared Components NPM library](https://www.npmjs.com/package/@catena-x/portal-shared-components) (React supported) to easily develop applications that are in-line with the Tractus-X style guidelines.


### PR DESCRIPTION
## Description

add TRG for UX/UI styleguide

## Pre-review checks

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
