### PR TITLE
docs(releaseinformation): add a tip admonition to mention the timelines

### DIFF
--- a/src/pages/release-information.md
+++ b/src/pages/release-information.md
@@ -8,3 +8,8 @@ In addition you may want to check the recent releases for content which was publ
 Go to the [sig-release/README.md](https://github.com/eclipse-tractusx/sig-release/blob/main/README.md) for a consolidated package on release-relevant information.
 
 Visit [tractus-x-release/CHANGELOG.md](https://github.com/eclipse-tractusx/tractus-x-release/blob/main/CHANGELOG.md) for our periodic release info.
+
+:::tip
+The timelines for the current and next releases, can be found on the [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26/views/35). The milestone filter can be used,
+to select a dedicated release and check the progress of the release.
+:::


### PR DESCRIPTION
## Description

This PR adds the information about the timelines, which are available on the Release Planning Board.

<img width="883" alt="image" src="https://github.com/user-attachments/assets/20ab2152-bbc1-4936-b815-a37fd8b12903">


Closes #1012 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
