### PR TITLE
docs(open-meetings): add timelines and taskboards to open meetings

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -23,7 +23,9 @@ These are dedicated sync meetings for specific products, as well as open plannin
              meetingLink="/meetings/office-hour.ics"
              additionalLinks={
                 [
-                    {title: 'meeting minutes', url: 'https://eclipse-tractusx.github.io/community/meeting-minutes/tags/community'},
+                    {title: 'Taskboard', url: 'https://github.com/orgs/eclipse-tractusx/projects/61/views/1'},
+                    {title: 'Meeting minutes', url: 'https://eclipse-tractusx.github.io/community/meeting-minutes/tags/community'},
+                    {title: 'Timelines minutes', url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/35'},
                 ]
              }
 />
@@ -42,6 +44,12 @@ These are dedicated sync meetings for specific products, as well as open plannin
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTItNWE1MmMzMWUzNmYw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
              meetingLink="/meetings/committer-office-hour.ics"
+             additionalLinks={
+                [
+                    {title: 'Taskboard', url: 'https://github.com/orgs/eclipse-tractusx/projects/61/views/6'},
+                    {title: 'Timelines', url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/35'},
+                ]
+             }
 />
 
 <MeetingInfo title="Portal - Open Meeting"


### PR DESCRIPTION
## Description

This PR adds more information to our meetings, e.g. the link to the timeline and also a link to our talkboard. 
Thanks, @ma3u, for bringing this up

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
