### PR TITLE
doc(release planning): cancel refinement day 1 in release planning 24.12

### DIFF
--- a/blog/2024-07-31-open-planning-r24.12.mdx
+++ b/blog/2024-07-31-open-planning-r24.12.mdx
@@ -22,7 +22,7 @@ Please feel free to forward this post to anyone interested in contributing, whet
 ## Open Meetings
 
 - **[Refinement Phase - Release 24.12](#refinement-phase---release-2412)**
-- **[Refinement Day 1 - Release 24.12](#refinement-day-1---release-2412)**
+- ~~**[Refinement Day 1 - Release 24.12](#refinement-day-1---release-2412)**~~ **meeting canceled**
 - **[Draft Feature Freeze - Release 24.12](#draft-feature-freeze---release-2412)**
 - **[Refinement Day 2 - Release 24.12](#refinement-day-2---release-2412)**
 - **[Open Planning Days - Release 24.12](#open-planning-days---release-2412)**
@@ -39,7 +39,7 @@ communicating with the relevant contacts themselves. The Teams Session link can 
 - *Monday, 24. June 2024 to Sunday, 28. July 2024 (CEST)*
 - [open meeting](https://eclipse-tractusx.github.io/community/open-meetings/#Refinement%20Phase%20-%20Release%2024.12)
 
-### Refinement Day 1 - Release 24.12
+### ~~Refinement Day 1 - Release 24.12~~ **meeting canceled
 
 This event is organised and moderated by the Catena-X Association. Based on a predefined agenda (depending on the features on the board), individual dependencies are discussed and
 also documented directly on the feature. If the refinement of the features has already been carried out 'in the refinement phase' and the Definition of Entry (DoE) has already reached,

--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -105,7 +105,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
              }
 />
 
-<MeetingInfo title="Refinement Day 1 - Release 24.12"
+<MeetingInfo title="Refinement Day 1 - Release 24.12 - meeting canceled"
              schedule="Monday, 1. July 2024 from 09:05 to 12:00 (CEST)"
              description="This event is organised and moderated by the Catena-X Association. Based on a predefined agenda (depending on the features on the board), individual dependencies are discussed and also documented directly on the feature. If the refinement of the features has already been carried out 'in the refinement phase' and the Definition of Entry (DoE) has already reached, this meeting can also be used as synchronisation."
              contact="stephan.bauer@catena-x.net"


### PR DESCRIPTION
## Description

Since the appointment cannot take place, this PR marks it as cancelled. 

It's by purpose marked as cancelled and not deleted.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
