### PR TITLE
Fix Traceability Policy example

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -58,7 +58,7 @@ npm/npmjs/-/boxen/5.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/boxen/6.2.1, MIT, approved, clearlydefined
 npm/npmjs/-/brace-expansion/1.1.11, MIT, approved, clearlydefined
 npm/npmjs/-/brace-expansion/2.0.1, MIT, approved, clearlydefined
-npm/npmjs/-/braces/3.0.2, MIT, approved, clearlydefined
+npm/npmjs/-/braces/3.0.2, MIT, approved, #14866
 npm/npmjs/-/browserslist/4.21.4, MIT, approved, #7034
 npm/npmjs/-/buffer-from/1.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/buffer/6.0.3, MIT, approved, clearlydefined

--- a/docs-kits/kits/Traceability Kit/Software Development View/page_app-provider_software-development-view.mdx
+++ b/docs-kits/kits/Traceability Kit/Software Development View/page_app-provider_software-development-view.mdx
@@ -109,17 +109,17 @@ Additionally, respective usage policies MAY include the following policy rule:
 ```json
 {
   "@context": {
-    "@vocab": " https://w3id.org/edc/v0.0.1/ns/"
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
    },
    "@id": "<POLICY-ID>",
    "policy": {
      "@context": [
        "http://www.w3.org/ns/odrl.jsonld",
          {
-           "cx-policy": " https://w3id.org/catenax/policy/v1.0.0/"
+           "cx-policy": "https://w3id.org/catenax/policy/"
          }
       ],
-        "@type": "Policy",
+        "@type": "Set",
         "profile": "cx-policy:profile2405",
         "permission": [
       {
@@ -129,12 +129,12 @@ Additionally, respective usage policies MAY include the following policy rule:
             {
               "leftOperand": "cx-policy:FrameworkAgreement",
               "operator": "eq",
-              "rightOperand": "traceability:1.0"
+              "rightOperand": "Traceability:1.0"
             },
             {
               "leftOperand": "cx-policy:UsagePurpose",
               "operator": "eq",
-              "rightOperand": "qualityNotifications:1"
+              "rightOperand": "cx.core.qualityNotifications:1"
             }
           ]
         }

--- a/docs-kits/kits/Traceability Kit/page_changelog.mdx
+++ b/docs-kits/kits/Traceability Kit/page_changelog.mdx
@@ -30,6 +30,18 @@ import Notice from './part_notice.mdx'
 
 All notable changes to this Kit will be documented in this file.
 
+## [5.0.1] - 2024-05-22
+
+### Changed
+
+- **Development View:**
+  - **App Provider:**
+    - Remove space before 'http' in namespaces (linter issue?)
+    - Use 'Set' instead of 'Policy' because of EDC data management API
+    - prefix UsagePurpose rightOperands with according value namespace "cx.core.*"
+    - Remove version from cx-policy namespace (which used to be there in a very early draft only)
+    - Update FrameworkAgreement rightOperand with upper case credential names as recently agreed and updated in Catena-X ODRL profile
+
 ## [5.0.0] - 2024-05-06
 
 Compatible for **release 24.05**.


### PR DESCRIPTION
- Remove space before 'http' (linter?)
- Use 'Set' instead of 'Policy' because of EDC
- prefix UsagePurpose with according value namespace cx.core.*
- Remove version from cx-policy namespace
- Update FrameworkAgreement rightOperand with upper case credential name
