### PR TITLE
documentation(kit-artifacts):broken link has been fixed

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -7,7 +7,7 @@ npm/npmjs/-/aggregate-error/3.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/ajv-formats/2.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/ajv-keywords/3.5.2, MIT, approved, clearlydefined
 npm/npmjs/-/ajv-keywords/5.1.0, MIT, approved, clearlydefined
-npm/npmjs/-/ajv/6.12.6, MIT, approved, #979
+npm/npmjs/-/ajv/6.12.6, MIT, approved, #15286
 npm/npmjs/-/ajv/8.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/ajv/8.12.0, MIT AND OFL-1.1 AND (EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0), approved, #6025
 npm/npmjs/-/algoliasearch-helper/3.11.2, MIT, approved, #6628
@@ -85,7 +85,7 @@ npm/npmjs/-/charset/1.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/cheerio-select/2.1.0, BSD-2-Clause, approved, clearlydefined
 npm/npmjs/-/cheerio/1.0.0-rc.12, MIT, approved, clearlydefined
 npm/npmjs/-/chokidar/3.5.3, MIT, approved, #2317
-npm/npmjs/-/chrome-trace-event/1.0.3, MIT, approved, #2414
+npm/npmjs/-/chrome-trace-event/1.0.3, MIT, approved, #15406
 npm/npmjs/-/ci-info/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/ci-info/3.7.1, MIT, approved, clearlydefined
 npm/npmjs/-/classnames/2.3.2, MIT, approved, clearlydefined
@@ -204,7 +204,7 @@ npm/npmjs/-/decode-named-character-reference/1.0.2, MIT, approved, clearlydefine
 npm/npmjs/-/decompress-response/3.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/deep-extend/0.6.0, MIT, approved, clearlydefined
 npm/npmjs/-/deepmerge/4.2.2, MIT, approved, clearlydefined
-npm/npmjs/-/default-gateway/6.0.3, BSD-2-Clause AND BSD-3-Clause, approved, #2956
+npm/npmjs/-/default-gateway/6.0.3, BSD-2-Clause AND BSD-3-Clause, approved, #15325
 npm/npmjs/-/defer-to-connect/1.1.3, MIT, approved, clearlydefined
 npm/npmjs/-/define-lazy-prop/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/define-properties/1.1.4, MIT, approved, clearlydefined
@@ -267,7 +267,7 @@ npm/npmjs/-/escape-string-regexp/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/eslint-scope/5.1.1, BSD-2-Clause, approved, clearlydefined
 npm/npmjs/-/esprima/4.0.1, BSD-2-Clause, approved, #995
 npm/npmjs/-/esrecurse/4.3.0, BSD-2-Clause, approved, clearlydefined
-npm/npmjs/-/estraverse/4.3.0, BSD-2-Clause, approved, #518
+npm/npmjs/-/estraverse/4.3.0, BSD-2-Clause AND MIT AND BSD-2-Clause, approved, #15352
 npm/npmjs/-/estraverse/5.3.0, BSD-2-Clause AND MIT, approved, #1557
 npm/npmjs/-/esutils/2.0.3, BSD-2-Clause AND BSD-3-Clause, approved, #120
 npm/npmjs/-/eta/1.12.3, MIT, approved, clearlydefined
@@ -379,7 +379,7 @@ npm/npmjs/-/http-cache-semantics/4.1.0, BSD-2-Clause, approved, clearlydefined
 npm/npmjs/-/http-deceiver/1.2.7, MIT, approved, clearlydefined
 npm/npmjs/-/http-errors/1.6.3, MIT, approved, clearlydefined
 npm/npmjs/-/http-errors/2.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/http-parser-js/0.5.8, MIT, approved, #2970
+npm/npmjs/-/http-parser-js/0.5.8, MIT, approved, #15223
 npm/npmjs/-/http-proxy-middleware/2.0.6, MIT, approved, clearlydefined
 npm/npmjs/-/http-proxy/1.18.1, MIT, approved, clearlydefined
 npm/npmjs/-/http-reasons/0.1.0, Apache-2.0, approved, clearlydefined
@@ -466,7 +466,7 @@ npm/npmjs/-/json-schema-merge-allof/0.8.1, MIT, approved, clearlydefined
 npm/npmjs/-/json-schema-traverse/0.4.1, MIT, approved, clearlydefined
 npm/npmjs/-/json-schema-traverse/1.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/json2mq/0.2.0, MIT, approved, clearlydefined
-npm/npmjs/-/json5/2.2.3, MIT, approved, #2126
+npm/npmjs/-/json5/2.2.3, MIT, approved, #15226
 npm/npmjs/-/jsonfile/6.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/keyv/3.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/khroma/2.0.0, MIT, approved, clearlydefined
@@ -599,7 +599,7 @@ npm/npmjs/-/oas-validator/5.0.8, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/-/object-assign/4.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/object-inspect/1.12.2, MIT, approved, clearlydefined
 npm/npmjs/-/object-keys/1.1.1, MIT, approved, clearlydefined
-npm/npmjs/-/object.assign/4.1.4, MIT, approved, #3232
+npm/npmjs/-/object.assign/4.1.4, MIT, approved, #15306
 npm/npmjs/-/obuf/1.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/on-finished/2.4.1, MIT, approved, clearlydefined
 npm/npmjs/-/on-headers/1.0.2, MIT, approved, clearlydefined
