### PR TITLE
doc(open meetings): fix wording in open meeting

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -25,7 +25,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
                 [
                     {title: 'Taskboard', url: 'https://github.com/orgs/eclipse-tractusx/projects/61/views/1'},
                     {title: 'Meeting minutes', url: 'https://eclipse-tractusx.github.io/community/meeting-minutes/tags/community'},
-                    {title: 'Timelines minutes', url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/35'},
+                    {title: 'Timelines', url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/35'},
                 ]
              }
 />


### PR DESCRIPTION
## Description

Just a short fix ... there is one word obsolete ;)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
