### PR TITLE
fix: backport knowledge-agents 24.08 changes to versioned folder.

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1220,7 +1220,7 @@ npm/npmjs/@mui/material/5.11.4, MIT, approved, #6619
 npm/npmjs/@mui/private-theming/5.11.2, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #6629
 npm/npmjs/@mui/styled-engine/5.11.0, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #6642
 npm/npmjs/@mui/system/5.11.4, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #6627
-npm/npmjs/@mui/types/7.2.3, MIT, approved, clearlydefined
+npm/npmjs/@mui/types/7.2.3, MIT, approved, #16017
 npm/npmjs/@mui/utils/5.11.2, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #6632
 npm/npmjs/@nodelib/fs.scandir/2.1.5, MIT, approved, clearlydefined
 npm/npmjs/@nodelib/fs.stat/2.0.5, MIT, approved, clearlydefined
@@ -1228,7 +1228,7 @@ npm/npmjs/@nodelib/fs.walk/1.2.8, MIT, approved, clearlydefined
 npm/npmjs/@paloaltonetworks/openapi-to-postmanv2/3.1.0-hotfix.1, Apache-2.0 AND (Apache-2.0 AND MIT) AND BSD-2-Clause-Views AND (Apache-2.0 AND BSD-2-Clause AND MIT) AND MIT, approved, #6641
 npm/npmjs/@paloaltonetworks/postman-code-generators/1.1.12, Apache-2.0, approved, #6636
 npm/npmjs/@paloaltonetworks/postman-collection/4.1.1, Apache-2.0, approved, #6638
-npm/npmjs/@polka/url/1.0.0-next.21, MIT, approved, clearlydefined
+npm/npmjs/@polka/url/1.0.0-next.21, MIT, approved, #16183
 npm/npmjs/@popperjs/core/2.11.6, MIT, approved, clearlydefined
 npm/npmjs/@redocly/ajv/8.11.0, MIT, approved, clearlydefined
 npm/npmjs/@redocly/openapi-core/1.0.0-beta.120, MIT AND Apache-2.0, approved, #6639
@@ -1283,7 +1283,7 @@ npm/npmjs/@types/node/18.11.18, MIT, approved, #5746
 npm/npmjs/@types/parse-json/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/@types/parse5/5.0.3, MIT, approved, clearlydefined
 npm/npmjs/@types/parse5/6.0.3, MIT, approved, clearlydefined
-npm/npmjs/@types/prop-types/15.7.5, MIT, approved, clearlydefined
+npm/npmjs/@types/prop-types/15.7.5, MIT, approved, #16176
 npm/npmjs/@types/qs/6.9.7, MIT, approved, #13991
 npm/npmjs/@types/range-parser/1.2.4, MIT, approved, #10795
 npm/npmjs/@types/react-is/17.0.3, MIT, approved, #8424

--- a/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/development-view/modules.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/development-view/modules.md
@@ -245,7 +245,7 @@ standard.
 
 Actually, this KIT is caring about two bridges, one which bridges AAS information that is described in Catena-X aspect schemas
 into the Catena-X domain ontologies (the AAS-KA Bridge). And one bridge which is able to emulate
-shells and submodels out of a given (federated) virtual graph.
+shells and submodels out of a given (federated) virtual graph (the SPARQL-AAS Bridge).
 
 [![AAS Bridge(s)](/img/knowledge-agents/aas_bridge_small.png)](/img/knowledge-agents/aas_bridge.png)
 
@@ -268,20 +268,20 @@ There are two main components whose interplay implements the AAS-KA bridge:
 * A flexible SQL/JSON engine, such as Dremio or in parts also Postgresql which is able to mount raw data in various
 formats from remote filesystems and APIs. This engine is used to build flat relational views onto a hierarchical
 json structure that may originate in the value-only-serialization of the AAS. Typically there will be one table/view
