### PR TITLE
Remove exceeded-tractus-x-meeting ending on 26.6.2024

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -71,21 +71,6 @@ These are dedicated sync meetings for specific products, as well as open plannin
              }
 />
 
-<MeetingInfo title="[TRACE-X] Trace-X Open Meeting"
-             schedule="Every Thursday effective 8. Feb 2024 until 20. Jun 2024 (except 22. Feb 2024) from 03:05 pm to 03:45 pm CEST"
-             description="Coordination of feature development & concepts. For further information, please contact Martin Kanal or have a look into the downloadable ics file."
-             contact="martin.kanal@doubleslash.de"
-             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MTEyNTAyNTYtY2VkOC00ZDdjLTk0NTItNWViYTJmNmJmOTlh%40thread.v2/0?context=%7b%22Tid%22%3a%2226f86412-f875-4281-b566-fe6fe385e17c%22%2c%22Oid%22%3a%22db3ba521-7335-4e4f-b672-fc9f7c3f5536%22%7d"
-             meetingLink="/meetings/coordination-feature-development-trace-x.ics"
-             additionalLinks={
-                [
-                    {title: 'Open Meeting Agenda', url: 'https://github.com/eclipse-tractusx/traceability-foss/discussions/658'},
-                    {title: 'Trace-X Matrix Chat', url: 'https://matrix.to/#/#tractusx-trace-x:matrix.eclipse.org'},
-                    {title: 'IRS Matrix Chat', url: 'https://matrix.to/#/#tractusx-irs:matrix.eclipse.org'},
-                ]
-             }
-/>
-
 <MeetingInfo title="Umbrella Helm Chart Sync"
              schedule="Every Monday from 11:00 am to 11:30 am CEST"
              description="Open meeting to discuss the integration work around the umbrella helm chart with the purpose to enable a sandbox environment to support end-to-end (e2e) testing and to provide an easy entry point to Tractus-X for developers and adopters."


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Removed meeting which was exceeded by the 26.6.2024

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
