### PR TITLE
chore: add meeting notes from 2024-04-26

### DIFF
--- a/blog-meeting-minutes/2024-04-26-community-hour.md
+++ b/blog-meeting-minutes/2024-04-26-community-hour.md
@@ -1,0 +1,35 @@
+---
+slug: community-office-hour-2024-04-29
+title: Community Office Hour 2024-04-26
+authors:
+    - fabian_gruen
+tags: [community, meeting-minutes]
+---
+
+## Office Hour meeting minutes
+
+### System team
+
+- We moved from the former [Miro](https://miro.com/app/board/uXjVOEDsHAI=/) board to the new Board within our [Eclipse Tractus-X GitHub organization projects](https://github.com/orgs/eclipse-tractusx/projects/61) and if you would like to give Feedback feel free to state it in the [draft issue](https://github.com/orgs/eclipse-tractusx/projects/61/views/1?pane=issue&itemId=61096455)
+- Now you can state everytime your topic for the next office hour as a draft issue for each open meeting like the "Office Hour" as described in the info section of the [board](https://github.com/orgs/eclipse-tractusx/projects/61?pane=info)
+
+### Security team
+
+- [Rohan](https://github.com/RoKrish14) will resume work on Monday, 13-May Alternate contact: [Lokesh Gujre](https://github.com/ZFLokesh) , [Tim Herres](https://github.com/BANANAS1337)
+- Bug bounty program is still in the work, but we are making progress on it see [issue](https://github.com/orgs/eclipse-tractusx/projects/61?pane=issue&itemId=61110062)
+
+### FOSS
+
+- Committer Elections to [Arno Weiß](https://github.com/arnoweiss)  open for [voting](https://projects.eclipse.org/projects/automotive.tractusx/elections/election-arno-wei%C3%9F-committer-eclipse-tractus-x)
+- Please check out the statements to the "Use of AI" in one of our Eclipse Office Hour [sessions](https://www.eclipse.org/projects/calendar/#2024-04-11)
+- OCX Conference - Call for speakers is open! Submit your talk [here](https://ocx.eclipse.org/2024/cfp)
+- Friendly reminder to the Eclipse Office hours about the process and shared information see [here](https://github.com/orgs/eclipse-tractusx/projects/61/views/1?pane=issue&itemId=61090283)
+- Friendly reminder to check our product notice sections in your documentation and update it if necessary a little example was found within the KIT documentation see [here](https://github.com/orgs/eclipse-tractusx/projects/61/views/1?pane=issue&itemId=61092600)
+
+### Open planning / community
+
+- We are looking for committers to help with the Release QG Check Review for the upcoming release. Please reach out to [Roland](https://github.com/RolaH1t) and [Siegfried](https://github.com/Siegfriedk) if you are interested.
+
+### Discussions
+
+- n/a


### PR DESCRIPTION
Please describe your PR: 

- add meeting minutes from last friday see current disscussed [topics](https://github.com/orgs/eclipse-tractusx/projects/61).

closes https://github.com/eclipse-tractusx/sig-infra/issues/483

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
