### PR TITLE
fix: remove upcoming kits  add data governance kit

### DIFF
--- a/docs-kits_versioned_sidebars/version-24.05-sidebars.json
+++ b/docs-kits_versioned_sidebars/version-24.05-sidebars.json
@@ -1051,18 +1051,6 @@
           "dirName": "kits/Traceability Kit"
         }
       ]
-    },
-    {
-      "type": "category",
-      "label": "Upcoming KITs",
-      "link": {
-        "type": "doc",
-        "id": "kits/Resiliency/resiliency"
-      },
-      "items": [
-        "kits/Resiliency/maas",
-        "kits/Resiliency/PURIS"
-      ]
     }
   ]
 }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -442,6 +442,10 @@ const config = {
                 label: 'Data Chain',
               },
               {
+                to: 'docs-kits/kits/Data%20Governance%20Kit/Data%20Governance%20Kit%20Adoption%20View',
+                label: 'Data Governance',
+              },
+              {
                 to: '/docs-kits/kits/DCM-Kit/adoption-view',
                 label: 'Demand & Capacity Management',
               },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -496,10 +496,6 @@ const config = {
               {
                 to: '/docs-kits/kits/Traceability%20Kit/Business%20View%20Traceability%20Kit',
                 label: 'Traceability',
-              },
-              {
-                to: 'docs-kits/kits/Resiliency/',
-                label: 'Upcoming KITs',
               }
             ],
           },

--- a/sidebarsDocsKits.js
+++ b/sidebarsDocsKits.js
@@ -624,19 +624,7 @@ const sidebars = {
                     dirName: 'kits/Traceability Kit',
                 },
             ],
-        },
-        {
-            type: 'category',
-            label: 'Upcoming KITs',
-            link: {
-                type: 'doc',
-                id: 'kits/Resiliency/resiliency'
-            },
-            items: [
-                'kits/Resiliency/maas',
-                'kits/Resiliency/PURIS'
-            ]
-        },
+        }
     ]
 };
 module.exports = sidebars;


### PR DESCRIPTION

## Description

remove upcoming kits from next and 24.05.
add data governance kit in the nav bar

#921 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
