### PR TITLE
docs: security office hour meeting minutes 2024-06-20

### DIFF
--- a/blog-meeting-minutes/2024-06-20-security-hour.md
+++ b/blog-meeting-minutes/2024-06-20-security-hour.md
@@ -1,0 +1,15 @@
+---
+slug: security-office-hour-2024-06-20
+title: Security Office Hour 2024-06-20
+authors: 
+    - rohan_krishnamurthy
+tags: [security, meeting-minutes]
+---
+
+## Security Office Hour meeting minutes
+
+### Announcements
+
+- Reminder about Catenax-ng
+- Reminder to remove any test credentials/sensitive that are present in catenax-ng
+- Reminder to look for the results of the security scans after migration to tractus-x

--- a/blog-meeting-minutes/2024-06-20-security-hour.md
+++ b/blog-meeting-minutes/2024-06-20-security-hour.md
@@ -10,6 +10,6 @@ tags: [security, meeting-minutes]
 
 ### Announcements
 
-- Reminder about Catenax-ng
-- Reminder to remove any test credentials/sensitive that are present in catenax-ng
-- Reminder to look for the results of the security scans after migration to tractus-x
+- Reminder about former GitHub Organisation Catenax-ng
+- Reminder to remove any test credentials/sensitive that are present in Catenax-ng
+- Reminder to look for the results of the security scans after migration to Eclipse Tractus-x


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Adding the security office hour meeting minutes for 2024-06-20.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