-per json-schema/submodel template. As an example, see these [scripts](https://github.com/catenax-ng/product-knowledge/tree/main/infrastructure/resources/dremio)
-* A graph engine (such as [ontop](https://ontop-vkg.org/guide/) ) that is able to bind/translate SPARQL queries into SQL. As an example, see these [bindings](https://github.com/catenax-ng/product-knowledge/tree/main/infrastructure/oem/resources/trace.obda)
+per json-schema/submodel template. As an example, see these [scripts](https://github.com/big-data-spaces/knowledge-agent-deployment/tree/main/infrastructure/resources/dremio)
+* A graph engine (such as [ontop](https://ontop-vkg.org/guide/) ) that is able to bind/translate SPARQL queries into SQL. As an example, see these [bindings](https://github.com/big-data-spaces/knowledge-agent-deployment/tree/main/infrastructure/oem/resources/trace.obda)
 
 Of course, if the data is available in a native SQL-schema, the SQL/JSON-engine can be omitted. Likewise, even the graph engine
 can be left out if a sparql-capable database holds its data in conformance to the CX-ontologies.
 
-#### KA->AAS Bridge
+#### SPARQL->AAS Bridge
 
 In order to form a twin-based, highly-standarized access to any graphTo allow for a more strict
 In order to form a graph-based, flexible access to AAS backend components, we
 employ a bridge virtualization module which denormalizes/caches the information
 inside Shells and Submodels.
 
-Exposing substructures of the distributed knowledge graph via the AAS APIs is possible by deploying the [KA-AAS-Bridge](https://github.com/eclipse-tractusx/knowledge-agents-aas-bridge). This generic tool can be used to expose the graphs structures as AAS by configuring a set of mappings. Each consists of two components
+Exposing substructures of the distributed knowledge graph via the AAS APIs is possible by deploying the [KA-AAS-Bridge](https://github.com/eclipse-tractusx/knowledge-agents-aas-bridge) and its [KA-AAS Deployment](../operation-view/bridge). This generic tool can be used to expose the graphs structures as AAS by configuring a set of mappings. Each consists of two components
 
 * a SPARQL query extracting "flat" information out of the virtual graph
 * a mapping configuration providing the basic structure of the target AAS

--- a/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/development-view/reference.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/development-view/reference.md
@@ -43,14 +43,11 @@ For more information see
 
 * Provider-Side Programming Language: Java > 12
   * Eclipse Dataspace Connector
-  * Provider Agent: OnTop
-  * Inference Agent: Fuseki
-  * Function Agent: RDF4J
+  * Provider Agent: OnTop VKP
+  * Matchmaking Agent: Apache Fuseki
+  * Remoting Agent: RDF4J
+  * Conforming Agent: JAX-RS (Jersey) & Glassfish
   * SPARQL-AAS Bridge: FAAAST
-* Consumer-Side Programming Language: Typescript
-  * Skill Framework: React/Redux
-  * Knowledge Explorer: React/Redux & Catena-X Portal
-  * Skill Development Environment: React/Redux & Catena-X Portal
 
 ## Sources And Artifacts
 

--- a/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/operation-view/agent_edc.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/operation-view/agent_edc.md
@@ -45,11 +45,11 @@ Add a helm dependency to your umbrella/infrastructure Chart.yaml (this example u
 - name: tractusx-connector
   alias: my-connector
   repository: https://eclipse-tractusx.github.io/charts/dev
-  version: 0.7.0
+  version: 0.7.3
 - name: agent-plane
   alias: my-agent-plane
   repository: https://eclipse-tractusx.github.io/charts/dev
-  version: 1.12.19
+  version: 1.13.22
 ```
 
 Then configure the connector in the values.yaml

--- a/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/operation-view/bridge.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/operation-view/bridge.md
@@ -28,4 +28,1115 @@ title: Bridging
 
 For Bridging between Knowledge Agents API and AAS, this KIT recommends deploying the [Tractus-X Knowledge Agents AAS Bridge (KA-AAS)](https://github.com/eclipse-tractusx/knowledge-agents-aas-api)
 
+## Quick Setup Guide for AAS Bridge
+
+### 1. Add Helm Dependency to the AAS Bridge
+
+Add a helm dependency to your umbrella/infrastructure Chart.yaml (this example uses a Traveability graph, see [here](https://github.com/eclipse-tractusx/knowledge-agents-aas-bridge/blob/main/sparql-aas/README.md) for more options and full details).
+
+```yaml
+    - name: aas-bridge
+      repository: https://eclipse-tractusx.github.io/charts/dev
+      version: 1.13.7
+      alias: my-aas-bridge
+```
+
+### 2. Configure the AAS Bridge with Mappings
+
+Then configure the aas bridge in the values.yaml - especially you introduce so-called mapping domains ("traceability") which are pairs of XSLT stylesheets and SPARQL commands.
+Using these mappings, the aas bridge know how to describe digital twins and submodels out of a background graph.
+
+Each domain will have a mandatory mapping `aas` which describes the digital twins and the existance of submodels. And it will have a dynamic set of submodel mappings for the individual submodels.
+Domains will also be representeded as a component of the resulting keys (asset and submodel id's).
+
+In the following example, we map digital twins with one submodel (`PartAsPlanned`) out of an existing graph following to the [Bill-Of-Material Ontology](https://w3id.org/catenax/ontology/bill-of-material), the [Vehicle Ontology](https://w3id.org/catenax/ontology/vehicle), the [Common (Dataspace) Ontology](https://w3id.org/catenax/ontology/common) and the [Core (Meta) Ontology](https://w3id.org/catenax/ontology/core) - all being part of the [Complete (Merged) Ontology](https://w3id.org/catenax/ontology).
+
+Since the AAS Bridge internally speaks https, you need to enable your ingress to relay the ssl-layer (see the `annotations` section).
+
+```yaml
+my-aas-bridge: 
+  nameOverride: my-aas-bridge
+  fullnameOverride: my-aas-bridge
+  aas:
+    persistence:
+      # -- The default sparql server is embedded
+      sparql: http://sparql.local
+    endpoints:
+      default:
+        path: "/"
+  ingresses:
+  - enabled: true
+    hostname: "aas-bridge.domain"
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    endpoints:
+      - default
+    tls:
+      enabled: true
+domains:
+  traceability:
+    aas:
+      mapping.xslt: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xsl:stylesheet version="1.0"
+                        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                        xmlns:sparql="http://www.w3.org/2005/sparql-results#"
+                        xmlns:semanticid="https://w3id.org/catenax/ontology/aas#"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <xsl:variable name="domain"  select="'traceability'"/>
+            <xsl:variable name="semanticid"  select="'https://w3id.org/catenax/ontology/aas#'"/>
+            <xsl:output method="xml" />
+            <xsl:template name="genAssetId">
+              <xsl:value-of select="$domain"/>/<xsl:value-of select="./sparql:binding[@name='id']/sparql:uri"/>
+            </xsl:template>
+            <xsl:template name="root" match="/">
+                <aas:environment xmlns:aas="https://admin-shell.io/aas/3/0"
+                                xsi:schemaLocation="">
+                    <aas:assetAdministrationShells>
+                        <xsl:for-each select="//sparql:result">
+                        <aas:assetAdministrationShell>
+                            <aas:idShort><xsl:call-template name="genAssetId"/></aas:idShort>
+                            <aas:id><xsl:call-template name="genAssetId"/></aas:id>
+                            <aas:assetInformation>
+                                <aas:assetKind>Instance</aas:assetKind>
+                                <aas:globalAssetId><xsl:call-template name="genAssetId"/></aas:globalAssetId>
+                            </aas:assetInformation>
+                            <aas:description>
+                                <aas:langStringTextType>
+                                    <aas:language>en</aas:language>
+                                    <aas:text><xsl:value-of select="./sparql:binding[@name='name']/sparql:literal"/></aas:text>
+                                </aas:langStringTextType>
+                            </aas:description>
+                            <aas:submodels>
+                                <xsl:for-each select="./sparql:binding[@name != 'id' and @name != 'name']">
+                                <aas:reference>
+                                    <aas:type>ExternalReference</aas:type>
+                                    <aas:keys>
+                                        <aas:key>
+                                            <aas:type>Submodel</aas:type>
+                                            <aas:value><xsl:value-of select="$domain"/>/<xsl:value-of select="./sparql:uri"/>/<xsl:value-of select="../sparql:binding[@name = 'id']/sparql:uri"/></aas:value>
+                                        </aas:key>
+                                    </aas:keys>
+                                </aas:reference>
+                                </xsl:for-each>
+                            </aas:submodels>
+                        </aas:assetAdministrationShell>
+                        </xsl:for-each>
+                    </aas:assetAdministrationShells>
+                </aas:environment>
+            </xsl:template>
+        </xsl:stylesheet>
+      select-all.rq: |-
+        PREFIX cx-common: <https://w3id.org/catenax/ontology/common#>
+        PREFIX cx-core: <https://w3id.org/catenax/ontology/core#>
+        PREFIX cx-vehicle: <https://w3id.org/catenax/ontology/vehicle#>
+        PREFIX cx-bom: <https://w3id.org/catenax/ontology/bill-of-material#>
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        #
+        # A request for obtaining all asset administration shells for serialized parts
+        #
+
+        SELECT DISTINCT ?id ?name ?pasp ?psasp ?hasRecycling ?slbomap ?slusap ?mfr WHERE {
+
+            # all parts are twins
+            ?id rdf:type cx-vehicle:Part;
+                cx-core:name ?name.
+
+            # Part
+            OPTIONAL{
+                ?id cx-core:id ?manufacturerPartId.
+                BIND(<urn:bamm:io.catenax.part_as_planned:1.0.1#PartAsPlanned> as ?pasp).
+            }
+        }
+        ORDER BY DESC(?id)
+      select-some.rq: |-
+        PREFIX cx-common: <https://w3id.org/catenax/ontology/common#>
+        PREFIX cx-core: <https://w3id.org/catenax/ontology/core#>
+        PREFIX cx-vehicle: <https://w3id.org/catenax/ontology/vehicle#>
+        PREFIX cx-bom: <https://w3id.org/catenax/ontology/bill-of-material#>
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        #
+        # A request for obtaining specific asset administration shells for serialized parts
+        #
+
+        SELECT DISTINCT ?id ?name ?pasp ?psasp ?hasRecycling ?slbomap ?slusap ?mfr WHERE {
+
+            VALUES(?id) {
+                (%s)
+            }
+
+            # all parts are twins
+            ?id rdf:type cx-vehicle:Part;
+                cx-core:name ?name.
+
+            # Part
+            OPTIONAL{
+                ?id cx-core:id ?manufacturerPartId.
+                BIND(<urn:bamm:io.catenax.part_as_planned:1.0.1#PartAsPlanned> as ?pasp).
+            }
+        }
+        ORDER BY DESC(?id)
+    partAsPlanned:
+      mapping.xslt: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xsl:stylesheet version="1.0"
+                        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                        xmlns:sparql="http://www.w3.org/2005/sparql-results#"
+                        xmlns:semanticid="urn:bamm:io.catenax.part_as_planned:1.0.1#PartAsPlanned"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xsl:variable name="domain" select="'traceability'"/>
+            <xsl:variable name="semanticid"  select="'urn:bamm:io.catenax.part_as_planned:1.0.1#PartAsPlanned'"/>
+            <xsl:output method="xml" />
+            <xsl:template name="genAssetId">
+                <xsl:value-of select="$domain"/>/<xsl:value-of select="./sparql:binding[@name='catenaXId']/sparql:uri"/>
+            </xsl:template>
+            <xsl:template name="genSubmodelId">
+                <xsl:value-of select="$domain"/>/<xsl:value-of select="$semanticid"/>/<xsl:value-of select="./sparql:binding[@name='catenaXId']/sparql:uri"/>
+            </xsl:template>
+            <xsl:key name="catenax-id" match="//sparql:result" use="sparql:binding[@name='catenaXId']/sparql:uri" />
+            <xsl:template name="root" match="/">
+                <aas:environment xmlns:aas="https://admin-shell.io/aas/3/0"
+                                xsi:schemaLocation="">
+                    <aas:assetAdministrationShells>
+                        <xsl:for-each select="//sparql:result[count(. | key('catenax-id', ./sparql:binding[@name='catenaXId']/sparql:uri)[1]) = 1]">
+                            <aas:assetAdministrationShell>
+                                <aas:idShort><xsl:call-template name="genAssetId"/></aas:idShort>
+                                <aas:id><xsl:call-template name="genAssetId"/></aas:id>
+                                <aas:assetInformation>
+                                    <aas:assetKind>Instance</aas:assetKind>
+                                    <aas:globalAssetId><xsl:call-template name="genAssetId"/></aas:globalAssetId>
+                                </aas:assetInformation>
+                                <aas:submodels>
+                                    <xsl:for-each select="key('catenax-id',./sparql:binding[@name='catenaXId']/sparql:uri)">
+                                    <aas:reference>
+                                        <aas:type>ExternalReference</aas:type>
+                                        <aas:keys>
+                                            <aas:key>
+                                                <aas:type>Submodel</aas:type>
+                                                <aas:value><xsl:call-template name="genSubmodelId"/></aas:value>
+                                            </aas:key>
+                                        </aas:keys>
+                                    </aas:reference>
+                                    </xsl:for-each>
+                                </aas:submodels>
+                            </aas:assetAdministrationShell>
+                        </xsl:for-each>
+                    </aas:assetAdministrationShells>
+                    <aas:submodels>
+                        <xsl:for-each select="//sparql:result">
+                            <aas:submodel>
+                                <aas:kind>Instance</aas:kind>
+                                <aas:semanticId>
+                                    <aas:type>ModelReference</aas:type>
+                                    <aas:keys>
+                                        <aas:key>
+                                            <aas:type>ConceptDescription</aas:type>
+                                            <aas:value><xsl:value-of select="$semanticid"/></aas:value>
+                                        </aas:key>
+                                    </aas:keys>
+                                </aas:semanticId>
+                                <aas:id><xsl:call-template name="genSubmodelId"/></aas:id>
+                                <aas:idShort>PartAsPlanned</aas:idShort>
+                                <aas:description>
+                                    <aas:langStringTextType>
+                                        <aas:language>en</aas:language>
+                                        <aas:text>A Part AsPlanned represents an item in the Catena-X Bill of Material (BOM) in As-Planned lifecycle status. </aas:text>
+                                    </aas:langStringTextType>
+                                </aas:description>
+                                <aas:submodelElements>
+                                    <aas:property>
+                                        <aas:category>Key</aas:category>
+                                        <aas:idShort>catenaXId</aas:idShort>
+                                        <aas:description>
+                                            <aas:langStringTextType>
+                                                <aas:language>en</aas:language>
+                                                <aas:text>The fully anonymous Catena-X ID of the serialized part, valid for the Catena-X dataspace.</aas:text>
+                                            </aas:langStringTextType>
+                                        </aas:description>
+                                        <aas:displayName>
+                                            <aas:langStringNameType>
+                                                <aas:language>en</aas:language>
+                                                <aas:text>Catena-X Identifier</aas:text>
+                                            </aas:langStringNameType>
+                                        </aas:displayName>
+                                        <aas:semanticId>
+                                            <aas:type>ModelReference</aas:type>
+                                            <aas:keys>
+                                                <aas:key>
+                                                    <aas:type>ConceptDescription</aas:type>
+                                                    <aas:value>urn:bamm:io.catenax.part_as_planned:1.0.1#catenaXId</aas:value>
+                                                </aas:key>
+                                            </aas:keys>
+                                        </aas:semanticId>
+                                        <aas:valueType>xs:string</aas:valueType>
+                                        <aas:value><xsl:value-of select="./sparql:binding[@name='catenaXId']/sparql:uri"/></aas:value>
+                                    </aas:property>
+                                    <aas:submodelElementCollection>
+                                        <aas:idShort>partTypeInformation</aas:idShort>
+                                        <aas:description>
+                                            <aas:langStringTextType>
+                                                <aas:language>en</aas:language>
+                                                <aas:text>Encapsulation for data related to the part type</aas:text>
+                                            </aas:langStringTextType>
+                                        </aas:description>
+                                        <aas:displayName>
+                                            <aas:langStringNameType>
+                                                <aas:language>en</aas:language>
+                                                <aas:text>Part Type Information Entity</aas:text>
+                                            </aas:langStringNameType>
+                                        </aas:displayName>
+                                        <aas:value>
+                                            <aas:property>
+                                                <aas:category>Key</aas:category>
+                                                <aas:idShort>manufacturerPartId</aas:idShort>
+                                                <aas:description>
+                                                    <aas:langStringTextType>
+                                                        <aas:language>en</aas:language>
+                                                        <aas:text>Part ID as assigned by the manufacturer of the part. The Part ID identifies the part (as designed) in the manufacturer`s dataspace. The Part ID does not reference a specific instance of a part and thus should not be confused with the serial number.</aas:text>
+                                                    </aas:langStringTextType>
+                                                </aas:description>
+                                                <aas:displayName>
+                                                    <aas:langStringNameType>
+                                                        <aas:language>en</aas:language>
+                                                        <aas:text>Manufacturer Part ID</aas:text>
+                                                    </aas:langStringNameType>
+                                                </aas:displayName>
+                                                <aas:semanticId>
+                                                    <aas:type>ModelReference</aas:type>
+                                                    <aas:keys>
+                                                        <aas:key>
+                                                            <aas:type>ConceptDescription</aas:type>
+                                                            <aas:value>urn:bamm:io.catenax.part_as_planned:1.0.1#manufacturerPartId</aas:value>
+                                                        </aas:key>
+                                                    </aas:keys>
+                                                </aas:semanticId>
+                                                <aas:valueType>xs:string</aas:valueType>
+                                                <aas:value><xsl:value-of select="./sparql:binding[@name='manufacturerPartId']/sparql:literal"/></aas:value>
+                                            </aas:property>
+                                            <aas:property>
+                                                <aas:category>Value</aas:category>
+                                                <aas:idShort>nameAtManufacturer</aas:idShort>
+                                                <aas:description>
+                                                    <aas:langStringTextType>
+                                                        <aas:language>en</aas:language>
+                                                        <aas:text>Name of the part as assigned by the manufacturer.</aas:text>
+                                                    </aas:langStringTextType>
+                                                </aas:description>
+                                                <aas:displayName>
+                                                    <aas:langStringNameType>
+                                                        <aas:language>en</aas:language>
+                                                        <aas:text>Name at Manufacturer</aas:text>
+                                                    </aas:langStringNameType>
+                                                </aas:displayName>
+                                                <aas:semanticId>
+                                                    <aas:type>ModelReference</aas:type>
+                                                    <aas:keys>
+                                                        <aas:key>
+                                                            <aas:type>ConceptDescription</aas:type>
+                                                            <aas:value>urn:bamm:io.catenax.part_as_planned:1.0.1#nameAtManufacturer</aas:value>
+                                                        </aas:key>
+                                                    </aas:keys>
+                                                </aas:semanticId>
+                                                <aas:valueType>xs:string</aas:valueType>
+                                                <aas:value><xsl:value-of select="./sparql:binding[@name='nameAtManufacturer']/sparql:literal"/></aas:value>
+                                            </aas:property>
+                                            <aas:property>
+                                                <aas:category>Enum</aas:category>
+                                                <aas:idShort>classification</aas:idShort>
+                                                <aas:description>
+                                                    <aas:langStringTextType>
+                                                        <aas:language>en</aas:language>
+                                                        <aas:text>Classification of the part as assigned by the manufacturer.</aas:text>
+                                                    </aas:langStringTextType>
+                                                </aas:description>
+                                                <aas:displayName>
+                                                    <aas:langStringNameType>
+                                                        <aas:language>en</aas:language>
+                                                        <aas:text>Product Classification</aas:text>
+                                                    </aas:langStringNameType>
+                                                </aas:displayName>
+                                                <aas:semanticId>
+                                                    <aas:type>ModelReference</aas:type>
+                                                    <aas:keys>
+                                                        <aas:key>
+                                                            <aas:type>ConceptDescription</aas:type>
+                                                            <aas:value>urn:bamm:io.catenax.part_as_planned:1.0.1#classification</aas:value>
+                                                        </aas:key>
+                                                    </aas:keys>
+                                                </aas:semanticId>
+                                                <aas:valueType>xs:string</aas:valueType>
+                                                <aas:value><xsl:value-of select="./sparql:binding[@name='classification']/sparql:literal"/></aas:value>
+                                            </aas:property>
+                                        </aas:value>
+                                    </aas:submodelElementCollection>
+                                    <aas:submodelElementCollection>
+                                        <aas:idShort>validityPeriod</aas:idShort>
+                                        <aas:description>
+                                            <aas:langStringTextType>
+                                                <aas:language>en</aas:language>
+                                                <aas:text>Temporal validity period of the part.</aas:text>
+                                            </aas:langStringTextType>
+                                        </aas:description>
+                                        <aas:displayName>
+                                            <aas:langStringNameType>
+                                                <aas:language>en</aas:language>
+                                                <aas:text>validityPeriod</aas:text>
+                                            </aas:langStringNameType>
+                                        </aas:displayName>
+                                        <aas:value>
+                                            <aas:property>
+                                                <aas:category>Time</aas:category>
+                                                <aas:idShort>validFrom</aas:idShort>
+                                                <aas:description>
+                                                    <aas:langStringTextType>
+                                                        <aas:language>en</aas:language>
+                                                        <aas:text>Start date of validity period.</aas:text>
+                                                    </aas:langStringTextType>
+                                                </aas:description>
+                                                <aas:displayName>
+                                                    <aas:langStringNameType>
+                                                        <aas:language>en</aas:language>
+                                                        <aas:text>Valid From</aas:text>
+                                                    </aas:langStringNameType>
+                                                </aas:displayName>
+                                                <aas:semanticId>
+                                                    <aas:type>ModelReference</aas:type>
+                                                    <aas:keys>
+                                                        <aas:key>
+                                                            <aas:type>ConceptDescription</aas:type>
+                                                            <aas:value>urn:bamm:io.catenax.part_as_planned:1.0.1#validFrom</aas:value>
+                                                        </aas:key>
+                                                    </aas:keys>
+                                                </aas:semanticId>
+                                                <aas:valueType>xs:dateTime</aas:valueType>
+                                                <aas:value><xsl:value-of select="./sparql:binding[@name='validFrom']/sparql:literal"/></aas:value>
+                                            </aas:property>
+                                            <aas:property>
+                                                <aas:category>Time</aas:category>
+                                                <aas:idShort>validFrom</aas:idShort>
+                                                <aas:description>
+                                                    <aas:langStringTextType>
+                                                        <aas:language>en</aas:language>
+                                                        <aas:text>End date of validity period.</aas:text>
+                                                    </aas:langStringTextType>
+                                                </aas:description>
+                                                <aas:displayName>
+                                                    <aas:langStringNameType>
+                                                        <aas:language>en</aas:language>
+                                                        <aas:text>Valid To</aas:text>
+                                                    </aas:langStringNameType>
+                                                </aas:displayName>
+                                                <aas:semanticId>
+                                                    <aas:type>ModelReference</aas:type>
+                                                    <aas:keys>
+                                                        <aas:key>
+                                                            <aas:type>ConceptDescription</aas:type>
+                                                            <aas:value>urn:bamm:io.catenax.part_as_planned:1.0.1#validTo</aas:value>
+                                                        </aas:key>
+                                                    </aas:keys>
+                                                </aas:semanticId>
+                                                <aas:valueType>xs:dateTime</aas:valueType>
+                                                <aas:value><xsl:value-of select="./sparql:binding[@name='validTo']/sparql:literal"/></aas:value>
+                                            </aas:property>
+                                        </aas:value>
+                                    </aas:submodelElementCollection>
+                                </aas:submodelElements>
+                            </aas:submodel>
+                        </xsl:for-each>
+                    </aas:submodels>
+                    <aas:conceptDescriptions>
+                    </aas:conceptDescriptions>
+                </aas:environment>
+            </xsl:template>
+        </xsl:stylesheet>
+      select-all.rq: |-
+        PREFIX cx-common: <https://w3id.org/catenax/ontology/common#>
+        PREFIX cx-core: <https://w3id.org/catenax/ontology/core#>
+        PREFIX cx-vehicle: <https://w3id.org/catenax/ontology/vehicle#>
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        # Select all part information
+
+        SELECT ?catenaXId ?validFrom ?validTo ?classification ?manufacturerPartId ?nameAtManufacturer
+        WHERE {
+            ?catenaXId rdf:type cx-vehicle:Part;
+                cx-core:id ?manufacturerPartId;
+                cx-core:name ?nameAtManufacturer;
+                cx-vehicle:productionPeriodStart ?validFrom;
+                cx-vehicle:productionPeriodEnd ?validTo.
+            BIND('product' AS ?classification).
+        }
+        ORDER BY DESC(?catenaXId)
+      select-some.rq: |-
+        PREFIX cx-common: <https://w3id.org/catenax/ontology/common#>
+        PREFIX cx-core: <https://w3id.org/catenax/ontology/core#>
+        PREFIX cx-vehicle: <https://w3id.org/catenax/ontology/vehicle#>
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        # Select some part information
+
+        SELECT ?catenaXId ?validFrom ?validTo ?classification ?manufacturerPartId ?nameAtManufacturer
+        WHERE {
+
+            VALUES(?catenaXId) {
+                (%s)
+            }
+
+            ?catenaXId rdf:type cx-vehicle:Part;
+                cx-core:id ?manufacturerPartId;
+                cx-core:name ?nameAtManufacturer;
+                cx-vehicle:productionPeriodStart ?validFrom;
+                cx-vehicle:productionPeriodEnd ?validTo.
+
+            BIND('product' AS ?classification).
+        }
+        ORDER BY DESC(?catenaXId)
+```
+
+### 3. Testdrive the AAS Bridge
+
+After the aas bridge has been setup, you may invoke AAS Api calls against it
+
+```console
+curl --location 'https://aas-bridge.domain/api/v3.0/description'
+```
+
+and you should receive an answer, such as
+
+```json
+{
+    "profiles": [
+        "https://admin-shell.io/aas/API/3/0/AssetAdministrationShellRepositoryServiceSpecification/SSP-001",
+        "https://admin-shell.io/aas/API/3/0/SubmodelRepositoryServiceSpecification/SSP-001",
+        "https://admin-shell.io/aas/API/3/0/ConceptDescriptionServiceSpecification/SSP-001",
+        "https://admin-shell.io/aas/API/3/0/DiscoveryServiceSpecification/SSP-001"
+    ]
+}
+```
+
+To get the list of shells, you may invoke
+
+```console
+curl --location 'http://aas-bridge.domain/api/v3.0/shells'
+```
+
+and you should receive an answer, such as
+
+```json
+{
+    "result": [
+        {
+            "modelType": "AssetAdministrationShell",
+            "assetInformation": {
+                "assetKind": "Instance",
+                "globalAssetId": "traceability/urn:uuid:f5efbf45-7d84-4442-b3b8-05cf1c5c5a0b"
+            },
+            "submodels": [
+                {
+                    "keys": [
+                        {
+                            "type": "Submodel",
+                            "value": "traceability/urn:bamm:io.catenax.part_as_planned:1.0.1#PartAsPlanned/urn:uuid:f5efbf45-7d84-4442-b3b8-05cf1c5c5a0b"
+                        }
+                    ],
+                    "type": "ExternalReference"
+                }
+            ],
+            "id": "traceability/urn:uuid:f5efbf45-7d84-4442-b3b8-05cf1c5c5a0b",
+            "description": [
+                {
+                    "language": "en",
+                    "text": "Tier C Piston Rod"
+                }
+            ],
+            "idShort": "traceability/urn:uuid:f5efbf45-7d84-4442-b3b8-05cf1c5c5a0b"
+        },
+        ...
+        {
+            "modelType": "AssetAdministrationShell",
+            "assetInformation": {
+                "assetKind": "Instance",
+                "globalAssetId": "traceability/urn:uuid:0733946c-59c6-41ae-9570-cb43a6e4c79e"
+            },
+            "submodels": [
+                {
+                    "keys": [
+                        {
+                            "type": "Submodel",
+                            "value": "traceability/urn:bamm:io.catenax.part_as_planned:1.0.1#PartAsPlanned/urn:uuid:0733946c-59c6-41ae-9570-cb43a6e4c79e"
+                        }
+                    ],
+                    "type": "ExternalReference"
+                }
+            ],
+            "id": "traceability/urn:uuid:0733946c-59c6-41ae-9570-cb43a6e4c79e",
+            "description": [
+                {
+                    "language": "en",
+                    "text": "Vehicle Model A"
+                }
+            ],
+            "idShort": "traceability/urn:uuid:0733946c-59c6-41ae-9570-cb43a6e4c79e"
+        }
+    ],
+    "paging_metadata": {
+        "cursor": null
+    }
+}
+```
+
+To get the list of shells, you may invoke
+
+```console
+curl --location 'http://oem-aas-bridge.knowledge.int.catena-x.net/api/v3.0/submodels?content=value&level=deep'
+```
+
+and you should receive an answer, such as
+
+```json
+{
+    "result": [
+        {
+            "modelType": "Submodel",
+            "kind": "Instance",
+            "semanticId": {
+                "keys": [
+                    {
+                        "type": "ConceptDescription",
+                        "value": "urn:bamm:io.catenax.part_as_planned:1.0.1#PartAsPlanned"
+                    }
+                ],
+                "type": "ModelReference"
+            },
+            "id": "traceability/urn:bamm:io.catenax.part_as_planned:1.0.1#PartAsPlanned/urn:uuid:f5efbf45-7d84-4442-b3b8-05cf1c5c5a0b",
+            "description": [
+                {
+                    "language": "en",
+                    "text": "A Part AsPlanned represents an item in the Catena-X Bill of Material (BOM) in As-Planned lifecycle status. "
+                }
+            ],
+            "idShort": "PartAsPlanned",
+            "submodelElements": [
+                {
+                    "modelType": "Property",
+                    "semanticId": {
+                        "keys": [
+                            {
+                                "type": "ConceptDescription",
+                                "value": "urn:bamm:io.catenax.part_as_planned:1.0.1#catenaXId"
+                            }
+                        ],
+                        "type": "ModelReference"
+                    },
+                    "value": "urn:uuid:f5efbf45-7d84-4442-b3b8-05cf1c5c5a0b",
+                    "valueType": "xs:string",
+                    "category": "Key",
+                    "description": [
+                        {
+                            "language": "en",
+                            "text": "The fully anonymous Catena-X ID of the serialized part, valid for the Catena-X dataspace."
+                        }
+                    ],
+                    "displayName": [
+                        {
+                            "language": "en",
+                            "text": "Catena-X Identifier"
+                        }
+                    ],
+                    "idShort": "catenaXId"
+                },
+                {
+                    "modelType": "SubmodelElementCollection",
+                    "description": [
+                        {
+                            "language": "en",
+                            "text": "Encapsulation for data related to the part type"
+                        }
+                    ],
+                    "displayName": [
+                        {
+                            "language": "en",
+                            "text": "Part Type Information Entity"
+                        }
+                    ],
+                    "idShort": "partTypeInformation",
+                    "value": [
+                        {
+                            "modelType": "Property",
+                            "semanticId": {
+                                "keys": [
+                                    {
+                                        "type": "ConceptDescription",
+                                        "value": "urn:bamm:io.catenax.part_as_planned:1.0.1#manufacturerPartId"
+                                    }
+                                ],
+                                "type": "ModelReference"
+                            },
+                            "value": "5760234-23",
+                            "valueType": "xs:string",
+                            "category": "Key",
+                            "description": [
+                                {
+                                    "language": "en",
+                                    "text": "Part ID as assigned by the manufacturer of the part. The Part ID identifies the part (as designed) in the manufacturer`s dataspace. The Part ID does not reference a specific instance of a part and thus should not be confused with the serial number."
+                                }
+                            ],
+                            "displayName": [
+                                {
+                                    "language": "en",
+                                    "text": "Manufacturer Part ID"
+                                }
+                            ],
+                            "idShort": "manufacturerPartId"
+                        },
+                        {
+                            "modelType": "Property",
+                            "semanticId": {
+                                "keys": [
+                                    {
+                                        "type": "ConceptDescription",
+                                        "value": "urn:bamm:io.catenax.part_as_planned:1.0.1#nameAtManufacturer"
+                                    }
+                                ],
+                                "type": "ModelReference"
+                            },
+                            "value": "Tier C Piston Rod",
+                            "valueType": "xs:string",
+                            "category": "Value",
+                            "description": [
+                                {
+                                    "language": "en",
+                                    "text": "Name of the part as assigned by the manufacturer."
+                                }
+                            ],
+                            "displayName": [
+                                {
+                                    "language": "en",
+                                    "text": "Name at Manufacturer"
+                                }
+                            ],
+                            "idShort": "nameAtManufacturer"
+                        },
+                        {
+                            "modelType": "Property",
+                            "semanticId": {
+                                "keys": [
+                                    {
+                                        "type": "ConceptDescription",
+                                        "value": "urn:bamm:io.catenax.part_as_planned:1.0.1#classification"
+                                    }
+                                ],
+                                "type": "ModelReference"
+                            },
+                            "value": "product",
+                            "valueType": "xs:string",
+                            "category": "Enum",
+                            "description": [
+                                {
+                                    "language": "en",
+                                    "text": "Classification of the part as assigned by the manufacturer."
+                                }
+                            ],
+                            "displayName": [
+                                {
+                                    "language": "en",
+                                    "text": "Product Classification"
+                                }
+                            ],
+                            "idShort": "classification"
+                        }
+                    ]
+                },
+                {
+                    "modelType": "SubmodelElementCollection",
+                    "description": [
+                        {
+                            "language": "en",
+                            "text": "Temporal validity period of the part."
+                        }
+                    ],
+                    "displayName": [
+                        {
+                            "language": "en",
+                            "text": "validityPeriod"
+                        }
+                    ],
+                    "idShort": "validityPeriod",
+                    "value": [
+                        {
+                            "modelType": "Property",
+                            "semanticId": {
+                                "keys": [
+                                    {
+                                        "type": "ConceptDescription",
+                                        "value": "urn:bamm:io.catenax.part_as_planned:1.0.1#validFrom"
+                                    }
+                                ],
+                                "type": "ModelReference"
+                            },
+                            "value": "2014-02-24",
+                            "valueType": "xs:dateTime",
+                            "category": "Time",
+                            "description": [
+                                {
+                                    "language": "en",
+                                    "text": "Start date of validity period."
+                                }
+                            ],
+                            "displayName": [
+                                {
+                                    "language": "en",
+                                    "text": "Valid From"
+                                }
+                            ],
+                            "idShort": "validFrom"
+                        },
+                        {
+                            "modelType": "Property",
+                            "semanticId": {
+                                "keys": [
+                                    {
+                                        "type": "ConceptDescription",
+                                        "value": "urn:bamm:io.catenax.part_as_planned:1.0.1#validTo"
+                                    }
+                                ],
+                                "type": "ModelReference"
+                            },
+                            "value": "2027-11-04",
+                            "valueType": "xs:dateTime",
+                            "category": "Time",
+                            "description": [
+                                {
+                                    "language": "en",
+                                    "text": "End date of validity period."
+                                }
+                            ],
+                            "displayName": [
+                                {
+                                    "language": "en",
+                                    "text": "Valid To"
+                                }
+                            ],
+                            "idShort": "validFrom"
+                        }
+                    ]
+                }
+            ]
+        },
+        ---
+                {
+            "modelType": "Submodel",
+            "kind": "Instance",
+            "semanticId": {
+                "keys": [
+                    {
+                        "type": "ConceptDescription",
+                        "value": "urn:bamm:io.catenax.part_as_planned:1.0.1#PartAsPlanned"
+                    }
+                ],
+                "type": "ModelReference"
+            },
+            "id": "traceability/urn:bamm:io.catenax.part_as_planned:1.0.1#PartAsPlanned/urn:uuid:0733946c-59c6-41ae-9570-cb43a6e4c79e",
+            "description": [
+                {
+                    "language": "en",
+                    "text": "A Part AsPlanned represents an item in the Catena-X Bill of Material (BOM) in As-Planned lifecycle status. "
+                }
+            ],
+            "idShort": "PartAsPlanned",
+            "submodelElements": [
+                {
+                    "modelType": "Property",
+                    "semanticId": {
+                        "keys": [
+                            {
+                                "type": "ConceptDescription",
+                                "value": "urn:bamm:io.catenax.part_as_planned:1.0.1#catenaXId"
+                            }
+                        ],
+                        "type": "ModelReference"
+                    },
+                    "value": "urn:uuid:0733946c-59c6-41ae-9570-cb43a6e4c79e",
+                    "valueType": "xs:string",
+                    "category": "Key",
+                    "description": [
+                        {
+                            "language": "en",
+                            "text": "The fully anonymous Catena-X ID of the serialized part, valid for the Catena-X dataspace."
+                        }
+                    ],
+                    "displayName": [
+                        {
+                            "language": "en",
+                            "text": "Catena-X Identifier"
+                        }
+                    ],
+                    "idShort": "catenaXId"
+                },
+                {
+                    "modelType": "SubmodelElementCollection",
+                    "description": [
+                        {
+                            "language": "en",
+                            "text": "Encapsulation for data related to the part type"
+                        }
+                    ],
+                    "displayName": [
+                        {
+                            "language": "en",
+                            "text": "Part Type Information Entity"
+                        }
+                    ],
+                    "idShort": "partTypeInformation",
+                    "value": [
+                        {
+                            "modelType": "Property",
+                            "semanticId": {
+                                "keys": [
+                                    {
+                                        "type": "ConceptDescription",
+                                        "value": "urn:bamm:io.catenax.part_as_planned:1.0.1#manufacturerPartId"
+                                    }
+                                ],
+                                "type": "ModelReference"
+                            },
+                            "value": "ZX-55",
+                            "valueType": "xs:string",
+                            "category": "Key",
+                            "description": [
+                                {
+                                    "language": "en",
+                                    "text": "Part ID as assigned by the manufacturer of the part. The Part ID identifies the part (as designed) in the manufacturer`s dataspace. The Part ID does not reference a specific instance of a part and thus should not be confused with the serial number."
+                                }
+                            ],
+                            "displayName": [
+                                {
+                                    "language": "en",
+                                    "text": "Manufacturer Part ID"
+                                }
+                            ],
+                            "idShort": "manufacturerPartId"
+                        },
+                        {
+                            "modelType": "Property",
+                            "semanticId": {
+                                "keys": [
+                                    {
+                                        "type": "ConceptDescription",
+                                        "value": "urn:bamm:io.catenax.part_as_planned:1.0.1#nameAtManufacturer"
+                                    }
+                                ],
+                                "type": "ModelReference"
+                            },
+                            "value": "Vehicle Model A",
+                            "valueType": "xs:string",
+                            "category": "Value",
+                            "description": [
+                                {
+                                    "language": "en",
+                                    "text": "Name of the part as assigned by the manufacturer."
+                                }
+                            ],
+                            "displayName": [
+                                {
+                                    "language": "en",
+                                    "text": "Name at Manufacturer"
+                                }
+                            ],
+                            "idShort": "nameAtManufacturer"
+                        },
+                        {
+                            "modelType": "Property",
+                            "semanticId": {
+                                "keys": [
+                                    {
+                                        "type": "ConceptDescription",
+                                        "value": "urn:bamm:io.catenax.part_as_planned:1.0.1#classification"
+                                    }
+                                ],
+                                "type": "ModelReference"
+                            },
+                            "value": "product",
+                            "valueType": "xs:string",
+                            "category": "Enum",
+                            "description": [
+                                {
+                                    "language": "en",
+                                    "text": "Classification of the part as assigned by the manufacturer."
+                                }
+                            ],
+                            "displayName": [
+                                {
+                                    "language": "en",
+                                    "text": "Product Classification"
+                                }
+                            ],
+                            "idShort": "classification"
+                        }
+                    ]
+                },
+                {
+                    "modelType": "SubmodelElementCollection",
+                    "description": [
+                        {
+                            "language": "en",
+                            "text": "Temporal validity period of the part."
+                        }
+                    ],
+                    "displayName": [
+                        {
+                            "language": "en",
+                            "text": "validityPeriod"
+                        }
+                    ],
+                    "idShort": "validityPeriod",
+                    "value": [
+                        {
+                            "modelType": "Property",
+                            "semanticId": {
+                                "keys": [
+                                    {
+                                        "type": "ConceptDescription",
+                                        "value": "urn:bamm:io.catenax.part_as_planned:1.0.1#validFrom"
+                                    }
+                                ],
+                                "type": "ModelReference"
+                            },
+                            "value": "2017-01-03",
+                            "valueType": "xs:dateTime",
+                            "category": "Time",
+                            "description": [
+                                {
+                                    "language": "en",
+                                    "text": "Start date of validity period."
+                                }
+                            ],
+                            "displayName": [
+                                {
+                                    "language": "en",
+                                    "text": "Valid From"
+                                }
+                            ],
+                            "idShort": "validFrom"
+                        },
+                        {
+                            "modelType": "Property",
+                            "semanticId": {
+                                "keys": [
+                                    {
+                                        "type": "ConceptDescription",
+                                        "value": "urn:bamm:io.catenax.part_as_planned:1.0.1#validTo"
+                                    }
+                                ],
+                                "type": "ModelReference"
+                            },
+                            "value": "2029-11-15",
+                            "valueType": "xs:dateTime",
+                            "category": "Time",
+                            "description": [
+                                {
+                                    "language": "en",
+                                    "text": "End date of validity period."
+                                }
+                            ],
+                            "displayName": [
+                                {
+                                    "language": "en",
+                                    "text": "Valid To"
+                                }
+                            ],
+                            "idShort": "validFrom"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "paging_metadata": {
+        "cursor": null
+    }
+}
+```
+
+To access a particular shell, you may
+
+```console
+curl --location 'http://oem-aas-bridge.knowledge.int.catena-x.net/api/v3.0/shells/dHJhY2VhYmlsaXR5L3Vybjp1dWlkOmY1ZWZiZjQ1LTdkODQtNDQ0Mi1iM2I4LTA1Y2YxYzVjNWEwYg=='
+```
+
+which would return
+
+```json
+{
+    "modelType": "AssetAdministrationShell",
+    "assetInformation": {
+        "assetKind": "Instance",
+        "globalAssetId": "traceability/urn:uuid:f5efbf45-7d84-4442-b3b8-05cf1c5c5a0b"
+    },
+    "submodels": [
+        {
+            "keys": [
+                {
+                    "type": "Submodel",
+                    "value": "traceability/urn:bamm:io.catenax.part_as_planned:1.0.1#PartAsPlanned/urn:uuid:f5efbf45-7d84-4442-b3b8-05cf1c5c5a0b"
+                }
+            ],
+            "type": "ExternalReference"
+        }
+    ],
+    "id": "traceability/urn:uuid:f5efbf45-7d84-4442-b3b8-05cf1c5c5a0b",
+    "description": [
+        {
+            "language": "en",
+            "text": "Tier C Piston Rod"
+        }
+    ],
+    "idShort": "traceability/urn:uuid:f5efbf45-7d84-4442-b3b8-05cf1c5c5a0b"
+}
+```
+
+A particular submodel can be selected as follows
+
+```console
+curl --location 'http://oem-aas-bridge.knowledge.int.catena-x.net/api/v3.0/shells/dHJhY2VhYmlsaXR5L3Vybjp1dWlkOmY1ZWZiZjQ1LTdkODQtNDQ0Mi1iM2I4LTA1Y2YxYzVjNWEwYg=='
+```
+
+which would produce a result like
+
+```json
+{
+    "modelType": "AssetAdministrationShell",
+    "assetInformation": {
+        "assetKind": "Instance",
+        "globalAssetId": "traceability/urn:uuid:f5efbf45-7d84-4442-b3b8-05cf1c5c5a0b"
+    },
+    "submodels": [
+        {
+            "keys": [
+                {
+                    "type": "Submodel",
+                    "value": "traceability/urn:bamm:io.catenax.part_as_planned:1.0.1#PartAsPlanned/urn:uuid:f5efbf45-7d84-4442-b3b8-05cf1c5c5a0b"
+                }
+            ],
+            "type": "ExternalReference"
+        }
+    ],
+    "id": "traceability/urn:uuid:f5efbf45-7d84-4442-b3b8-05cf1c5c5a0b",
+    "description": [
+        {
+            "language": "en",
+            "text": "Tier C Piston Rod"
+        }
+    ],
+    "idShort": "traceability/urn:uuid:f5efbf45-7d84-4442-b3b8-05cf1c5c5a0b"
+}
+```
+
 <sub><sup>(C) 2021,2024 Contributors to the Eclipse Foundation. SPDX-License-Identifier: CC-BY-4.0</sup></sub>

--- a/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/operation-view/ka_conformity_scripts.postman_collection.json
+++ b/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/operation-view/ka_conformity_scripts.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"_postman_id": "0ad1b7a6-734c-4289-9221-667fc56a21da",
-		"name": "KA Conformity Assessment Scripts (R24.05)",
+		"name": "KA Conformity Assessment Scripts (R24.08)",
 		"description": "(C) 2021,2023 Contributors to the Eclipse Foundation\n\nSPDX-LICENSE-IDENTIFIER: CC-BY-4.0",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "2757771",
@@ -232,7 +232,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n        \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\",\n        \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n        \"sh\": \"http://www.w3.org/ns/shacl#\",\n        \"cs-taxo\": \"https://w3id.org/catenax/taxonomy#\",\n        \"dct\": \"https://purl.org/dc/terms/\"\n    },\n    \"@id\": \"GraphAsset?cab=Conforming&mode=open\",\n    \"properties\": {\n        \"cx-common:name\": \"Open Conforming Asset.\",\n        \"cx-common:description\": \"A graph asset/offering hosting a conforming agent for testing and conformity checking.\",\n        \"cx-common:version\": \"1.12.19\",\n        \"cx-common:contenttype\": \"application/json, application/xml\",\n        \"cx-common:publishedUnderContract\": \"Contract?cab=Asset&mode=open\",\n        \"dct:type\": \"cx-taxo:GraphAsset\",\n        \"rdfs:isDefinedBy\": \"<https://w3id.org/catenax/ontology/common>\",\n        \"cx-common:implementsProtocol\": \"cx-common:Protocol?w3c:http:SPARQL\",\n        \"sh:shapesGraph\": \"@prefix : <GraphAsset?cab=Conforming&mode=open#> .\\n\",\n        \"cx-common:isFederated\": \"true^^xsd:boolean\"\n    },\n    \"privateProperties\": {},\n    \"dataAddress\": {\n        \"id\": \"GraphAsset?cab=Conforming&mode=open\",\n        \"@type\": \"DataAddress\",\n        \"baseUrl\": \"{{cabConformingAgent}}/bind\",\n        \"type\": \"cx-common:Protocol?w3c:http:SPARQL\",\n        \"proxyPath\": \"false\",\n        \"proxyMethod\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
+							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n        \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\",\n        \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n        \"sh\": \"http://www.w3.org/ns/shacl#\",\n        \"cs-taxo\": \"https://w3id.org/catenax/taxonomy#\",\n        \"dct\": \"https://purl.org/dc/terms/\"\n    },\n    \"@id\": \"GraphAsset?cab=Conforming&mode=open\",\n    \"properties\": {\n        \"cx-common:name\": \"Open Conforming Asset.\",\n        \"cx-common:description\": \"A graph asset/offering hosting a conforming agent for testing and conformity checking.\",\n        \"cx-common:version\": \"1.13.22\",\n        \"cx-common:contenttype\": \"application/json, application/xml\",\n        \"cx-common:publishedUnderContract\": \"Contract?cab=Asset&mode=open\",\n        \"dct:type\": \"cx-taxo:GraphAsset\",\n        \"rdfs:isDefinedBy\": \"<https://w3id.org/catenax/ontology/common>\",\n        \"cx-common:implementsProtocol\": \"cx-common:Protocol?w3c:http:SPARQL\",\n        \"sh:shapesGraph\": \"@prefix : <GraphAsset?cab=Conforming&mode=open#> .\\n\",\n        \"cx-common:isFederated\": \"true^^xsd:boolean\"\n    },\n    \"privateProperties\": {},\n    \"dataAddress\": {\n        \"id\": \"GraphAsset?cab=Conforming&mode=open\",\n        \"@type\": \"DataAddress\",\n        \"baseUrl\": \"{{cabConformingAgent}}/bind\",\n        \"type\": \"cx-common:Protocol?w3c:http:SPARQL\",\n        \"proxyPath\": \"false\",\n        \"proxyMethod\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -281,7 +281,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n        \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\",\n        \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n        \"sh\": \"http://www.w3.org/ns/shacl#\",\n        \"cs-taxo\": \"https://w3id.org/catenax/taxonomy#\",\n        \"dct\": \"https://purl.org/dc/terms/\"\n    },\n    \"@id\": \"GraphAsset?cab=Conforming&mode=closed\",\n    \"properties\": {\n        \"cx-common:name\": \"Closed Conforming Asset.\",\n        \"cx-common:description\": \"A graph asset/offering hosting a conforming agent for testing and conformity checking.\",\n        \"cx-common:version\": \"1.12.19\",\n        \"cx-common:contenttype\": \"application/json, application/xml\",\n        \"cx-common:publishedUnderContract\": \"Contract?cab=Asset&mode=closed\",\n        \"dct:type\": \"cx-taxo:GraphAsset\",\n        \"rdfs:isDefinedBy\": \"<https://w3id.org/catenax/ontology/common>\",\n        \"cx-common:implementsProtocol\": \"cx-common:Protocol?w3c:http:SPARQL\",\n        \"sh:shapesGraph\": \"@prefix : <GraphAsset?cab=Conforming&mode=closed#> .\\n\",\n        \"cx-common:isFederated\": \"true^^xsd:boolean\"\n    },\n    \"privateProperties\": {},\n    \"dataAddress\": {\n        \"id\": \"GraphAsset?cab=Conforming&mode=closed\",\n        \"@type\": \"DataAddress\",\n        \"baseUrl\": \"{{cabConformingAgent}}/bind\",\n        \"type\": \"cx-common:Protocol?w3c:http:SPARQL\",\n        \"proxyPath\": \"false\",\n        \"proxyMethod\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
+							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n        \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\",\n        \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n        \"sh\": \"http://www.w3.org/ns/shacl#\",\n        \"cs-taxo\": \"https://w3id.org/catenax/taxonomy#\",\n        \"dct\": \"https://purl.org/dc/terms/\"\n    },\n    \"@id\": \"GraphAsset?cab=Conforming&mode=closed\",\n    \"properties\": {\n        \"cx-common:name\": \"Closed Conforming Asset.\",\n        \"cx-common:description\": \"A graph asset/offering hosting a conforming agent for testing and conformity checking.\",\n        \"cx-common:version\": \"1.13.22\",\n        \"cx-common:contenttype\": \"application/json, application/xml\",\n        \"cx-common:publishedUnderContract\": \"Contract?cab=Asset&mode=closed\",\n        \"dct:type\": \"cx-taxo:GraphAsset\",\n        \"rdfs:isDefinedBy\": \"<https://w3id.org/catenax/ontology/common>\",\n        \"cx-common:implementsProtocol\": \"cx-common:Protocol?w3c:http:SPARQL\",\n        \"sh:shapesGraph\": \"@prefix : <GraphAsset?cab=Conforming&mode=closed#> .\\n\",\n        \"cx-common:isFederated\": \"true^^xsd:boolean\"\n    },\n    \"privateProperties\": {},\n    \"dataAddress\": {\n        \"id\": \"GraphAsset?cab=Conforming&mode=closed\",\n        \"@type\": \"DataAddress\",\n        \"baseUrl\": \"{{cabConformingAgent}}/bind\",\n        \"type\": \"cx-common:Protocol?w3c:http:SPARQL\",\n        \"proxyPath\": \"false\",\n        \"proxyMethod\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -330,7 +330,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n        \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\",\n        \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n        \"sh\": \"http://www.w3.org/ns/shacl#\",\n        \"cs-taxo\": \"https://w3id.org/catenax/taxonomy#\",\n        \"dct\": \"https://purl.org/dc/terms/\"\n    },\n    \"@id\": \"GraphAsset?cab=Conforming&mode=unfederated\",\n    \"properties\": {\n        \"cx-common:name\": \"Unfederated Conforming Asset.\",\n        \"cx-common:description\": \"A graph asset/offering hosting a conforming agent for testing and conformity checking.\",\n        \"cx-common:version\": \"1.12.19\",\n        \"cx-common:contenttype\": \"application/json, application/xml\",\n        \"cx-common:publishedUnderContract\": \"Contract?cab=Graph&mode=open\",\n        \"dct:type\": \"cx-taxo:GraphAsset\",\n        \"rdfs:isDefinedBy\": \"<https://w3id.org/catenax/ontology/common>\",\n        \"cx-common:implementsProtocol\": \"cx-common:Protocol?w3c:http:SPARQL\",\n        \"sh:shapesGraph\": \"@prefix : <GraphAsset?cab=Conforming&mode=unfederated#> .\\n\",\n        \"cx-common:isFederated\": \"false^^xsd:boolean\"\n    },\n    \"privateProperties\": {},\n    \"dataAddress\": {\n        \"id\": \"GraphAsset?cab=Conforming&mode=unfederated\",\n        \"@type\": \"DataAddress\",\n        \"baseUrl\": \"{{cabConformingAgent}}/bind\",\n        \"type\": \"cx-common:Protocol?w3c:http:SPARQL\",\n        \"proxyPath\": \"false\",\n        \"proxyMethod\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
+							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n        \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\",\n        \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n        \"sh\": \"http://www.w3.org/ns/shacl#\",\n        \"cs-taxo\": \"https://w3id.org/catenax/taxonomy#\",\n        \"dct\": \"https://purl.org/dc/terms/\"\n    },\n    \"@id\": \"GraphAsset?cab=Conforming&mode=unfederated\",\n    \"properties\": {\n        \"cx-common:name\": \"Unfederated Conforming Asset.\",\n        \"cx-common:description\": \"A graph asset/offering hosting a conforming agent for testing and conformity checking.\",\n        \"cx-common:version\": \"1.13.22\",\n        \"cx-common:contenttype\": \"application/json, application/xml\",\n        \"cx-common:publishedUnderContract\": \"Contract?cab=Graph&mode=open\",\n        \"dct:type\": \"cx-taxo:GraphAsset\",\n        \"rdfs:isDefinedBy\": \"<https://w3id.org/catenax/ontology/common>\",\n        \"cx-common:implementsProtocol\": \"cx-common:Protocol?w3c:http:SPARQL\",\n        \"sh:shapesGraph\": \"@prefix : <GraphAsset?cab=Conforming&mode=unfederated#> .\\n\",\n        \"cx-common:isFederated\": \"false^^xsd:boolean\"\n    },\n    \"privateProperties\": {},\n    \"dataAddress\": {\n        \"id\": \"GraphAsset?cab=Conforming&mode=unfederated\",\n        \"@type\": \"DataAddress\",\n        \"baseUrl\": \"{{cabConformingAgent}}/bind\",\n        \"type\": \"cx-common:Protocol?w3c:http:SPARQL\",\n        \"proxyPath\": \"false\",\n        \"proxyMethod\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -453,7 +453,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n        \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\",\n        \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n        \"sh\": \"http://www.w3.org/ns/shacl#\",\n        \"cs-taxo\": \"https://w3id.org/catenax/taxonomy#\",\n        \"dct\": \"https://purl.org/dc/terms/\"\n    },\n    \"@id\": \"SkillAsset?cab=Conforming&mode=open\",\n    \"properties\": {\n        \"cx-common:name\": \"Open Skill\",\n        \"cx-common:description\": \"A conformity assessment skill.\",\n        \"cx-common:version\": \"1.12.19\",\n        \"cx-common:contenttype\": \"application/json, application/xml\",\n        \"cx-common:publishedUnderContract\": \"Contract?cab=Asset&mode=open\",\n        \"dct:type\": \"cx-taxo:SkillAsset\",\n        \"rdfs:isDefinedBy\": \"<https://w3id.org/catenax/ontology/core>\",\n        \"cx-common:implementsProtocol\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"cx-common:distributionMode\": \"cx-common:SkillDistribution?run=all\",\n        \"cx-common:isFederated\": \"true^^xsd:boolean\"\n    },\n    \"privateProperties\": {\n        \"cx-common:query\": \"# Sample Skill accessing a graph\\n\\nSELECT ?subject ?predicate ?object WHERE { \\n    SERVICE <edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN> {\\n        GRAPH <GraphAsset?cab=Conforming&mode=open> { \\n            ?subject ?predicate ?object. \\n        }\\n    } \\n}\"\n    },\n    \"dataAddress\": {\n        \"id\": \"SkillAsset?cab=Conforming&mode=open\",\n        \"@type\": \"DataAddress\",\n        \"type\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"proxyPath\": \"false\",\n        \"proxyMethod\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
+							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n        \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\",\n        \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n        \"sh\": \"http://www.w3.org/ns/shacl#\",\n        \"cs-taxo\": \"https://w3id.org/catenax/taxonomy#\",\n        \"dct\": \"https://purl.org/dc/terms/\"\n    },\n    \"@id\": \"SkillAsset?cab=Conforming&mode=open\",\n    \"properties\": {\n        \"cx-common:name\": \"Open Skill\",\n        \"cx-common:description\": \"A conformity assessment skill.\",\n        \"cx-common:version\": \"1.13.22\",\n        \"cx-common:contenttype\": \"application/json, application/xml\",\n        \"cx-common:publishedUnderContract\": \"Contract?cab=Asset&mode=open\",\n        \"dct:type\": \"cx-taxo:SkillAsset\",\n        \"rdfs:isDefinedBy\": \"<https://w3id.org/catenax/ontology/core>\",\n        \"cx-common:implementsProtocol\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"cx-common:distributionMode\": \"cx-common:SkillDistribution?run=all\",\n        \"cx-common:isFederated\": \"true^^xsd:boolean\"\n    },\n    \"privateProperties\": {\n        \"cx-common:query\": \"# Sample Skill accessing a graph\\n\\nSELECT ?subject ?predicate ?object WHERE { \\n    SERVICE <edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN> {\\n        GRAPH <GraphAsset?cab=Conforming&mode=open> { \\n            ?subject ?predicate ?object. \\n        }\\n    } \\n}\"\n    },\n    \"dataAddress\": {\n        \"id\": \"SkillAsset?cab=Conforming&mode=open\",\n        \"@type\": \"DataAddress\",\n        \"type\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"proxyPath\": \"false\",\n        \"proxyMethod\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -577,7 +577,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n        \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\",\n        \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n        \"sh\": \"http://www.w3.org/ns/shacl#\",\n        \"cs-taxo\": \"https://w3id.org/catenax/taxonomy#\",\n        \"dct\": \"https://purl.org/dc/terms/\"\n    },\n    \"@id\": \"SkillAsset?cab=Conforming&mode=closed\",\n    \"properties\": {\n        \"cx-common:name\": \"Closed Skill\",\n        \"cx-common:description\": \"A conformity assessment skill.\",\n        \"cx-common:version\": \"1.12.19\",\n        \"cx-common:contenttype\": \"application/json, application/xml\",\n        \"cx-common:publishedUnderContract\": \"Contract?cab=Asset&mode=closed\",\n        \"dct:type\": \"cx-taxo:SkillAsset\",\n        \"rdfs:isDefinedBy\": \"<https://w3id.org/catenax/ontology/core>\",\n        \"cx-common:implementsProtocol\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"cx-common:distributionMode\": \"cx-common:SkillDistribution?run=all\",\n        \"cx-common:isFederated\": \"false^^xsd:boolean\"\n    },\n    \"privateProperties\": {\n        \"cx-common:query\": \"# Sample Skill accessing a graph\\n\\nSELECT ?subject ?predicate ?object WHERE { \\n    SERVICE <edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN> {\\n        GRAPH <GraphAsset?cab=Conforming&mode=closed> { \\n            ?subject ?predicate ?object. \\n        }\\n    } \\n}\"\n    },\n    \"dataAddress\": {\n        \"id\": \"SkillAsset?cab=Conforming&mode=closed\",\n        \"@type\": \"DataAddress\",\n        \"type\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"proxyPath\": \"false\",\n        \"proxyMethod\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
+							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n        \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\",\n        \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n        \"sh\": \"http://www.w3.org/ns/shacl#\",\n        \"cs-taxo\": \"https://w3id.org/catenax/taxonomy#\",\n        \"dct\": \"https://purl.org/dc/terms/\"\n    },\n    \"@id\": \"SkillAsset?cab=Conforming&mode=closed\",\n    \"properties\": {\n        \"cx-common:name\": \"Closed Skill\",\n        \"cx-common:description\": \"A conformity assessment skill.\",\n        \"cx-common:version\": \"1.13.22\",\n        \"cx-common:contenttype\": \"application/json, application/xml\",\n        \"cx-common:publishedUnderContract\": \"Contract?cab=Asset&mode=closed\",\n        \"dct:type\": \"cx-taxo:SkillAsset\",\n        \"rdfs:isDefinedBy\": \"<https://w3id.org/catenax/ontology/core>\",\n        \"cx-common:implementsProtocol\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"cx-common:distributionMode\": \"cx-common:SkillDistribution?run=all\",\n        \"cx-common:isFederated\": \"false^^xsd:boolean\"\n    },\n    \"privateProperties\": {\n        \"cx-common:query\": \"# Sample Skill accessing a graph\\n\\nSELECT ?subject ?predicate ?object WHERE { \\n    SERVICE <edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN> {\\n        GRAPH <GraphAsset?cab=Conforming&mode=closed> { \\n            ?subject ?predicate ?object. \\n        }\\n    } \\n}\"\n    },\n    \"dataAddress\": {\n        \"id\": \"SkillAsset?cab=Conforming&mode=closed\",\n        \"@type\": \"DataAddress\",\n        \"type\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"proxyPath\": \"false\",\n        \"proxyMethod\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -701,7 +701,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n        \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\",\n        \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n        \"sh\": \"http://www.w3.org/ns/shacl#\",\n        \"cs-taxo\": \"https://w3id.org/catenax/taxonomy#\",\n        \"dct\": \"https://purl.org/dc/terms/\"\n    },\n    \"@id\": \"SkillAsset?cab=Conforming&mode=provider\",\n    \"properties\": {\n        \"cx-common:name\": \"Provider-Forced Skill\",\n        \"cx-common:description\": \"A conformity assessment skill.\",\n        \"cx-common:version\": \"1.12.19\",\n        \"cx-common:contenttype\": \"application/json, application/xml\",\n        \"cx-common:publishedUnderContract\": \"Contract?cab=Asset&mode=open\",\n        \"dct:type\": \"cx-taxo:SkillAsset\",\n        \"rdfs:isDefinedBy\": \"<https://w3id.org/catenax/ontology/core>\",\n        \"cx-common:implementsProtocol\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"cx-common:distributionMode\": \"cx-common:SkillDistribution?run=provider\",\n        \"cx-common:isFederated\": \"true^^xsd:boolean\"\n    },\n    \"privateProperties\": {\n        \"cx-common:query\": \"# Sample Skill accessing a graph\\n\\nSELECT ?subject ?predicate ?object WHERE { \\n    SERVICE <edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN> {\\n        GRAPH <GraphAsset?cab=Conforming&mode=open> { \\n            ?subject ?predicate ?object. \\n        }\\n    } \\n}\"\n    },\n    \"dataAddress\": {\n        \"id\": \"SkillAsset?cab=Conforming&mode=provider\",\n        \"@type\": \"DataAddress\",\n        \"type\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"proxyPath\": \"false\",\n        \"proxyMethod\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
+							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n        \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\",\n        \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n        \"sh\": \"http://www.w3.org/ns/shacl#\",\n        \"cs-taxo\": \"https://w3id.org/catenax/taxonomy#\",\n        \"dct\": \"https://purl.org/dc/terms/\"\n    },\n    \"@id\": \"SkillAsset?cab=Conforming&mode=provider\",\n    \"properties\": {\n        \"cx-common:name\": \"Provider-Forced Skill\",\n        \"cx-common:description\": \"A conformity assessment skill.\",\n        \"cx-common:version\": \"1.13.22\",\n        \"cx-common:contenttype\": \"application/json, application/xml\",\n        \"cx-common:publishedUnderContract\": \"Contract?cab=Asset&mode=open\",\n        \"dct:type\": \"cx-taxo:SkillAsset\",\n        \"rdfs:isDefinedBy\": \"<https://w3id.org/catenax/ontology/core>\",\n        \"cx-common:implementsProtocol\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"cx-common:distributionMode\": \"cx-common:SkillDistribution?run=provider\",\n        \"cx-common:isFederated\": \"true^^xsd:boolean\"\n    },\n    \"privateProperties\": {\n        \"cx-common:query\": \"# Sample Skill accessing a graph\\n\\nSELECT ?subject ?predicate ?object WHERE { \\n    SERVICE <edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN> {\\n        GRAPH <GraphAsset?cab=Conforming&mode=open> { \\n            ?subject ?predicate ?object. \\n        }\\n    } \\n}\"\n    },\n    \"dataAddress\": {\n        \"id\": \"SkillAsset?cab=Conforming&mode=provider\",\n        \"@type\": \"DataAddress\",\n        \"type\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"proxyPath\": \"false\",\n        \"proxyMethod\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -825,7 +825,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n        \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\",\n        \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n        \"sh\": \"http://www.w3.org/ns/shacl#\",\n        \"cs-taxo\": \"https://w3id.org/catenax/taxonomy#\",\n        \"dct\": \"https://purl.org/dc/terms/\"\n    },\n    \"@id\": \"SkillAsset?cab=Conforming&mode=consumer\",\n    \"properties\": {\n        \"cx-common:name\": \"Consumer-Forced Skill\",\n        \"cx-common:description\": \"A conformity assessment skill.\",\n        \"cx-common:version\": \"1.12.19\",\n        \"cx-common:contenttype\": \"application/json, application/xml\",\n        \"cx-common:publishedUnderContract\": \"Contract?cab=Asset&mode=open\",\n        \"dct:type\": \"cx-taxo:SkillAsset\",\n        \"rdfs:isDefinedBy\": \"<https://w3id.org/catenax/ontology/core>\",\n        \"cx-common:implementsProtocol\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"cx-common:distributionMode\": \"cx-common:SkillDistribution?run=consumer\",\n        \"cx-common:isFederated\": \"true^^xsd:boolean\"\n    },\n    \"privateProperties\": {\n        \"cx-common:query\": \"# Sample Skill accessing a graph\\n\\nSELECT ?subject ?predicate ?object WHERE { \\n    SERVICE <edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN> {\\n        GRAPH <GraphAsset?cab=Conforming&mode=open> { \\n            ?subject ?predicate ?object. \\n        }\\n    } \\n}\"\n    },\n    \"dataAddress\": {\n        \"id\": \"SkillAsset?cab=Conforming&mode=consumer\",\n        \"@type\": \"DataAddress\",\n        \"type\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"proxyPath\": \"false\",\n        \"proxyMethod\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
+							"raw": "{\n    \"@context\": {\n        \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n        \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n        \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n        \"cx-common\": \"https://w3id.org/catenax/ontology/common#\",\n        \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n        \"sh\": \"http://www.w3.org/ns/shacl#\",\n        \"cs-taxo\": \"https://w3id.org/catenax/taxonomy#\",\n        \"dct\": \"https://purl.org/dc/terms/\"\n    },\n    \"@id\": \"SkillAsset?cab=Conforming&mode=consumer\",\n    \"properties\": {\n        \"cx-common:name\": \"Consumer-Forced Skill\",\n        \"cx-common:description\": \"A conformity assessment skill.\",\n        \"cx-common:version\": \"1.13.22\",\n        \"cx-common:contenttype\": \"application/json, application/xml\",\n        \"cx-common:publishedUnderContract\": \"Contract?cab=Asset&mode=open\",\n        \"dct:type\": \"cx-taxo:SkillAsset\",\n        \"rdfs:isDefinedBy\": \"<https://w3id.org/catenax/ontology/core>\",\n        \"cx-common:implementsProtocol\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"cx-common:distributionMode\": \"cx-common:SkillDistribution?run=consumer\",\n        \"cx-common:isFederated\": \"true^^xsd:boolean\"\n    },\n    \"privateProperties\": {\n        \"cx-common:query\": \"# Sample Skill accessing a graph\\n\\nSELECT ?subject ?predicate ?object WHERE { \\n    SERVICE <edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN> {\\n        GRAPH <GraphAsset?cab=Conforming&mode=open> { \\n            ?subject ?predicate ?object. \\n        }\\n    } \\n}\"\n    },\n    \"dataAddress\": {\n        \"id\": \"SkillAsset?cab=Conforming&mode=consumer\",\n        \"@type\": \"DataAddress\",\n        \"type\": \"cx-common:Protocol?w3c:http:SKILL\",\n        \"proxyPath\": \"false\",\n        \"proxyMethod\": \"true\",\n        \"proxyQueryParams\": \"true\",\n        \"proxyBody\": \"true\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3298,6 +3298,402 @@
 											]
 										},
 										"description": "A sample SparQL query with a more complex binding where the input is a json document."
+									},
+									"response": []
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "0303_PROVIDER_AAS",
+					"item": [
+						{
+							"name": "030301_PROVIDER_AAS_BRIDGE",
+							"item": [
+								{
+									"name": "030301_AAS_DESCRIPTION",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"AAS 3.0 description was successful\", function () {",
+													"    pm.expect(pm.response.code).oneOf([200]);",
+													"    res = pm.response.json();",
+													"\t\tpm.expect(res).to.have.property('profiles');",
+													"\t\tpm.expect(res.profiles).to.have.length.gte(1);",
+													"\t\taasProfiles=res.profiles.filter(function(profile) {",
+													"\t\t\treturn profile.includes(\"AssetAdministrationShellRepository\");",
+													"\t\t});",
+													"\t\tpm.expect(aasProfiles.length).to.be.eq(1);",
+													"\t\tsubmodelProfiles=res.profiles.filter(function(profile) {",
+													"\t\t\treturn profile.includes(\"SubmodelRepository\");",
+													"\t\t});",
+													"        pm.expect(submodelProfiles.length).to.be.eq(1);",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disabledSystemHeaders": {
+											"accept": true,
+											"user-agent": true,
+											"accept-encoding": true,
+											"connection": true
+										}
+									},
+									"request": {
+										"auth": {
+											"type": "noauth"
+										},
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{providerAasBridge}}/api/v3.0/description",
+											"host": [
+												"{{providerAasBridge}}"
+											],
+											"path": [
+												"api",
+												"v3.0",
+												"description"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "030302_AAS_ALL_SHELLS",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"AAS 3.0 shells was successful\", function () {",
+													"    pm.expect(pm.response.code).oneOf([200]);",
+													"    res = pm.response.json();",
+													"\tpm.expect(res).to.have.property('result');",
+													"\tpm.expect(res.result).to.have.length.gte(1);",
+													"\tres.result.forEach(function(shell) {",
+													"        pm.expect(shell).to.have.property(\"id\");",
+													"        pm.expect(shell).to.have.property(\"idShort\");",
+													"        pm.expect(shell).to.have.property(\"assetInformation\");",
+													"        pm.expect(shell.assetInformation).to.have.property(\"globalAssetId\");",
+													"        pm.expect(shell).to.have.property(\"submodels\");",
+													"        pm.expect(shell.submodels).to.have.length.gte(1);",
+													"        shell.submodels.forEach(function(submodel) {",
+													"            pm.expect(submodel).to.have.property(\"keys\");",
+													"            pm.expect(submodel.keys).to.have.length.gte(1);",
+													"        });",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{providerAasBridge}}/api/v3.0/shells",
+											"host": [
+												"{{providerAasBridge}}"
+											],
+											"path": [
+												"api",
+												"v3.0",
+												"shells"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "030303_AAS_ALL_SUBMODELS",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"AAS 3.0 submodels was successful\", function () {",
+													"    pm.expect(pm.response.code).oneOf([200]);",
+													"    res = pm.response.json();",
+													"\tpm.expect(res).to.have.property('result');",
+													"\tpm.expect(res.result).to.have.length.gte(1);",
+													"\tres.result.forEach(function(submodel) {",
+													"        pm.expect(submodel).to.have.property(\"id\");",
+													"        pm.expect(submodel).to.have.property(\"idShort\");",
+													"        pm.expect(submodel).to.have.property(\"semanticId\");",
+													"        pm.expect(submodel.semanticId).to.have.property(\"keys\");",
+													"        pm.expect(submodel.semanticId.keys).to.have.length.gte(1);",
+													"        pm.expect(submodel).to.have.property(\"submodelElements\");",
+													"        pm.expect(submodel.submodelElements).to.have.length.gte(1);",
+													"        submodel.submodelElements.forEach(function(submodelElement) {",
+													"            pm.expect(submodelElement).to.have.property(\"idShort\");",
+													"            pm.expect(submodelElement).to.have.property(\"value\");",
+													"        });",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{providerAasBridge}}/api/v3.0/submodels?content=value&level=deep",
+											"host": [
+												"{{providerAasBridge}}"
+											],
+											"path": [
+												"api",
+												"v3.0",
+												"submodels"
+											],
+											"query": [
+												{
+													"key": "content",
+													"value": "value"
+												},
+												{
+													"key": "level",
+													"value": "deep"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "030304_ONE_SHELL",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"AAS 3.0 specific shell was successful\", function () {",
+													"    pm.expect(pm.response.code).oneOf([200]);",
+													"    shell = pm.response.json();",
+													"    pm.expect(shell).to.have.property(\"id\");",
+													"    pm.expect(shell).to.have.property(\"idShort\");",
+													"    pm.expect(shell).to.have.property(\"assetInformation\");",
+													"    pm.expect(shell.assetInformation).to.have.property(\"globalAssetId\");",
+													"    pm.expect(shell).to.have.property(\"submodels\");",
+													"    pm.expect(shell.submodels).to.have.length.gte(1);",
+													"    shell.submodels.forEach(function(submodel) {",
+													"        pm.expect(submodel).to.have.property(\"keys\");",
+													"        pm.expect(submodel.keys).to.have.length.gte(1);",
+													"    });",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{providerAasBridge}}/api/v3.0/shells/:shellid",
+											"host": [
+												"{{providerAasBridge}}"
+											],
+											"path": [
+												"api",
+												"v3.0",
+												"shells",
+												":shellid"
+											],
+											"variable": [
+												{
+													"key": "shellid",
+													"value": "dHJhY2VhYmlsaXR5L3Vybjp1dWlkOmY1ZWZiZjQ1LTdkODQtNDQ0Mi1iM2I4LTA1Y2YxYzVjNWEwYg=="
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "030305_NOTEXISTS_SHELL",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"AAS 3.0 not existant shell wasfailure\", function () {",
+													"  pm.expect(pm.response.code).oneOf([400,500]);",
+													"  message = pm.response.json();",
+													"\tpm.expect(message).to.have.property(\"messages\");",
+													"\tpm.expect(message.messages).to.have.length.gte(1);",
+													"\tmessage.messages.forEach(function(message) {",
+													"\t\t\tpm.expect(message).to.have.property(\"messageType\");",
+													"\t\t\tpm.expect(message).to.have.property(\"text\");",
+													"\t\t\tpm.expect(message).to.have.property(\"code\");",
+													"\t\t\tpm.expect(message).to.have.property(\"timestamp\");",
+													"\t});",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{providerAasBridge}}/api/v3.0/shells/:shellid",
+											"host": [
+												"{{providerAasBridge}}"
+											],
+											"path": [
+												"api",
+												"v3.0",
+												"shells",
+												":shellid"
+											],
+											"variable": [
+												{
+													"key": "shellid",
+													"value": "dHJhY2VhYmlsaXR5L3Vybjp1dWlkOmY1ZWZiZjQ1LTdkODQtNDQ0Mi1iM2I4LTA1Y2YxYzVjNWEwYw=="
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "030306_ONE_SUBMODEL",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"AAS 3.0 specific submodel was successful\", function () {",
+													"  pm.expect(pm.response.code).oneOf([200]);",
+													"  submodel = pm.response.json();",
+													"\tpm.expect(submodel).to.have.property(\"id\");",
+													"\tpm.expect(submodel).to.have.property(\"idShort\");",
+													"\tpm.expect(submodel).to.have.property(\"semanticId\");",
+													"\tpm.expect(submodel.semanticId).to.have.property(\"keys\");",
+													"\tpm.expect(submodel.semanticId.keys).to.have.length.gte(1);",
+													"\tpm.expect(submodel).to.have.property(\"submodelElements\");",
+													"\tpm.expect(submodel.submodelElements).to.have.length.gte(1);",
+													"\tsubmodel.submodelElements.forEach(function(submodelElement) {",
+													"\t\t\tpm.expect(submodelElement).to.have.property(\"idShort\");",
+													"\t\t\tpm.expect(submodelElement).to.have.property(\"value\");",
+													"\t});",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{providerAasBridge}}/api/v3.0/submodels/:submodelIdentifier?level=deep",
+											"host": [
+												"{{providerAasBridge}}"
+											],
+											"path": [
+												"api",
+												"v3.0",
+												"submodels",
+												":submodelIdentifier"
+											],
+											"query": [
+												{
+													"key": "level",
+													"value": "deep"
+												},
+												{
+													"key": "content",
+													"value": "value",
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "submodelIdentifier",
+													"value": "dHJhY2VhYmlsaXR5L3VybjpiYW1tOmlvLmNhdGVuYXgucGFydF9hc19wbGFubmVkOjEuMC4xI1BhcnRBc1BsYW5uZWQvdXJuOnV1aWQ6ZjVlZmJmNDUtN2Q4NC00NDQyLWIzYjgtMDVjZjFjNWM1YTBi"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "030307_NOTEXISTS_SUBMODEL",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"AAS 3.0 not existant submodel wasfailure\", function () {",
+													"  pm.expect(pm.response.code).oneOf([400,500]);",
+													"  message = pm.response.json();",
+													"\tpm.expect(message).to.have.property(\"messages\");",
+													"\tpm.expect(message.messages).to.have.length.gte(1);",
+													"\tmessage.messages.forEach(function(message) {",
+													"\t\t\tpm.expect(message).to.have.property(\"messageType\");",
+													"\t\t\tpm.expect(message).to.have.property(\"text\");",
+													"\t\t\tpm.expect(message).to.have.property(\"code\");",
+													"\t\t\tpm.expect(message).to.have.property(\"timestamp\");",
+													"\t});",
+													"});"
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{providerAasBridge}}/api/v3.0/submodels/:submodelIdentifier?level=deep",
+											"host": [
+												"{{providerAasBridge}}"
+											],
+											"path": [
+												"api",
+												"v3.0",
+												"submodels",
+												":submodelIdentifier"
+											],
+											"query": [
+												{
+													"key": "level",
+													"value": "deep"
+												},
+												{
+													"key": "content",
+													"value": "value",
+													"disabled": true
+												}
+											],
+											"variable": [
+												{
+													"key": "submodelIdentifier",
+													"value": "dHJhY2VhYmlsaXR5L3VybjpiYW1tOmlvLmNhdGVuYXgucGFydF9zaXRlX2luZm9ybWF0aW9uX2FzX3BsYW5uZWQ6MS4wLjAjUGFydFNpdGVJbmZvcm1hdGlvbkFzUGxhbm5lZC91cm46dXVpZDplNWM5NmFiNS04OTZhLTQ4MmMtODc2MS1lZmQ3NDc3N2NhOTc="
+												}
+											]
+										}
 									},
 									"response": []
 								}

--- a/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/operation-view/policy.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/operation-view/policy.md
@@ -117,7 +117,7 @@ A result from would look like this
                 },
                 "version": {
                     "type": "literal",
-                    "value": "1.12.19"
+                    "value": "1.13.22"
                 }
             },
             {

--- a/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/operation-view/provider.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/operation-view/provider.md
@@ -50,7 +50,7 @@ Add a helm dependency to your umbrella/infrastructure Chart.yaml (this example u
 ```yaml
     - name: provisioning-agent
       repository: https://eclipse-tractusx.github.io/charts/dev
-      version: 1.12.19
+      version: 1.13.22
       alias: my-provider-agent
 ```
 
@@ -317,7 +317,7 @@ Add a helm dependency to your umbrella/infrastructure Chart.yaml (this example u
 ```yaml
     - name: remoting-agent
       repository: https://eclipse-tractusx.github.io/charts/dev
-      version: 1.12.19
+      version: 1.13.22
       alias: my-remoting-agent
 ```
 
@@ -1112,7 +1112,7 @@ curl --location --globoff 'https://my-connector-control.domain/management/v3/ass
         "cx-common:name": "Lifetime Prognosis Service for Gearboxes",
         "cx-common:description": "A sample graph asset/offering referring to a specific prognosis resource.",
         "cx-common:description@de": "Ein Beispielasset für eine Prognosefunktion.",
-        "cx-common:version": "1.12.19",
+        "cx-common:version": "1.13.22",
         "cx-common:contenttype": "application/json, application/xml",
         "cx-common:publishedUnderContract": "Contract?supplier=Graph",
         "dc:type": "cx-taxo:GraphAsset",
@@ -1158,7 +1158,7 @@ curl --location --globoff 'https://my-connector-control.domain/management/v3/ass
         "cx-common:name": "Health Prognosis Service for Gearboxes",
         "cx-common:description": "A second sample graph asset/offering referring to a specific prognosis resource.",
         "cx-common:description@de": "Ein weiteres Beispielasset für eine Prognosefunktion.",
-        "cx-common:version": "1.12.19",
+        "cx-common:version": "1.13.22",
         "cx-common:contenttype": "application/json, application/xml",
         "cx-common:publishedUnderContract": "Contract?supplier=Graph",
         "dc:type": "cx-taxo:GraphAsset",

--- a/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/operation-view/testbed.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/operation-view/testbed.md
@@ -57,6 +57,8 @@ The scripts are organised as follows:
     * 030101_PROVIDER_DATA_SPARQL - scripts to be run against Data Provider Agents
   * 0302_PROVIDER_FUNCTION - scripts to be run at Function Provider CAPs
     * 030201_PROVIDER_FUNCTION_SPARQL - scripts to be run against Function Provider Agents
+  * 0303_PROVIDER_AAS - scripts to be run at AAS Provider CAPs
+    * 030301_PROVIDER_AAS_API - scripts to be run against AAS Provider Bridge
 * 04_CONSUMER - scripts to be run against Consumer CAPs
   * 0401_CONSUMER_APPLICATION - scripts to be run against a KA-enabled Application
     * 040101_CONSUMER_APPLICATION_SPARQL  - scripts to be run against a SPARQL-speaking Application
@@ -184,7 +186,7 @@ The CAB may use the following Graph Asset Descriptions (referring to the contrac
     "properties": {
         "cx-common:name": "Open Conforming Asset.",
         "cx-common:description": "A graph asset/offering hosting a conforming agent for testing and conformity checking.",
-        "cx-common:version": "1.12.19",
+        "cx-common:version": "1.13.22",
         "cx-common:contenttype": "application/json, application/xml",
         "cx-common:publishedUnderContract": "Contract?cab=Asset&mode=open",
         "dct:type": "cx-taxo:GraphAsset",
@@ -225,7 +227,7 @@ The CAB may use the following Graph Asset Descriptions (referring to the contrac
     "properties": {
         "cx-common:name": "Closed Conforming Asset.",
         "cx-common:description": "A graph asset/offering hosting a conforming agent for testing and conformity checking.",
-        "cx-common:version": "1.12.19",
+        "cx-common:version": "1.13.22",
         "cx-common:contenttype": "application/json, application/xml",
         "cx-common:publishedUnderContract": "Contract?cab=Asset&mode=closed",
         "dct:type": "cx-taxo:GraphAsset",
@@ -266,7 +268,7 @@ The CAB may use the following Graph Asset Descriptions (referring to the contrac
     "properties": {
         "cx-common:name": "Unfederated Conforming Asset.",
         "cx-common:description": "A graph asset/offering hosting a conforming agent for testing and conformity checking.",
-        "cx-common:version": "1.12.19",
+        "cx-common:version": "1.13.22",
         "cx-common:contenttype": "application/json, application/xml",
         "cx-common:publishedUnderContract": "Contract?cab=Graph&mode=open",
         "dct:type": "cx-taxo:GraphAsset",
@@ -311,7 +313,7 @@ The CAB may use the following Skill Asset Descriptions (referring to the contrac
     "properties": {
         "cx-common:name": "Open Skill",
         "cx-common:description": "A conformity assessment skill.",
-        "cx-common:version": "1.12.19",
+        "cx-common:version": "1.13.22",
         "cx-common:contenttype": "application/json, application/xml",
         "cx-common:publishedUnderContract": "Contract?cab=Asset&mode=open",
         "dct:type": "cx-taxo:SkillAsset",
@@ -353,7 +355,7 @@ The CAB may use the following Skill Asset Descriptions (referring to the contrac
     "properties": {
         "cx-common:name": "Closed Skill",
         "cx-common:description": "A conformity assessment skill.",
-        "cx-common:version": "1.12.19",
+        "cx-common:version": "1.13.22",
         "cx-common:contenttype": "application/json, application/xml",
         "cx-common:publishedUnderContract": "Contract?cab=Asset&mode=closed",
         "dct:type": "cx-taxo:SkillAsset",
@@ -395,7 +397,7 @@ The CAB may use the following Skill Asset Descriptions (referring to the contrac
     "properties": {
         "cx-common:name": "Provider-Forced Skill",
         "cx-common:description": "A conformity assessment skill.",
-        "cx-common:version": "1.12.19",
+        "cx-common:version": "1.13.22",
         "cx-common:contenttype": "application/json, application/xml",
         "cx-common:publishedUnderContract": "Contract?cab=Asset&mode=open",
         "dct:type": "cx-taxo:SkillAsset",
@@ -437,7 +439,7 @@ The CAB may use the following Skill Asset Descriptions (referring to the contrac
     "properties": {
         "cx-common:name": "Consumer-Forced Skill",
         "cx-common:description": "A conformity assessment skill.",
-        "cx-common:version": "1.12.19",
+        "cx-common:version": "1.13.22",
         "cx-common:contenttype": "application/json, application/xml",
         "cx-common:publishedUnderContract": "Contract?cab=Asset&mode=open",
         "dct:type": "cx-taxo:SkillAsset",

--- a/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/page_changelog.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/page_changelog.md
@@ -32,6 +32,16 @@ sidebar_position: 1
 
 All notable changes to the (Knowledge) Agents KIT will be documented in this file.
 
+## [1.2.0] - 2024-07-29
+
+### Added
+
+- AAS Bridge Released
+
+### Changed
+
+- References to 24.08 (1.31.22/1.13.7)
+
 ## [1.1.0] - 2024-05-13
 
 ### Added


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

Companion PR to https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/pull/1006 in order to sync the versioned folder of the knowledge agents kit 24.08 with its main version.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

DEPs are outdated already in the main branch. Did not do any changes to the modules.

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
