### PR TITLE
docs(meetings): add office hour meeting minutes for may 03

### DIFF
--- a/blog-meeting-minutes/2024-05-03-community-hour.md
+++ b/blog-meeting-minutes/2024-05-03-community-hour.md
@@ -1,0 +1,35 @@
+---
+slug: community-office-hour-2024-05-03
+title: Community Office Hour 2024-05-03
+authors:
+    - sebastian_bezold
+tags: [community, meeting-minutes]
+---
+
+## Office Hour meeting minutes
+
+### System team
+
+- Support needed for overarching `CHANGELOG` creation for release 24.05. If interested, please get in contact with Stephan Bauer
+
+### Security team
+
+- n/a
+
+### FOSS
+
+- Committer Election for [Arno Weiß](https://github.com/arnoweiss) concluded successfully. Congratulations!
+- [Committer Election](https://projects.eclipse.org/projects/automotive.tractusx/elections/election-lucas-capellino-committer-eclipse-tractus-x) for [Lucas Capellino](https://github.com/ds-lcapellino) open for voting
+
+### Open planning / community
+
+- We are looking for committers to help with the Release QG Check Review for the upcoming release. Please reach out to [Roland](https://github.com/RolaH1t) and [Siegfried](https://github.com/Siegfriedk) if you are interested.
+- Check out the meeting [invitations for open meetings](https://eclipse-tractusx.github.io/community/open-meetings/#one-time-meetings) regarding planning for release 24.12
+
+### Discussions
+
+- Are there defined deadlines for release 24.08 -> No one in the meeting did know of one yet
+- Interoperability and Thread Modelling checks in 24.05?
+  - You can approach the Security Team via issue on [sig-security](https://github.com/eclipse-tractusx/sig-security)
+  - Checks, that have been documented in a Consorita Confluence instance, could still take place, but a transparent format should be considered.
+    Some Teams already documented on GitHub.


### PR DESCRIPTION
## Description

Add the meeting minutes for may 03 2024

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
