### PR TITLE
docs(trg): bump k8s version

### DIFF
--- a/docs/release/trg-5/trg-5-10.md
+++ b/docs/release/trg-5/trg-5-10.md
@@ -37,7 +37,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker
-  image: kindest/node:v1.25.3@sha256:f1de3b0670462f43280114eccceab8bf1b9576d2afe0582f8f74529da6fd0365
+  image: kindest/node:v1.28.9@sha256:f1de3b0670462f43280114eccceab8bf1b9576d2afe0582f8f74529da6fd0365
 ```
 
 After Kind is installed locally, run the following command with the config above:
@@ -46,4 +46,4 @@ After Kind is installed locally, run the following command with the config above
 kind create cluster --config=config.yaml
 ```
 
-A Kubernetes node will start with version 1.25.
+A Kubernetes node will start with version 1.28.


### PR DESCRIPTION
PR to bump current aligned kubernetes version in the [TRG 5.10](https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-10)