@@ -739,9 +739,9 @@ npm/npmjs/-/react-slick/0.29.0, MIT, approved, clearlydefined
 npm/npmjs/-/react-textarea-autosize/8.4.0, MIT, approved, clearlydefined
 npm/npmjs/-/react-transition-group/4.4.5, BSD-3-Clause, approved, CQ22955
 npm/npmjs/-/react/17.0.2, MIT, approved, clearlydefined
-npm/npmjs/-/readable-stream/2.3.7, MIT, approved, #945
+npm/npmjs/-/readable-stream/2.3.7, MIT, approved, #15394
 npm/npmjs/-/readable-stream/3.6.0, MIT, approved, CQ22627
-npm/npmjs/-/readdirp/3.6.0, MIT, approved, #2977
+npm/npmjs/-/readdirp/3.6.0, MIT, approved, #15328
 npm/npmjs/-/reading-time/1.5.0, MIT, approved, clearlydefined
 npm/npmjs/-/rechoir/0.6.2, MIT, approved, #981
 npm/npmjs/-/recursive-readdir/2.2.3, MIT, approved, clearlydefined
@@ -837,9 +837,9 @@ npm/npmjs/-/slash/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/slash/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/slick-carousel/1.8.1, MIT, approved, #2986
 npm/npmjs/-/slugify/1.6.5, MIT, approved, clearlydefined
-npm/npmjs/-/sockjs/0.3.24, MIT, approved, #2985
+npm/npmjs/-/sockjs/0.3.24, MIT, approved, #15295
 npm/npmjs/-/sort-css-media-queries/2.1.0, MIT, approved, clearlydefined
-npm/npmjs/-/source-map-js/1.0.2, BSD-3-Clause, approved, #2412
+npm/npmjs/-/source-map-js/1.0.2, BSD-3-Clause, approved, #15401
 npm/npmjs/-/source-map-support/0.5.21, MIT, approved, clearlydefined
 npm/npmjs/-/source-map/0.5.7, BSD-3-Clause, approved, #2400
 npm/npmjs/-/source-map/0.6.1, BSD-3-Clause, approved, #2417
@@ -952,7 +952,7 @@ npm/npmjs/-/util/0.10.4, MIT, approved, clearlydefined
 npm/npmjs/-/utila/0.4.0, MIT, approved, clearlydefined
 npm/npmjs/-/utility-types/3.10.0, MIT, approved, clearlydefined
 npm/npmjs/-/utils-merge/1.0.1, MIT, approved, clearlydefined
-npm/npmjs/-/uuid/8.3.2, MIT AND (BSD-3-Clause AND MIT), approved, #2438
+npm/npmjs/-/uuid/8.3.2, MIT AND (BSD-3-Clause AND MIT), approved, #15399
 npm/npmjs/-/uuid/9.0.0, MIT AND (BSD-3-Clause AND MIT), approved, #6869
 npm/npmjs/-/uvu/0.5.6, MIT, approved, clearlydefined
 npm/npmjs/-/validate.io-array/1.0.6, MIT, approved, clearlydefined
@@ -979,7 +979,7 @@ npm/npmjs/-/webidl-conversions/3.0.1, BSD-2-Clause, approved, clearlydefined
 npm/npmjs/-/webpack-bundle-analyzer/4.7.0, MIT, approved, clearlydefined
 npm/npmjs/-/webpack-dev-middleware/5.3.3, MIT, approved, clearlydefined
 npm/npmjs/-/webpack-dev-server/4.11.1, MIT, approved, clearlydefined
-npm/npmjs/-/webpack-merge/5.8.0, MIT, approved, #2407
+npm/npmjs/-/webpack-merge/5.8.0, MIT, approved, #15298
 npm/npmjs/-/webpack-sources/3.2.3, MIT, approved, clearlydefined
 npm/npmjs/-/webpack/5.75.0, MIT, approved, #5005
 npm/npmjs/-/webpackbar/5.0.2, MIT, approved, clearlydefined
@@ -1261,7 +1261,7 @@ npm/npmjs/@types/connect-history-api-fallback/1.3.5, MIT, approved, clearlydefin
 npm/npmjs/@types/connect/3.4.35, MIT, approved, clearlydefined
 npm/npmjs/@types/debug/4.1.7, MIT, approved, #10817
 npm/npmjs/@types/eslint-scope/3.7.4, MIT, approved, #10812
-npm/npmjs/@types/eslint/8.4.10, MIT, approved, #2429
+npm/npmjs/@types/eslint/8.4.10, MIT, approved, #15340
 npm/npmjs/@types/estree/0.0.51, MIT, approved, clearlydefined
 npm/npmjs/@types/express-serve-static-core/4.17.32, MIT, approved, #6020
 npm/npmjs/@types/express/4.17.15, MIT, approved, #5760

--- a/documentation/kit-artifacts.md
+++ b/documentation/kit-artifacts.md
@@ -5,7 +5,7 @@ title: KIT Artifacts
 |------------|--------------|----------------------------------------|
 | Draft      | 04-Apr-2024  | Initial contribution                   |
 
-This explains each artifact a KIT can or must follow - depending on the graduation stage [TRG 9.02](docs/release/trg-0/trg-9-02.md). An artifact is textual content or a technical component that is part of a KIT (e.g. a Vision statement).
+This explains each artifact a KIT can or must follow - depending on the graduation stage [TRG 9.01](@site/docs/release/trg-0/trg-9-01.md). An artifact is textual content or a technical component that is part of a KIT (e.g. a Vision statement).
 
 ## CHANGELOG
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
In this pull request , we have fixed the broken link in kit artifacts file.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
