### PR TITLE
chore(ecopass-kit): added R24.08 changelog for the ecopass-kit

### DIFF
--- a/docs-kits/kits/Eco_Pass_KIT/changelog.md
+++ b/docs-kits/kits/Eco_Pass_KIT/changelog.md
@@ -5,9 +5,17 @@ title: Changelog
 ## [1.5.0] - 2024-07-25
 
 ### 24.08 Added
-- Added Digital Product Pass Verification Section
-- Added Digital Product Pass Tutorial Section
 
+- Added Digital Product Pass Verification Section in adoption view
+- Added Digital Product Pass Tutorial Section adoption view & software view
+- Added Digital Product Passport as Enabler for Circular Economy Whitepaper reference
+
+### 24.08 Updated
+
+- Updated DPP model to version v5.0.0
+- Updated BatteryPass to v6.0.0
+- Updated TransmissionPass to v3.0.0
+- Updated DPP Verification add-on in the software development view.
 
 ## [1.4.0] - 2024-05-15
 

--- a/docs-kits/kits/Eco_Pass_KIT/changelog.md
+++ b/docs-kits/kits/Eco_Pass_KIT/changelog.md
@@ -2,6 +2,13 @@
 title: Changelog
 ---
 
+## [1.5.0] - 2024-07-25
+
+### 24.08 Added
+- Added Digital Product Pass Verification Section
+- Added Digital Product Pass Tutorial Section
+
+
 ## [1.4.0] - 2024-05-15
 
 ### 24.05 Added


### PR DESCRIPTION
## Description
We need to generate a proper changelog for this R24.08.

This is the changelog: 

### 24.08 Added

- Added Digital Product Pass Verification Section in adoption view
- Added Digital Product Pass Tutorial Section adoption view & software view
- Added Digital Product Passport as Enabler for Circular Economy Whitepaper reference

### 24.08 Updated

- Updated DPP model to version v5.0.0
- Updated BatteryPass to v6.0.0
- Updated TransmissionPass to v3.0.0
- Updated DPP Verification add-on in the software development view.


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
