### PR TITLE
documentation(kit-maturity-levels):Issue has been fixed

### DIFF
--- a/documentation/kit-maturity-levels.md
+++ b/documentation/kit-maturity-levels.md
@@ -54,6 +54,7 @@ This an overview - for the details and examples please check the TRG 8.03 - KIT 
 Legend:
 Mandatory ✓
 Optional ✓ *
+
 | Artifact / Stage  | Sandbox | Incubating | Graduated | Additional Info  |
 |---|---|---|---|---|
 |  Changelog |  | ✓ | ✓ |   |


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
In this pull request, we have successfully resolved the issue affecting the rendering of the table under the kit-maturity-level file. The table now displays as expected.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
#880 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
