### PR TITLE
docs: update trg-8-03.md, introduce TruffleHog 

### DIFF
--- a/docs/release/trg-8/trg-8-03.md
+++ b/docs/release/trg-8/trg-8-03.md
@@ -61,7 +61,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Ensure full clone for pull request workflows
-          ref: ${{ github.head_ref }}  # Fetch specific branch/commit for pull requests
 
       - name: TruffleHog OSS
         id: trufflehog

--- a/docs/release/trg-8/trg-8-03.md
+++ b/docs/release/trg-8/trg-8-03.md
@@ -2,11 +2,11 @@
 title: TRG 8.03 - TruffleHog
 ---
 
-| Status | Created     | Post-History    |
-|--------|-------------|-----------------|
-| Update | 27-Jun-2024 | Switching to TruffleHog due to GitGuardian licence expiration|
-| Active | 26-Mar-2024 | Initial release |
-| Draft  | 04-Mar-2024 | Draft release   |
+| Status | Created     | Post-History                                                  |
+|--------|-------------|---------------------------------------------------------------|
+| Update | 27-Jun-2024 | Switching to TruffleHog due to GitGuardian licence expiration |
+| Active | 26-Mar-2024 | Initial release                                               |
+| Draft  | 04-Mar-2024 | Draft release                                                 |
 
 ## Why
 

--- a/docs/release/trg-8/trg-8-03.md
+++ b/docs/release/trg-8/trg-8-03.md
@@ -30,7 +30,6 @@ Including run: exit 1 in a step of a GitHub Actions workflow, as demonstrated be
 
 GitHub Actions allows you to define workflows to automatically run TruffleHog scans on your code. You'll see the output that triggered the failure directly in the logs.
 
