### PR TITLE
docs: added meeting minutes office hour 21.06.2024

### DIFF
--- a/blog-meeting-minutes/2024-06-21-community-hour.md
+++ b/blog-meeting-minutes/2024-06-21-community-hour.md
@@ -17,14 +17,14 @@ tags: [community, meeting-minutes]
 ### Security team
 
 - No security team will be available for R24.08, [Rohan Krish](https://github.com/RoKrish14) has told he will be going in July, contact him if you know who will be responsible for security in the Association.
-- Handover from [Rohan Krish](https://github.com/RoKrish14) will be done in this ticket: https://github.com/eclipse-tractusx/sig-security/issues/83
+- Handover from [Rohan Krishnamurthy](https://github.com/RoKrish14) will be done in this ticket: https://github.com/eclipse-tractusx/sig-security/issues/83
 
 ### FOSS
 
 - Committer Election for [Lucas Capellino](https://github.com/arnoweiss), please vote if you are a committer!
 - [Evelyn Gurschler](https://github.com/evegufy) election to project lead concluded successfully, congratulations to our new project lead!
 - [Committer Election](https://projects.eclipse.org/projects/automotive.tractusx/elections/election-lucas-capellino-eclipse-tractus-x) for [Lucas Capellino](https://github.com/ds-lcapellino) open for voting again
-- Don't forget to update the legal docs regarding CC-BY-4.0 for documentation! Close the tickets in your repositories if its done: [eclipse-tractusx/sig-infra#477](https://github.com/eclipse-tractusx/sig-infra/issues/477)
+- Don't forget to update the legal docs!! Close the tickets in your repositories if its done: [eclipse-tractusx/sig-infra#477](https://github.com/eclipse-tractusx/sig-infra/issues/477)
 - 1.000 Lines of code in PRs for non-contributors require project Ip check: https://www.eclipse.org/projects/handbook/#ip-project-content
 
 ### Open planning / community
@@ -34,4 +34,4 @@ tags: [community, meeting-minutes]
 ### Discussions
 
 - Mermaid version in current docussaurus for the tractus-x webpage do not support specific type block-beta and xychart-beta.
-  - [Stephan Bauer](https://github.com/stephanbcbauer) will test to upgrate the version of docussaurus in the Catena-X eV repo
+  - [Stephan Bauer](https://github.com/stephanbcbauer) will test to upgrade the version of docussaurus in the Catena-X e.V. Repository.

--- a/blog-meeting-minutes/2024-06-21-community-hour.md
+++ b/blog-meeting-minutes/2024-06-21-community-hour.md
@@ -1,0 +1,36 @@
+---
+slug: community-office-hour-2024-06-21
+title: Community Office Hour 2024-06-21
+authors:
+    - matbmoser
+tags: [community, meeting-minutes]
+---
+
+## Office Hour meeting minutes
+
+### Infrastructure
+
+- Info from Test Management will be taken over by [Harald Zimmer](https://github.com/ds-hzimmer), please contact with your product owners to get a meeting with Harald and get the access if you are in the association.
+- Feedback requested from [Harald Zimmer](https://github.com/ds-hzimmer) for who is using: https://github.com/catenax-ng/product-test-data-generator
+- Branch protecting example provided by [Tom Meyer](https://github.com/tom-rm-meyer-ISST)
+
+### Security team
+
+- No security team will be available for R24.08, [Rohan Krish](https://github.com/RoKrish14) has told he will be going in July, contact him if you know who will be responsible for security in the Association.
+- Handover from [Rohan Krish](https://github.com/RoKrish14) will be done in this ticket: https://github.com/eclipse-tractusx/sig-security/issues/83
+
+### FOSS
+
+- Committer Election for [Lucas Capellino(https://github.com/arnoweiss)
+- [Committer Election](https://projects.eclipse.org/projects/automotive.tractusx/elections/election-lucas-capellino-eclipse-tractus-x) for [Lucas Capellino](https://github.com/ds-lcapellino) open for voting again
+- Don't forget to update the legal docs regarding CC-BY-4.0 for documentation! Close the tickets in your repositories if its done: [eclipse-tractusx/sig-infra#477](https://github.com/eclipse-tractusx/sig-infra/issues/477)
+- 1.000 Lines of code in PRs for non-contributors require project Ip check: https://www.eclipse.org/projects/handbook/#ip-project-content
+
+### Open planning / community
+
+- Every office hour there will be a slot to talk about the current process of the working model of Tractus-X/Catena-X. With the updates from the community.
+
+### Discussions
+
+- Mermaid version in current docussaurus for the tractus-x webpage do not support specific type block-beta and xychart-beta.
+  - [Stephan Bauer](https://github.com/stephanbcbauer) will test to upgrate the version of docussaurus in the Catena-X eV repo

--- a/blog-meeting-minutes/2024-06-21-community-hour.md
+++ b/blog-meeting-minutes/2024-06-21-community-hour.md
@@ -21,7 +21,8 @@ tags: [community, meeting-minutes]
 
 ### FOSS
 
-- Committer Election for [Lucas Capellino(https://github.com/arnoweiss)
+- Committer Election for [Lucas Capellino](https://github.com/arnoweiss), please vote if you are a committer!
+- [Evelyn Gurschler](https://github.com/evegufy) election to project lead concluded successfully, congratulations to our new project lead!
 - [Committer Election](https://projects.eclipse.org/projects/automotive.tractusx/elections/election-lucas-capellino-eclipse-tractus-x) for [Lucas Capellino](https://github.com/ds-lcapellino) open for voting again
 - Don't forget to update the legal docs regarding CC-BY-4.0 for documentation! Close the tickets in your repositories if its done: [eclipse-tractusx/sig-infra#477](https://github.com/eclipse-tractusx/sig-infra/issues/477)
 - 1.000 Lines of code in PRs for non-contributors require project Ip check: https://www.eclipse.org/projects/handbook/#ip-project-content

--- a/blog-meeting-minutes/authors.yaml
+++ b/blog-meeting-minutes/authors.yaml
@@ -40,3 +40,8 @@ stephan_bauer:
   name: Stephan Bauer
   title: Platform Domain Manager
   url: https://github.com/stephanbcbauer
+
+matbmoser:
+  name: Mathias Brunkow Moser
+  title: DPP Architect, Eclipse Committer
+  url: https://github.com/matbmoser


### PR DESCRIPTION
## Description
### Added
- Office hour meeting minutes from 21.06.2024

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
