### PR TITLE
chore: added community hour meeting minutes 26.07.2024

### DIFF
--- a/blog-meeting-minutes/2024-07-26-community-hour.md
+++ b/blog-meeting-minutes/2024-07-26-community-hour.md
@@ -1,0 +1,40 @@
+---
+slug: community-office-hour-2024-07-26
+title: Community Office Hour 2024-07-26
+authors:
+    - matbmoser
+tags: [community, meeting-minutes]
+---
+
+## Office Hour meeting minutes
+
+### Infrastructure
+
+- @SebastianBezold -> Wednesday (31.07.2024) the Catena-NG will be deleted! No more access to the consortia environment will be allowed!
+    - Friendly reminder from @matbmoser: copy the configuration from the consortia environment argo, so you dont loose it, for the association env;)
+- @hzierer -> Most of E2E Tests are already passed! Great job everyone!
+- @matbmoser -> Don't forget to document the Quality Gate tickets!
+- System team is leaving in wednesday! The participants that will not act as committers please or remove yourself from the list, or contact a project lead. Thank you for you wonderful hard work!
+
+### Security team
+
+- @RoKrish14 -> TRG for truffelhog is in review https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/pull/950! 
+  - Example Workflow: https://github.com/RoKrish14/puris/blob/test/.github/workflows/trufflehog.yml
+
+- @RoKrish14 announce that he is leaving wednesday the project! Thank you for you wonderful hard work too!
+
+- @matbmoser -> We need to start a discussion and an action plan to solve the vulnerabilities in the eclipse-tractusx.github.io webpage repository. (Transfered to Committer Meeting)
+
+### FOSS
+
+- Open Project Lead election for Mathias Brunkow Moser, if you are a committer please vote: https://projects.eclipse.org/projects/automotive.tractusx/elections/election-mathias-brunkow-moser-eclipse-tractus-x-0 
+
+- @matbmoser -> New TRG 9 for UI/UX Styleguideline compliance: https://eclipse-tractusx.github.io/docs/release/trg-9/trg-9-01! 
+   - If you don't agree with something or want an improvement please open a PR with the changes! The Tractus-X community will support you :)
+
+### Open planning / community
+
+- Quality Gates and E2E phase is finishing today (26.07.2024). Make sure to keep your QG tickets updated and 
+- @agg3fe -> The TRG checklist is outdated
+  - @matbmoser -> I have created a PR to update the list: https://github.com/eclipse-tractusx/.github/pull/27
+  

--- a/blog-meeting-minutes/authors.yaml
+++ b/blog-meeting-minutes/authors.yaml
@@ -45,6 +45,7 @@ matbmoser:
   name: Mathias Brunkow Moser
   title: DPP Architect, Eclipse Committer
   url: https://github.com/matbmoser
+  image_url: https://github.com/matbmoser.png
 
 evelyn_gurschler:
   name: Evelyn Gurschler


### PR DESCRIPTION
## Description

Added the office hour meeting minutes for 26.07.2024 meeting.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
