### PR TITLE
doc(open meetings): removed open meeting for secuirty meeting hour

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -44,20 +44,6 @@ These are dedicated sync meetings for specific products, as well as open plannin
              meetingLink="/meetings/committer-office-hour.ics"
 />
 
-<MeetingInfo title="Security - Office Hour"
-             schedule="Every 2 weeks on Thursday effective 15. Feb 2024 until 31. Dec 2024 from 08:35 am to 09:30 am CEST"
-             description="Open hour meeting, hosted by the sig-security team. The goal of the meeting is to follow-up on security incidents, request review and assignments, and progress through security tools and procedures."
-             contact="rohan.krishnamurthy@zf.com"
-             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MzYzMzVhODMtYWQyOC00NWVlLWEyMjMtNjVlZmY2NTlkNTdk%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
-             meetingLink="/meetings/security-office-hour.ics"
-             additionalLinks={
-                [
-                    {title: 'meeting minutes', url: 'https://eclipse-tractusx.github.io/community/meeting-minutes/tags/security'},
-                    {title: 'sig-security', url: 'https://github.com/eclipse-tractusx/sig-security?tab=readme-ov-file#readme'},
-                ]
-             }
-/>
-
 <MeetingInfo title="Portal - Open Meeting"
              schedule="Every Thursday effective 4. Jul 2024 until 31. Dec 2024 from 01:30 pm to 02:00 pm CEST"
              description="Coordination of feature refinement and development for portal product."


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
The open meeting for Security - Office Hour will be discontinued due to lack of security experts post consortia.
The meeting was hosted by @RoKrish14, every 2 weeks on Thursday from 08:35 am to 09:30 am CEST.
The[meeting minutes](https://eclipse-tractusx.github.io/community/meeting-minutes) of the previous office hour can still be found under open meetings page.

![image](https://github.com/user-attachments/assets/4589f1d9-9f5c-429d-b267-e79aeae512d9)


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
