### PR TITLE
docs: add meeting minutes for office hour from 05-July 2024

### DIFF
--- a/blog-meeting-minutes/2024-07-05-community-hour.md
+++ b/blog-meeting-minutes/2024-07-05-community-hour.md
@@ -1,0 +1,34 @@
+---
+slug: community-office-hour-2024-07-05
+title: Community Office Hour 2024-07-05
+authors:
+    - rohan_krishnamurthy
+tags: [community, meeting-minutes]
+---
+
+## Office Hour meeting minutes
+
+### Infrastructure
+
+- Info from Test / Infrastructure Management CX Association by [Harald](https://github.com/ds-hzimmer):
+  - SAP DIM follow up meeting with on 8.7.2024 together with Christian Lahmer (SAP) and Evelyn Gurschler and DoubleSlash Net-Business GmbH
+  - Work-in-progress with SDE team and importing of test cases
+  - Access is currently limited –> would be great to make it accessible and available within Tractus-X
+- [Tomasz](https://github.com/tomaszbarwicki) -	Presented about how do you need to publish your API using .tractusx metafile and publish via GitHub pages - [API Hub](https://github.com/eclipse-tractusx/api-hub).
+
+### Security team
+
+- Info from security team by [Rohan](https://github.com/RoKrish14):
+  - Reminder about replacement of GitGuardian with TruffleHog, see according pull request to update TX release guideline: [#950](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/pull/950)
+  - Reminder about updates to Trivy workflow , see according pull request to update TX release guideline: [#949](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/pull/949)
+  - Reminder about about absence of security team members from August 2024
+  - Security tools walkthrough in the Committers Meeting of July 5, 2024 (about 20 minutes) - [Rohan](https://github.com/RoKrish14) will announce the walkthrough next week on the TX mailing list while sending out a reminder for the meeting
+
+### FOSS
+
+- Don't forget to update the legal docs!! Close the tickets in your repositories if its done: [eclipse-tractusx/sig-infra#477](https://github.com/eclipse-tractusx/sig-infra/issues/477)
+
+### Open planning / community
+
+- Info by community manager [Stephan](https://github.com/stephanbcbauer) about the Tractus-X/Catena-X working model and the refinement phase for the 24.12 release
+- [Registration](https://eveeno.com/126949167) is open for the Third Eclipse Tractus-X Community Days on December 05 and 06, 2024, ARENA2036 in Stuttgart!


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
add minutes for office hour from 05-July 2024

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
