### PR TITLE
doc(trg): replace link to metadata file doc

### DIFF
--- a/docs/release/trg-4/trg-4-02.md
+++ b/docs/release/trg-4/trg-4-02.md
@@ -58,7 +58,7 @@ open source license compliant.
 
 For automated TRG checks, you can skip base image checks on Dockerfiles by declaring it in the `.tractusx` metadata
 files. Details can be found in
-the [metadata file documentation](https://github.com/eclipse-tractusx/tractusx-quality-checks/blob/main/docs/metadata_file.md)
+the [metadata file documentation](https://github.com/eclipse-tractusx/sig-release/blob/main/docs/metadata_file.md)
 :::
 
 ### Use minor or major Image Tag


### PR DESCRIPTION
## Description
PR to fix/replace .tractusx metadata file url (linking to archived repo) in the TRG 4.02.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
