### PR TITLE
fix: fixed link issue

### DIFF
--- a/docs/release/trg-0/trg-9-01.md
+++ b/docs/release/trg-0/trg-9-01.md
@@ -18,9 +18,9 @@ A detailed explanation can be found here:
 ## Description
 
 - A KIT must have a <code>changelog.md</code> following semantic versioning - see [TRG 1.03 - CHANGELOG.md](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-3)
-- A KIT must have, at minimum, an adoption view (Sandbox stage) - see [KIT Maturity Levels](documentation/kit-maturity-levels.md)
-- KIT artifacts must be structured according to the respective views (i.e. adoption, development, operations) - see [KIT Artifacts](documentation/kit-artifacts.md)
+- A KIT must have, at minimum, an adoption view (Sandbox stage) - see [KIT Maturity Levels](https://eclipse-tractusx.github.io/documentation/kit-maturity-levels)
+- KIT artifacts must be structured according to the respective views (i.e. adoption, development, operations) - see [KIT Artifacts](https://eclipse-tractusx.github.io/documentation/kit-artifacts)
 - Linked documents (e.g., Catena-X standards, Whitepapers) must include the current valid version (e.g. Business Partner Number (Version 2.0.0))
 - Each KIT view (business, development, ..) must include a license notice and adhere to the CY BB 4.0 license - see [TRG 7.08 - Legal notice for KIT documentation (CC-BY-4.0)](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-08)
 - Images must be neutral without any branding, and displayed on a. Images need to follow a the legal notice TRG - see [Legal notice for non-code](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07)
-- A KIT must indicate its maturity level (sandbox, incubating, graduated) - see [KIT Maturity Levels](documentation/kit-maturity-levels.md)
+- A KIT must indicate its maturity level (sandbox, incubating, graduated) - see [KIT Maturity Levels](https://eclipse-tractusx.github.io/documentation/kit-maturity-levels)

--- a/docs/release/trg-0/trg-9-01.md
+++ b/docs/release/trg-0/trg-9-01.md
@@ -17,7 +17,7 @@ A detailed explanation can be found here:
 
 ## Description
 
-- A KIT must have a <code>changelog.md</code> following semantic versioning - see [TRG 1.03 - CHANGELOG.md](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-3)
+- A KIT must have a <code>changelog.md</code> following semantic versioning + the release date of Tractus-X - see [TRG 1.03 - CHANGELOG.md](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-3)
 - A KIT must have, at minimum, an adoption view (Sandbox stage) - see [KIT Maturity Levels](https://eclipse-tractusx.github.io/documentation/kit-maturity-levels)
 - KIT artifacts must be structured according to the respective views (i.e. adoption, development, operations) - see [KIT Artifacts](https://eclipse-tractusx.github.io/documentation/kit-artifacts)
 - Linked documents (e.g., Catena-X standards, Whitepapers) must include the current valid version (e.g. Business Partner Number (Version 2.0.0))


### PR DESCRIPTION
## Description

link to the respective sections maturity-level kits and artifacts from trg file fixed

Issue - #916 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
