### PR TITLE
docs(news-blog): add new entry for refinement day 2

### DIFF
--- a/blog/2024-10-16-refinement-day-1-R25.03.mdx
+++ b/blog/2024-10-16-refinement-day-1-R25.03.mdx
@@ -1,0 +1,103 @@
+---
+title: Refinement Day 1 for Release 25.03
+description: Tractus-X Community Update - Refinement Day 1 for Release 25.03
+slug: refinement-day-1-R25.03
+date: 2024-10-09T09:00
+hide_table_of_contents: false
+authors:
+  - name: Stephan Bauer
+    title: Platform Domain Manager
+    url: https://github.com/stephanbcbauer
+    image_url: https://github.com/stephanbcbauer.png
+    email: stephan.bauer@catena-x.net
+---
+
+import RenderImage from './RenderImage'
+
+![eclipse tractus x logo](@site/static/img/Tractus-X_openplanning.png)
+
+Hello, Eclipse Tractus-X Community!
+
+We’re excited to announce **Refinement Day 1**, taking place on **October 16th, from 09:05 to 12:00**. This event is focused on refining features for the
+upcoming **Release 25.03**. Unlike previous meetings, this won't just be a feature presentation day — we’ll be diving into hands-on work, helping each other
+refine features and identify dependencies.
+
+The blocker and overall teams session link can be found on our [open-meetings](https://eclipse-tractusx.github.io/community/open-meetings#Refinement%20Day%201%20-%20Release%2025.03) page. We look forward to seeing you all there!
+
+<!--truncate-->
+
+## Agenda for Refinement Day 1
+
+Here’s the plan for the day:
+- **09:05 - 09:30**: Welcome, Introduction, and Expectations
+- **09:30 - 11:15**: Refinement in dedicated groups, grouped by expert groups
+- **11:15 - 11:45**: Presenting the results, grouped by expert groups
+- **11:45 - 12:00**: Closing and Next Steps
+
+During the refinement sessions, each group will focus on the first steps of skeleton-building for their features (based on the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md),
+mapping them to the related roadmap items. Don’t worry about completing every section of the feature template just yet — this is a time for brainstorming and forming initial ideas.
+
+It's essential, however, to use the **feature template** and identify **dependencies** with other components or groups, which will help us add the correct labels to the features.
+You’re encouraged to collaborate across groups as needed, and we’ll provide **Teams sessions** for each group to work in.
+
+## Group Work & Presenting Results
+
+The goal of the refinement is to **identify the first ideas and dependencies** within your group. The **General Teams session** will be available for any questions that come up during this collaborative work.
+
+Important for the session:
+- Use the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md) to structure your work
+- Identify dependencies with other components or groups and add the correct labels to the features
+- Use the supported-by field to map the feature with your expert group
+
+At the end of the refinement session, we’ll regroup and present the progress made. Each expert group will present their refined features, focusing on what’s been developed so far and the key insights.
+
+### Committee/Expert Groups and Teams Sessions:
+
+:::tip
+The sessions for the committees can be used to sync within the underlying expert groups. Feel free to switch between groups if necessary!
+:::
+
+- [Network Service Committee](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MDM1MjE2NmQtMDU5NC00MjM2LTlkOGEtZWI1YTM0MzBjMTkw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Business Partner Data Management](https://teams.microsoft.com/l/meetup-join/19%3ameeting_YThmNzMzODAtM2M0NS00MGVjLWJiNjMtODA5Njk3OWY4ODFi%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Self-Sovereign Identity](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MGY3YzE1OTAtMDgxMS00YTVhLWE2ODYtMzM4MDMxZTk5MWJh%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Dataspace Connectivity](https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZTJmYzdmOGMtOGE3Mi00YjkzLThlZTEtMTliNzJiZDljMTZl%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Digital Twins](https://teams.microsoft.com/l/meetup-join/19%3ameeting_NDkyMWZmNDMtYmYzYi00MGM4LTg5NmUtNDIzZGJiZjFmZTIz%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Company Certificate Management](https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDVhNGMzYjAtNTk1MC00NTZlLWI1NzgtYjE0MjQ2NDgxOTJj%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+- [Sustainability Committee](https://teams.microsoft.com/l/meetup-join/19%3ameeting_Y2Y1YTY3ZGQtMzEzOC00MGJmLTk1ZjEtOTBhZjgxMWVkZjBi%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Digital Product Pass](https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZTQxMWY0YzgtYmM5MS00ZTA4LWE2YTUtMzk5Y2Y2NmZmNjJl%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Circularity](https://teams.microsoft.com/l/meetup-join/19%3ameeting_NDMxOGM2YTItZGVhOC00N2EzLTlmMGEtYWJmYjYwOWFmMjk4%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Product Carbon Footprint - Methodology & Verification](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MDIwMmQ3MGQtZWQ1Mi00YzQ5LTg3MjMtMmM3MWY1OGRlYmM2%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Product Carbon Footprint - Architecture & Interoperability](https://teams.microsoft.com/l/meetup-join/19%3ameeting_NjFlZWYzNWYtNTViMy00NmExLTljOGYtYWE0N2U5MmQ3MzI3%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Product Carbon Footprint - on Electronics](https://teams.microsoft.com/l/meetup-join/19%3ameeting_NWI1MzJmMzQtODliOC00ZDM0LTk0ZDgtMDdmYTljMGUxZjE3%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+- [Product Lifecycle, Quality and Resiliency Committee](https://teams.microsoft.com/l/meetup-join/19%3ameeting_YmFhNDllOWItMWFiYi00MzBhLTkwZDMtM2FiOGZjOTAwY2E4%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Traceability](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MTRmZjI5Y2EtZmZjYy00ZDcxLWIyMTItMzc0YzYwMzMwZGI3%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Demand & Capacity](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MzhhMDMwZDQtMWM5Ny00YjNlLWEyZDYtNjg1MTRlZTM0ZGI5%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Online Simulation](https://teams.microsoft.com/l/meetup-join/19%3ameeting_NjUyMzRiYTItMDNhNC00YzJhLWE0MmItOGZjZGU2MDEzNWE1%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [PURIS](https://teams.microsoft.com/l/meetup-join/19%3ameeting_OWZhODUxZGMtMGExNS00Y2NiLThlM2YtM2ExMjYyM2IzZTkw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Data-driven Quality](https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZDNjYTg5NjEtMGU1Mi00MWQ4LWI2ZTctZmQ5NDQwNmYzOGM1%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+- [Industry Core Committee](https://teams.microsoft.com/l/meetup-join/19%3ameeting_NzUxYzNlZjYtNzdkMi00NTExLWEzMWItMDc0NTM1YjM4ZGM5%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+- [Architecture Management Committee](https://teams.microsoft.com/l/meetup-join/19%3ameeting_NjI5YjNiNjItYTY4Ny00YTY0LTllNDAtZGRkMmMwYjA4OGRl%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+- [Data Space Operations Committee](https://teams.microsoft.com/l/meetup-join/19%3ameeting_Mzk3N2ExMWMtNTk4ZS00ZjI0LWEzZjgtZDliOTM1MjE0ZmY0%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Data Sovereignty](https://teams.microsoft.com/l/meetup-join/19%3ameeting_NWIwOGFiOGYtMjQ3Ni00YjA0LTg1N2MtNDJmMTQ0OGQ0ZTBm%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+- [Working Groups](https://teams.microsoft.com/l/meetup-join/19%3ameeting_NjdmMTk2ZGEtMjFiMy00ZWIxLTllZDYtNTVlNTMwZDE5MjQ5%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+  - [Data Integration Pattern](https://teams.microsoft.com/l/meetup-join/19%3ameeting_OTk4NTYxZDctYmQzMy00ZTRmLTg0YzctZjBiZGExODUxM2Uw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+
+:::note
+Feel free to switch between groups if necessary!
+:::
+
+### Special Note for KITs
+
+For KITs, we understand that not all sections of the template are necessary right now. The most important things to include at this stage are:
+- The **Feature Team** responsible for the work
+- A brief **explanation of the feature** (just 2 sentences)
+
+## Next Steps & Refinement Day 2
+
+By the end of the session, we expect to have features that may not be fully refined but will be in good shape for further refinement or proactive work on dependencies. You’ll have the opportunity
+to connect with other groups and components that you’re dependent on.
+
+As we look ahead to **[Refinement Day 2](https://eclipse-tractusx.github.io/community/open-meetings#Refinement%20Day%202%20-%20Release%2025.03)**, our focus will shift towards **dependency components**. It will be crucial to have those dependencies properly tagged with labels on the features.
+
+We look forward to a productive Refinement Day - Happy Refining! 🚀
+

--- a/blog/2024-11-06-refinement-day-2-R25.03.mdx
+++ b/blog/2024-11-06-refinement-day-2-R25.03.mdx
@@ -1,8 +1,8 @@
 ---
-title: Refinement Day 1 for Release 25.03
-description: Tractus-X Community Update - Refinement Day 1 for Release 25.03
-slug: refinement-day-1-R24.03
-date: 2024-10-09T09:00
+title: Refinement Day 2 for Release 25.03
+description: Tractus-X Community Update - Refinement Day 2 for Release 25.03
+slug: refinement-day-2-R25.03
+date: 2024-10-10T12:38
 hide_table_of_contents: false
 authors:
   - name: Stephan Bauer
@@ -16,17 +16,21 @@ import RenderImage from './RenderImage'
 
 ![eclipse tractus x logo](@site/static/img/Tractus-X_openplanning.png)
 
-Hello, Tractus-X Community!
 
-We’re excited to announce **Refinement Day 1**, taking place on **October 16th, from 09:05 to 12:00**. This event is focused on refining features for the
-upcoming **Release 25.03**. Unlike previous meetings, this won't just be a feature presentation day — we’ll be diving into hands-on work, helping each other
-refine features and identify dependencies.
+Hello, Eclipse Tractus-X Community!
 
-The blocker and overall teams session link can be found on our [open-meetings](https://eclipse-tractusx.github.io/community/open-meetings#Refinement%20Day%201%20-%20Release%2025.03) page. We look forward to seeing you all there!
+We are excited to announce **Refinement Day 2**, taking place on **November 6th, from 09:05 to 12:00**. This session will build on the work from **Refinement Day 1**
+and focus primarily on the **identified dependencies**. These dependencies, **which were highlighted by the labels on the features during Refinement Day 1**, will be the
+center of attention for this event.
+
+You can still continue refining features as necessary, but our main focus for this session will be resolving these dependencies to ensure smooth progress toward **Release 25.03**.
+
+The Teams session links and breakout groups remain the same as on Refinement Day 1. You can find the overall Teams session link and more information on the
+[open-meetings](https://eclipse-tractusx.github.io/community/open-meetings#Refinement%20Day%202%20-%20Release%2025.03) page.
 
 <!--truncate-->
 
-## Agenda for Refinement Day 1
+## Agenda for Refinement Day 2
 
 Here’s the plan for the day:
 - **09:05 - 09:30**: Welcome, Introduction, and Expectations
@@ -34,22 +38,27 @@ Here’s the plan for the day:
 - **11:15 - 11:45**: Presenting the results, grouped by expert groups
 - **11:45 - 12:00**: Closing and Next Steps
 
-During the refinement sessions, each group will focus on the first steps of skeleton-building for their features (based on the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md),
-mapping them to the related roadmap items. Don’t worry about completing every section of the feature template just yet — this is a time for brainstorming and forming initial ideas.
-
-It's essential, however, to use the **feature template** and identify **dependencies** with other components or groups, which will help us add the correct labels to the features.
-You’re encouraged to collaborate across groups as needed, and we’ll provide **Teams sessions** for each group to work in.
-
 ## Group Work & Presenting Results
 
-The goal of the refinement is to **identify the first ideas and dependencies** within your group. The **General Teams session** will be available for any questions that come up during this collaborative work.
+During the refinement sessions, each group will focus on resolving **identified dependencies** from Refinement Day 1, which are visible via the **related labels** on the features.
+While further feature refinement is allowed, the emphasis is on addressing and coordinating **dependencies** between groups and components.
+
+Our working Board for the day is the [Release Planning - R25.03 - Preperation](https://github.com/orgs/eclipse-tractusx/projects/26/views/36)
+
+You’re encouraged to collaborate across groups as needed, and we’ll provide **Teams sessions** (we will use the same sessions from Refinement Day 1) for each group to work in.
+It might be the case for some experts to jump into different other groups to resolve dependencies.
 
 Important for the session:
 - Use the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md) to structure your work
 - Identify dependencies with other components or groups and add the correct labels to the features
 - Use the supported-by field to map the feature with your expert group
+- help each other to solve/analyze dependencies
 
 At the end of the refinement session, we’ll regroup and present the progress made. Each expert group will present their refined features, focusing on what’s been developed so far and the key insights.
+
+:::note
+If the feature is ready refined, the status should be set to `Backlog`-> this should by an alignment, between the requesting Expert Group/Committee and the open-source community.
+:::
 
 ### Committee/Expert Groups and Teams Sessions:
 
@@ -92,12 +101,10 @@ For KITs, we understand that not all sections of the template are necessary righ
 - The **Feature Team** responsible for the work
 - A brief **explanation of the feature** (just 2 sentences)
 
-## Next Steps & Refinement Day 2
+## Next Steps & Release Planning Days
 
-By the end of the session, we expect to have features that may not be fully refined but will be in good shape for further refinement or proactive work on dependencies. You’ll have the opportunity
-to connect with other groups and components that you’re dependent on.
-
-As we look ahead to **[Refinement Day 2](https://eclipse-tractusx.github.io/community/open-meetings#Refinement%20Day%202%20-%20Release%2025.03)**, our focus will shift towards **dependency components**. It will be crucial to have those dependencies properly tagged with labels on the features.
+By the end of the session, we expect to have features ready refined. It might be the case, not all are fully refined but will be in good shape for further refinement and proactive work until we will meet again for the
+[Release Planning Days](https://eclipse-tractusx.github.io/community/open-meetings#Release%20Planning%20Days%20-%20Release%2025.03)
 
 We look forward to a productive Refinement Day - Happy Refining! 🚀
 

--- a/utils/newsTitles.js
+++ b/utils/newsTitles.js
@@ -1,8 +1,13 @@
 export const newsTitles = [
   {
+    date: "06.11.2024",
+    title: "Refinement Day 2 for Release 25.03",
+    blogLink: "/blog/refinement-day-2-R25.03"
+  },
+  {
     date: "16.10.2024",
     title: "Refinement Day 1 for Release 25.03",
-    blogLink: "/blog/refinement-day-1-R24.03"
+    blogLink: "/blog/refinement-day-1-R25.03"
   },
   {
     date: "05.12.2024",


### PR DESCRIPTION
## Description

This PR fixes some naming issues within refinement day 1 and adds a new entry for refinement day 2

![image](https://github.com/user-attachments/assets/bcac72ae-ba9d-4722-8751-35974eac4e6c)
![image](https://github.com/user-attachments/assets/65590c68-9fb5-4585-8150-18543ff10787)
![image](https://github.com/user-attachments/assets/824157ce-db87-4ac9-991c-5bff1ac5cc32)


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
