### PR TITLE
docs(news-blog): add news blog for open planning

### DIFF
--- a/blog/2024-11-13-open-planning-R25.03.mdx
+++ b/blog/2024-11-13-open-planning-R25.03.mdx
@@ -89,6 +89,6 @@ During the session, if there is a common alignment among the participants, the f
 
 ---
 
-For any questions or further information, feel free to reach out via our [mailing list](https://accounts.eclipse.org/mailing-list/tractus-x-dev) or join us in the Tractus-X [Matrix channel](https://matrix.to/#/#tractus-x:matrix.org).
+For any questions or further information, feel free to reach out via our [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) or join us in the Tractus-X [Matrix channel](https://matrix.to/#/#automotive.tractusx:matrix.eclipse.org).
 
 We look forward to your participation and collaboration! 🚀

--- a/blog/2024-11-13-open-planning-R25.03.mdx
+++ b/blog/2024-11-13-open-planning-R25.03.mdx
@@ -24,7 +24,7 @@ final step in aligning and confirming the features for our next release.
 
 ## Prerequisites
 
-Before participating in the Open Planning, please have a look at the previous previous **Refinement Days**:
+Before participating in the Open Planning, please have a look at the previous **Refinement Days**:
 - [Refinement Day 1 for Release 25.03](https://eclipse-tractusx.github.io/blog/refinement-day-1-R25.03) and the [slides](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io.largefiles/raw/refs/heads/main/presentations/R25.03_SLIDES_REFINEMENTDAY_ONE.pdf)
 - [Refinement Day 2 for Release 25.03](https://eclipse-tractusx.github.io/blog/refinement-day-2-R25.03)
 
@@ -35,10 +35,7 @@ These Refinement Days were crucial for laying the groundwork and ensuring featur
 ## Event Details
 
 **Dates**:
-November 13th and 14th, 2024
-
-**Time**:
-09:00 – 17:00 CET
+November 13th and 14th, 2024, each day from 09:05 – 12:00 CET
 
 **Location**:
 Online via [Tractus-X Open Meetings Page](https://eclipse-tractusx.github.io/community/open-meetings#Release%20Planning%20Days%20-%20Release%2025.03)
@@ -70,12 +67,12 @@ A detailed agenda will be shared with all participants before the event. Since t
 
 The planning sessions will be driven by our [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Asupported-by+label%3A%22Prep-R25.03%22+status%3ABacklog), which organizes features based on their **supported-by** field.
 
-## Prerequisites for Features to Be Considered in Open Planning
+## Prerequisites for features to be considered in Open Planning
 
-For a feature to be included in the open planning, the following conditions must be met:
+For a feature to be included in the Open Planning, the following conditions must be met:
 - **Status must be 'Backlog'** – Committers and Expert Groups can set this status after the feature is fully refined.
 - **All categories in the feature template must be filled** – Do not delete any sections from the template.
-- **Milestone is NOT set** – This will be assigned during the open planning session.
+- **Milestone is NOT set** – This will be assigned during the Open Planning session.
 - **Contributor and Committer must be assigned**.
 - **Supported-by must be set**.
 

--- a/blog/2024-11-13-open-planning-R25.03.mdx
+++ b/blog/2024-11-13-open-planning-R25.03.mdx
@@ -1,0 +1,94 @@
+---
+title: Open Planning for Release 25.03
+description: Tractus-X Community Update - Open Planning for Release 25.03
+slug: open-planning-R25.03
+date: 2024-10-23T21:45
+hide_table_of_contents: false
+authors:
+  - name: Stephan Bauer
+    title: Platform Domain Manager
+    url: https://github.com/stephanbcbauer
+    image_url: https://github.com/stephanbcbauer.png
+    email: stephan.bauer@catena-x.net
+---
+
+import RenderImage from './RenderImage'
+
+![eclipse tractus x logo](@site/static/img/Tractus-X_openplanning.png)
+
+Hello, Eclipse Tractus-X Community!
+
+We are excited to announce the **Eclipse Tractus-X Release Planning Days** for Release 25.03, which will take place on **November 13th and 14th, 2024**. These days are the
+final step in aligning and confirming the features for our next release.
+
+
+## Prerequisites
+
+Before participating in the Open Planning, please have a look at the previous previous **Refinement Days**:
+- [Refinement Day 1 for Release 25.03](https://eclipse-tractusx.github.io/blog/refinement-day-1-R25.03) and the [slides](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io.largefiles/raw/refs/heads/main/presentations/R25.03_SLIDES_REFINEMENTDAY_ONE.pdf)
+- [Refinement Day 2 for Release 25.03](https://eclipse-tractusx.github.io/blog/refinement-day-2-R25.03)
+
+These Refinement Days were crucial for laying the groundwork and ensuring features are properly prepared for the release planning.
+
+<!--truncate-->
+
+## Event Details
+
+**Dates**:
+November 13th and 14th, 2024
+
+**Time**:
+09:00 – 17:00 CET
+
+**Location**:
+Online via [Tractus-X Open Meetings Page](https://eclipse-tractusx.github.io/community/open-meetings#Release%20Planning%20Days%20-%20Release%2025.03)
+
+**Who Should Attend**:
+- Contributors and Committers from the open-source community
+- Expert Group and Committee members
+- Feature requesters and stakeholders
+
+:::note
+Your participation is crucial to ensure the success of the release planning. Expert Groups, Committees, the open-source community (contributor and committer),
+feature requesters are encouraged to attend and actively engage in the discussions.
+:::
+
+## Agenda
+
+### First Day: November 13th
+- **09:05 - 09:30**: Open Planning - Vision & Introduction
+- **09:30 - 12:00**: Joint Open Planning (all teams)
+
+### Second Day: November 14th
+- **09:05 - 11:00**: Joint Open Planning (all teams)
+- **11:00 - 11:30**: Confidence Vote & Feedback Retro
+- **11:30 - 12:00**: Open Planning Wrap-Up / Summary & Next Steps
+
+:::note
+A detailed agenda will be shared with all participants before the event. Since the agenda is dependent on the refined features it might be on short notoce.note
+:::
+
+The planning sessions will be driven by our [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Asupported-by+label%3A%22Prep-R25.03%22+status%3ABacklog), which organizes features based on their **supported-by** field.
+
+## Prerequisites for Features to Be Considered in Open Planning
+
+For a feature to be included in the open planning, the following conditions must be met:
+- **Status must be 'Backlog'** – Committers and Expert Groups can set this status after the feature is fully refined.
+- **All categories in the feature template must be filled** – Do not delete any sections from the template.
+- **Milestone is NOT set** – This will be assigned during the open planning session.
+- **Contributor and Committer must be assigned**.
+- **Supported-by must be set**.
+
+During the session, if there is a common alignment among the participants, the feature milestone can be set to **25.03**, meaning it will be developed in the upcoming release.
+
+## Important Notes and Hints
+
+- Keep the board clean – there are still features with older milestones that have not yet been completed.
+- Do not delete any sections from the feature template, except for KITs.
+- For KITs, only the Contributor, Committer, and Description fields need to be filled.
+
+---
+
+For any questions or further information, feel free to reach out via our [mailing list](https://accounts.eclipse.org/mailing-list/tractus-x-dev) or join us in the Tractus-X [Matrix channel](https://matrix.to/#/#tractus-x:matrix.org).
+
+We look forward to your participation and collaboration! 🚀

--- a/utils/newsTitles.js
+++ b/utils/newsTitles.js
@@ -1,5 +1,10 @@
 export const newsTitles = [
   {
+    date: "13.11.2024",
+    title: "Open Planning for Release 25.03",
+    blogLink: "/blog/open-planning-R25.03"
+  },
+  {
     date: "06.11.2024",
     title: "Refinement Day 2 for Release 25.03",
     blogLink: "/blog/refinement-day-2-R25.03"


### PR DESCRIPTION
## Description

This PR adds more information to the planned open planning meeting. The information is provided via news blog, which looks like:

<img width="1346" alt="image" src="https://github.com/user-attachments/assets/0d11d06e-9c10-4008-b81f-568201f69bf3">

<img width="1882" alt="image" src="https://github.com/user-attachments/assets/089617b7-c3c1-47fd-b80c-c18ad09a7f73">
<img width="1884" alt="image" src="https://github.com/user-attachments/assets/122208c6-139b-4e40-a99a-193fcb5f02c8">
<img width="1884" alt="image" src="https://github.com/user-attachments/assets/4f38a373-1f5e-46bc-8b1f-dc8941b30418">

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
