### PR TITLE
Behaviour Twin KIT 24.05: Resolved Issue 914: Corrected links to Behaviour Twin KIT

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -422,7 +422,7 @@ const config = {
                 label: 'Agents',
               },
               {
-                to: '/docs-kits/next/kits/behaviour-twin-kit/overview',
+                to: '/docs-kits/kits/behaviour-twin-kit/overview',
                 label: 'Behaviour Twin',
               },
               {

--- a/utils/kitsGallery.js
+++ b/utils/kitsGallery.js
@@ -63,7 +63,7 @@ export const kitsGallery = [
     name: 'Behaviour Twin Kit',
     domain: 'PLM / Quality',
     img: BehaviourTwin_Kit,
-    pageRoute: "/docs-kits/next/kits/behaviour-twin-kit/overview"
+    pageRoute: "/docs-kits/kits/behaviour-twin-kit/overview"
   },
   {
     id: 6,


### PR DESCRIPTION
## Description

Resolves #914.

BUG: The link to the Behaviour Twin KIT (24.05) in the  KITs menue and in the KITs gallery were pointing to "next" version instead of 24.05 version. 

Resolved by removing "next/" from the link addresses.