-
 Here’s how you can set it up:
 
 ```yml

--- a/docs/release/trg-8/trg-8-03.md
+++ b/docs/release/trg-8/trg-8-03.md
@@ -1,26 +1,76 @@
 ---
-title: TRG 8.03 - GitGuardian
+title: TRG 8.03 - TruffleHog
 ---
 
 | Status | Created     | Post-History    |
 |--------|-------------|-----------------|
+| Update | 27-Jun-2024 | Switching to TruffleHog due to GitGuardian licence expiration|
 | Active | 26-Mar-2024 | Initial release |
 | Draft  | 04-Mar-2024 | Draft release   |
 
 ## Why
 
-GitGuardian excels at detecting and preventing leaks of sensitive data in your code repositories, such as API keys, passwords, and other secrets. This can help you avoid security breaches and comply with data privacy regulations.
+TruffleHog is an open source tool designed to identify sensitive information, such as API keys, passwords, and other credentials, that may have been inadvertently committed to your code repository. This tool is expected to be used in parallel to the native GitHub Secret Scanning tool.
 
 ## Description
 
-GitGuardian is integrated via its GitHub App, enabling automated secret scanning of our repositories. Each pull request undergoes a scan. If a potential secret is detected, the commit's author receives an immediate email notification.
+Detecting and removing these secrets is crucial for maintaining the security of your application and infrastructure. TruffleHog performs a thorough search by checking the entire repository history, not just the latest commits. This means it can find secrets that were committed in the past and might still pose a security risk.
 
-If a secret is suspected, the pull request will be locked. Immediate action is required regarding the potential secret due to the high risk associated with exposing secrets.
+Configure your GitHub Actions to include:
 
-:::caution
+- `workflow dispatch`: Manual workflow execution.
+- `schedule`: Schedule the workflow to run at least once a week with 0 0 * * 0.
+- `push` and `pull_request`: Activate the workflow on both push and pull request events targeting the branch that contains the code for the currently supported version, which may not necessarily be the main branch. This is the branch from which new releases will be made.
 
-Address all findings.
+Note: extra_args: --filter-entropy=4 --results=verified,unknown
 
-:::
+Including extra_args: --filter-entropy=4 --results=verified,unknown in the GitHub Actions workflow ensures that TruffleHog focuses on detecting high-entropy strings, which are more likely to be sensitive information such as passwords or API keys. This setup also instructs TruffleHog to report both verified secrets and potential but unverified secrets, providing a comprehensive security scan that helps identify and address all possible vulnerabilities in the code.
 
-The email contains a _temporary **link**_, allowing the author to either **report** the detected secret or **mark it as a false positive**, streamlining the review process for software engineers.
+Including run: exit 1 in a step of a GitHub Actions workflow, as demonstrated below, commands the workflow to halt execution. This ensures that should TruffleHog uncover any secrets during its scan, the workflow promptly terminates in failure.
+
+GitHub Actions allows you to define workflows to automatically run TruffleHog scans on your code. You'll see the output that triggered the failure directly in the logs.
+
+
+Here’s how you can set it up:
+
+```yml
+name: "TruffleHog"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+  id-token: write
+  issues: write
+
+jobs:
+  ScanSecrets:
+    name: Scan secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Ensure full clone for pull request workflows
+          ref: ${{ github.head_ref }}  # Fetch specific branch/commit for pull requests
+
+      - name: TruffleHog OSS
+        id: trufflehog
+        uses: trufflesecurity/trufflehog@main
+        continue-on-error: true
+        with:
+          path: ./  # Scan the entire repository
+          base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
+          extra_args: --filter-entropy=4 --results=verified,unknown --debug
+      
+      - name: Scan Results Status
+        if: steps.trufflehog.outcome == 'failure'
+        run: exit 1  # Set workflow run to failure if TruffleHog finds secrets 
+```

--- a/docs/release/trg-8/trg-8-03.md
+++ b/docs/release/trg-8/trg-8-03.md
@@ -19,14 +19,14 @@ Detecting and removing these secrets is crucial for maintaining the security of 
 Configure your GitHub Actions to include:
 
 - `workflow dispatch`: Manual workflow execution.
-- `schedule`: Schedule the workflow to run at least once a week with 0 0 * * 0.
+- `schedule`: Schedule the workflow to run at least once a week with `0 0 * * 0`.
 - `push` and `pull_request`: Activate the workflow on both push and pull request events targeting the branch that contains the code for the currently supported version, which may not necessarily be the main branch. This is the branch from which new releases will be made.
 
-Note: extra_args: --filter-entropy=4 --results=verified,unknown
+Note: `extra_args: --filter-entropy=4 --results=verified,unknown`
 
-Including extra_args: --filter-entropy=4 --results=verified,unknown in the GitHub Actions workflow ensures that TruffleHog focuses on detecting high-entropy strings, which are more likely to be sensitive information such as passwords or API keys. This setup also instructs TruffleHog to report both verified secrets and potential but unverified secrets, providing a comprehensive security scan that helps identify and address all possible vulnerabilities in the code.
+Including `extra_args: --filter-entropy=4 --results=verified,unknown` in the GitHub Actions workflow ensures that TruffleHog focuses on detecting high-entropy strings, which are more likely to be sensitive information such as passwords or API keys. This setup also instructs TruffleHog to report both verified secrets and potential but unverified secrets, providing a comprehensive security scan that helps identify and address all possible vulnerabilities in the code.
 
-Including run: exit 1 in a step of a GitHub Actions workflow, as demonstrated below, commands the workflow to halt execution. This ensures that should TruffleHog uncover any secrets during its scan, the workflow promptly terminates in failure.
+Including `run: exit 1` in a step of a GitHub Actions workflow, as demonstrated below, commands the workflow to halt execution. This ensures that should TruffleHog uncover any secrets during its scan, the workflow promptly terminates in failure.
 
 GitHub Actions allows you to define workflows to automatically run TruffleHog scans on your code. You'll see the output that triggered the failure directly in the logs.
 

--- a/docs/release/trg-8/trg-8-03.md
+++ b/docs/release/trg-8/trg-8-03.md
@@ -37,12 +37,13 @@ name: "TruffleHog"
 
 on:
   push:
-    branches: [ main ]
+    branches: ["main"]
   pull_request:
-
-  workflow_dispatch:
+    # The branches below must be a subset of the branches above
+    branches: ["main"]
   schedule:
     - cron: "0 0 * * *" # Once a day
+  workflow_dispatch:
 
 permissions:
   actions: read

--- a/docs/release/trg-8/trg-8-03.md
+++ b/docs/release/trg-8/trg-8-03.md
@@ -41,6 +41,8 @@ on:
   pull_request:
 
   workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # Once a day
 
 permissions:
   actions: read

--- a/docs/release/trg-8/trg-8-03.md
+++ b/docs/release/trg-8/trg-8-03.md
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Ensure full clone for pull request workflows
           ref: ${{ github.head_ref }}  # Fetch specific branch/commit for pull requests


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

This PR introduces TruffleHog as a new open source tool for secret scanning to be used alongside native Github Secret scanning. This is being enforced as a replacement to the existing GitGuardian (commercial) tool.

Example workflow:
1. https://github.com/eclipse-tractusx/bpdm/blob/main/.github/workflows/trufflehog.yml
2. https://github.com/eclipse-tractusx/demand-capacity-mgmt/blob/main/.github/workflows/trufflehog.yml

Please note: The TRG checks continues for 24.08 under GitGuardian for secret scanning.
The teams who have already implemented TruffleHog, can also be considered for the TRG checks.

**NOTE: Please do not merge this PR until the August release**

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
