### PR TITLE
Updated digital twin consumption sequence diagram

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1228,7 +1228,7 @@ npm/npmjs/@nodelib/fs.walk/1.2.8, MIT, approved, clearlydefined
 npm/npmjs/@paloaltonetworks/openapi-to-postmanv2/3.1.0-hotfix.1, Apache-2.0 AND (Apache-2.0 AND MIT) AND BSD-2-Clause-Views AND (Apache-2.0 AND BSD-2-Clause AND MIT) AND MIT, approved, #6641
 npm/npmjs/@paloaltonetworks/postman-code-generators/1.1.12, Apache-2.0, approved, #6636
 npm/npmjs/@paloaltonetworks/postman-collection/4.1.1, Apache-2.0, approved, #6638
-npm/npmjs/@polka/url/1.0.0-next.21, MIT, approved, clearlydefined
+npm/npmjs/@polka/url/1.0.0-next.21, MIT, approved, #16183
 npm/npmjs/@popperjs/core/2.11.6, MIT, approved, clearlydefined
 npm/npmjs/@redocly/ajv/8.11.0, MIT, approved, clearlydefined
 npm/npmjs/@redocly/openapi-core/1.0.0-beta.120, MIT AND Apache-2.0, approved, #6639
@@ -1283,7 +1283,7 @@ npm/npmjs/@types/node/18.11.18, MIT, approved, #5746
 npm/npmjs/@types/parse-json/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/@types/parse5/5.0.3, MIT, approved, clearlydefined
 npm/npmjs/@types/parse5/6.0.3, MIT, approved, clearlydefined
-npm/npmjs/@types/prop-types/15.7.5, MIT, approved, clearlydefined
+npm/npmjs/@types/prop-types/15.7.5, MIT, approved, #16176
 npm/npmjs/@types/qs/6.9.7, MIT, approved, #13991
 npm/npmjs/@types/range-parser/1.2.4, MIT, approved, #10795
 npm/npmjs/@types/react-is/17.0.3, MIT, approved, #8424

--- a/docs-kits/kits/Digital Twin Kit/Software Development View/page_interaction-patterns.md
+++ b/docs-kits/kits/Digital Twin Kit/Software Development View/page_interaction-patterns.md
@@ -84,6 +84,7 @@ sequenceDiagram
     participant Con as Data Consumer
     participant CEDC as Consumer EDC <br/>Control Plane
     participant PEDC as Provider EDC <br/>Control Plane
+    participant PEDCDP as Provider EDC <br/>Data Plane
     participant DTR as Digital Twin Registry
     participant SM as Submodel Server
     participant EDCD as EDC Discovery
@@ -109,8 +110,10 @@ autonumber
         CEDC-->>Con: Dataset for submodel(-bundle)
         Con->>PEDC: negotiate for Dataset and retrieve token
         PEDC-->>Con: access token
-        Con->>SM: GET {{submodel-descriptor/href}}/$value
-        SM-->>Con: data
+        Con->>PEDCDP: GET {{submodel-descriptor/href}}/$value
+        PEDCDP-->>SM: consume
+        SM-->>PEDCDP: return
+        PEDCDP-->>Con: data
 ```
 
 If the `data` is a Bill of


### PR DESCRIPTION
In the EDC context, the data consumer does not bypass the EDC so fetch the data from the submodel server. That would mean that the submodel server is reachable via public internet. The standard dictates that the dataflow happens via the EDC. Also, in the previous diagram is described, that the digital twin in the submodel server is registered as an asset in the EDC. Why doing that, if the EDC is bypassed and the asset never consumed?

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
