### PR TITLE
fix(open-meetings): adapt the dates for open meetings

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -89,7 +89,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 />
 
 <MeetingInfo title="Refinement Day 1 - Release 25.03"
-             schedule="Monday, 14. October 2024, 09:05 AM to 12:00 PM (CEST)"
+             schedule="Wednesday, 16. October 2024, 09:05 AM to 12:00 PM (CEST)"
              description="This event is organised and moderated by the Catena-X Association. Based on a predefined agenda (depending on the features on the board), individual dependencies are discussed and also documented directly on the feature. If the refinement of the features has already been carried out 'in the refinement phase' and the Definition of Entry (DoE) has already reached, this meeting can also be used as synchronisation."
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_OGYzZGM3Y2ItMDA3MC00NDVmLWJlMzItZWRjNjQ4NmQ5YmRl%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
@@ -119,7 +119,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 />
 
 <MeetingInfo title="Refinement Day 2 - Release 25.03"
-             schedule="Monday, 04. November 2024, 09:05 AM to 12:00 PM (CEST)"
+             schedule="Wednesday, 06. November 2024, 09:05 AM to 12:00 PM (CEST)"
              description="This event is organised and moderated by the Catena-X Association. Based on a predefined agenda (depending on the features on the board), individual dependencies are discussed and also documented directly on the feature. If the refinement of the features has already been carried out 'in the refinement phase' and the Definition of Entry (DoE) has already reached, this meeting can also be used as synchronisation."
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NDQzNTQ0MWItODc4Ni00NTc3LWI3MWEtMjhiMzAwNjk3YzM3%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"

--- a/static/meetings/refinement-day-1---release-2503.ics
+++ b/static/meetings/refinement-day-1---release-2503.ics
@@ -15,9 +15,9 @@ END:VTIMEZONE
 
 BEGIN:VEVENT
 UID:Refinement Day 1 - Release 25.03
-DTSTAMP:20240925T094139Z
-DTSTART;TZID=Europe/Berlin:20241014T090500
-DTEND;TZID=Europe/Berlin:20241014T120000
+DTSTAMP:20240926T184747Z
+DTSTART;TZID=Europe/Berlin:20241016T090500
+DTEND;TZID=Europe/Berlin:20241016T120000
 SUMMARY:Refinement Day 1 - Release 25.03
 DESCRIPTION:This event is organised and moderated by the Catena-X Association. Based on a predefined agenda (depending on the features on the board), individual dependencies are discussed and also documented directly on the feature. If the refinement of the features has already been carried out 'in the refinement phase' and the Definition of Entry (DoE) has already reached, this meeting can also be used as synchronisation.
 ORGANIZER;CN=Catena-X Automotive Network e.V.:MAILTO:stephan.bauer@catena-x.net

--- a/static/meetings/refinement-day-2---release-2503.ics
+++ b/static/meetings/refinement-day-2---release-2503.ics
@@ -15,9 +15,9 @@ END:VTIMEZONE
 
 BEGIN:VEVENT
 UID:Refinement Day 2 - Release 25.03
-DTSTAMP:20240925T094139Z
-DTSTART;TZID=Europe/Berlin:20241104T090500
-DTEND;TZID=Europe/Berlin:20241104T120000
+DTSTAMP:20240926T184747Z
+DTSTART;TZID=Europe/Berlin:20241106T090500
+DTEND;TZID=Europe/Berlin:20241106T120000
 SUMMARY:Refinement Day 2 - Release 25.03
 DESCRIPTION:This event is organised and moderated by the Catena-X Association. Based on a predefined agenda (depending on the features on the board), individual dependencies are discussed and also documented directly on the feature. If the refinement of the features has already been carried out 'in the refinement phase' and the Definition of Entry (DoE) has already reached, this meeting can also be used as synchronisation.
 ORGANIZER;CN=Catena-X Automotive Network e.V.:MAILTO:stephan.bauer@catena-x.net


### PR DESCRIPTION
## Description

Unfortunately, we have to reschedule the meetings for the Refinement Day 1 and 2. Both were on Mondays, which is not perfect. With this PR, both are moved for two Days to Wednesday.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
