### PR TITLE
chore: correct copyright notices

### DIFF
--- a/docs-kits/kits/Digital Twin Kit/Software Development View/page_interaction-patterns.md
+++ b/docs-kits/kits/Digital Twin Kit/Software Development View/page_interaction-patterns.md
@@ -282,5 +282,5 @@ The same holds true for use-case-defined APIs that trigger automatic updates/cre
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: 2023 Contributors of the Eclipse Foundation
-- Source URL: [https://github.com/eclipse-tractusx/tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc)
+- SPDX-FileCopyrightText: 2023, 2024 Contributors of the Eclipse Foundation
+- Source URL: [https://github.com/eclipse-tractusx/eclipse-tractusx.github.io](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io)

--- a/docs-kits/kits/Digital Twin Kit/Software Development View/page_software-development-view.md
+++ b/docs-kits/kits/Digital Twin Kit/Software Development View/page_software-development-view.md
@@ -618,5 +618,5 @@ the assets but also for the AAS - this is hard to realize in a pure stateless im
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: 2023 Contributors of the Eclipse Foundation
-- Source URL: [https://github.com/eclipse-tractusx/tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc)
+- SPDX-FileCopyrightText: 2023, 2024 Contributors of the Eclipse Foundation
+- Source URL: [https://github.com/eclipse-tractusx/eclipse-tractusx.github.io](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io)

--- a/docs-kits/kits/Digital Twin Kit/page_adoption-view.md
+++ b/docs-kits/kits/Digital Twin Kit/page_adoption-view.md
@@ -100,5 +100,5 @@ standard](https://catena-x.net/fileadmin/user_upload/Standard-Bibliothek/Update_
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: 2023 Contributors of the Eclipse Foundation
-- Source URL: [https://github.com/eclipse-tractusx/tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc)
+- SPDX-FileCopyrightText: 2023, 2024 Contributors of the Eclipse Foundation
+- Source URL: [https://github.com/eclipse-tractusx/eclipse-tractusx.github.io](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io)

--- a/docs-kits/kits/Digital Twin Kit/page_changelog.md
+++ b/docs-kits/kits/Digital Twin Kit/page_changelog.md
@@ -92,5 +92,5 @@ All notable changes to this Kit will be documented in this file.
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: 2023 Contributors of the Eclipse Foundation
-- Source URL: [https://github.com/eclipse-tractusx/tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc)
+- SPDX-FileCopyrightText: 2023, 2024 Contributors of the Eclipse Foundation
+- Source URL: [https://github.com/eclipse-tractusx/eclipse-tractusx.github.io](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io)

--- a/docs-kits/kits/Digital Twin Kit/page_software-operation-view.md
+++ b/docs-kits/kits/Digital Twin Kit/page_software-operation-view.md
@@ -48,5 +48,5 @@ implementations.
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 - SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: 2023 Contributors of the Eclipse Foundation
-- Source URL: [https://github.com/eclipse-tractusx/tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc)
+- SPDX-FileCopyrightText: 2023, 2024 Contributors of the Eclipse Foundation
+- Source URL: [https://github.com/eclipse-tractusx/eclipse-tractusx.github.io](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io)

--- a/docs-kits/kits/OSim Kit/Software Development View/02-page_software-development-view.md
+++ b/docs-kits/kits/OSim Kit/Software Development View/02-page_software-development-view.md
@@ -181,3 +181,11 @@ The following example shows the payload used for exchange of scenario data betwe
   }
 }
 ```
+
+## Notice
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2024 Contributors of the Eclipse Foundation
+- Source URL: [https://github.com/eclipse-tractusx/eclipse-tractusx.github.io](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io)

--- a/docs-kits/kits/OSim Kit/page_adoption-view.md
+++ b/docs-kits/kits/OSim Kit/page_adoption-view.md
@@ -253,3 +253,4 @@ This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses
 - SPDX-License-Identifier: CC-BY-4.0
 - SPDX-FileCopyrightText: 2024,Fraunhofer Institute for Factory Operation and Automation IFF
 - SPDX-FileCopyrightText: 2024,Siemens AG
+- Source URL: [https://github.com/eclipse-tractusx/eclipse-tractusx.github.io](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io)

--- a/docs-kits/kits/OSim Kit/page_changelog.md
+++ b/docs-kits/kits/OSim Kit/page_changelog.md
@@ -46,3 +46,12 @@ Additionally to the “simulation flow” released in the version 1.0.0 this ver
 ### Removed
 
 - ./.
+
+## Notice
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2024,Fraunhofer Institute for Factory Operation and Automation IFF
+- SPDX-FileCopyrightText: 2024,Siemens AG
+- Source URL: [https://github.com/eclipse-tractusx/eclipse-tractusx.github.io](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

Previously, the DT Kit's copyright notice contained incorrect links to source. OSim was missing some all along

Fixes #864 
<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
