### PR TITLE
docs(open planning): adapt open meetings and open planning

### DIFF
--- a/blog/2024-11-13-open-planning-R25.03.mdx
+++ b/blog/2024-11-13-open-planning-R25.03.mdx
@@ -55,15 +55,24 @@ feature requesters are encouraged to attend and actively engage in the discussio
 ### First Day: November 13th
 - **09:05 - 09:30**: Open Planning - Vision & Introduction
 - **09:30 - 12:00**: Joint Open Planning (all teams)
+  - **09:30 - 09:35**: [NSC](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?sliceBy%5Bvalue%5D=NSC+-+Committee) (2)
+  - **09:35 - 10:05**: [NSC - Dataspace Connectivity](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?sliceBy%5Bvalue%5D=NSC+-+Dataspace+Connectivity) (7)
+  - **10:05 - 10:35**: [NSC - BPDM](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?sliceBy%5Bvalue%5D=NSC+-+BPDM) (6)
+  - **10:35 - 10:45**: [NSC - DT](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?sliceBy%5Bvalue%5D=NSC+-+DT) (2)
+  - **10:45 - 11:55**: [NSC - Portal](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?sliceBy%5Bvalue%5D=NSC+-+Portal) (21)
+  - **11:55 - 12:00**: [NSC - SSI](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?sliceBy%5Bvalue%5D=NSC+-+SSI) (1)
 
 ### Second Day: November 14th
 - **09:05 - 11:00**: Joint Open Planning (all teams)
+  - **09:05 - 09:20**: [SUS](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Asupported-by+label%3A%22Prep-R25.03%22+supported-by%3A%22SUS+-+PCF+-+on+Electronics%22%2C%22SUS+-+PCF+-+Secondary+Data+Provision%22%2C%22SUS+-+Commitee%22%2C%22SUS+-+DPP%22%2C%22SUS+-+Circularity%22%2C%22SUS+-+Human+Rights%22%2C%22SUS+-+PCF+-+Methodology+%26+Verification%22%2C%22SUS+-+PCF+-+Architecture+%26+Interoperability%22%2C) (4)
+  - **09:20 - 09:30**: [PQR - Traceability](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?sliceBy%5Bvalue%5D=PQR+-+Traceability) (2)
+  - **09:30 - 09:40**: [PQR - DCM](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?sliceBy%5Bvalue%5D=PQR+-+DCM) (3)
+  - **09:40 - 09:50**: [PQR - Puris](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?sliceBy%5Bvalue%5D=PQR+-+PURIS) (3)
+  - **09:50 - 10:50**: [IC](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?sliceBy%5Bvalue%5D=IC+-+Committee) (17)
+  - **10:50 - 10:55**: [Test Management](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?sliceBy%5Bvalue%5D=Testmanagement) (2)
+  - **10:55 - 11:00**: [Architecture Management](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?sliceBy%5Bvalue%5D=ARC+-+Committee) (1)
 - **11:00 - 11:30**: Confidence Vote & Feedback Retro
 - **11:30 - 12:00**: Open Planning Wrap-Up / Summary & Next Steps
-
-:::note
-A detailed agenda will be shared with all participants before the event. Since the agenda is dependent on the refined features it might be on short notoce.note
-:::
 
 The planning sessions will be driven by our [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Asupported-by+label%3A%22Prep-R25.03%22+status%3ABacklog), which organizes features based on their **supported-by** field.
 

--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -87,8 +87,8 @@ These are dedicated sync meetings for specific products, as well as open plannin
              meetingLink="/meetings/refinement-phase---release-2503.ics"
              additionalLinks={
                 [
-                    {title: "Refinement & Dependencies (Working Model)", url: "https://catenax-ev.github.io/docs/next/working-model/release-management/planning/refinement-and-dependencies"},
-                    {title: "Release Planning Board - Preperation (GitHub)", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/36"},
+                    {title: "Refinement & Dependencies (Working Model)", url: "https://catenax-ev.github.io/docs/working-model/release-management/planning/tx-feature-proposal-creation-approval"},
+                    {title: "Release Planning Board - Preperation (GitHub)", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=label%3A%22Prep-R25.03%22+-status%3ADone"},
                     {title: "sig-release repository (GitHub)", url: "https://github.com/eclipse-tractusx/sig-release"},
                     {title: "Timeline", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A25.03+"}
                 ]
@@ -103,9 +103,11 @@ These are dedicated sync meetings for specific products, as well as open plannin
              meetingLink="/meetings/refinement-day-1---release-2503.ics"
              additionalLinks={
                 [
-                    {title: "Refinement Day (Working Model)", url: "https://catenax-ev.github.io/docs/next/working-model/release-management/planning/refinement-day"},
-                    {title: "Release Planning Board - Supported (GitHub)", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Asupported-by+label%3A%22Prep-R25.03%22"},
-                    {title: "Timeline", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A25.03+"}
+                    {title: "Refinement Day (Working Model)", url: "https://catenax-ev.github.io/docs/working-model/release-management/planning/tx-refinement-day"},
+                    {title: "Release Planning Board - Supported (GitHub)", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=label%3A%22Prep-R25.03%22+-status%3ADone"},
+                    {title: "Timeline", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A25.03+"},
+                    {title: "News Blog", url: "https://eclipse-tractusx.github.io/blog/refinement-day-1-R25.03"},
+                    {title: "Refinement Sessions", url: "https://eclipse-tractusx.github.io/blog/refinement-day-1-R25.03#committeeexpert-groups-and-teams-sessions"}
                 ]
              }
 />
@@ -116,8 +118,8 @@ These are dedicated sync meetings for specific products, as well as open plannin
              contact="stephan.bauer@catena-x.net"
              additionalLinks={
                 [
-                    {title: "Draft Feature Freeze (Working Model)", url: "https://catenax-ev.github.io/docs/next/working-model/release-management/planning/draft-feature-freeze"},
-                    {title: "Release Planning Board - Supported (GitHub)", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Asupported-by+label%3A%22Prep-R25.03%22"},
+                    {title: "Draft Feature Freeze (Working Model)", url: "https://catenax-ev.github.io/docs/working-model/release-management/planning/tx-draft-feature-freeze"},
+                    {title: "Release Planning Board - Supported (GitHub)", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=label%3A%22Prep-R25.03%22+-status%3ADone"},
                     {title: "Timeline", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A25.03+"}
                 ]
              }
@@ -131,9 +133,11 @@ These are dedicated sync meetings for specific products, as well as open plannin
              meetingLink="/meetings/refinement-day-2---release-2503.ics"
              additionalLinks={
                 [
-                    {title: "Refinement Day (Working Model)", url: "https://catenax-ev.github.io/docs/next/working-model/release-management/planning/refinement-day"},
-                    {title: "Release Planning Board - Supported (GitHub)", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Asupported-by+label%3A%22Prep-R25.03%22"},
-                    {title: "Timeline", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A25.03+"}
+                    {title: "Refinement Day (Working Model)", url: "https://catenax-ev.github.io/docs/working-model/release-management/planning/tx-refinement-day"},
+                    {title: "Release Planning Board - Supported (GitHub)", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=label%3A%22Prep-R25.03%22+-status%3ADone"},
+                    {title: "Timeline", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A25.03+"},
+                    {title: "News Blog", url: "https://eclipse-tractusx.github.io/blog/refinement-day-2-R25.03"},
+                    {title: "Refinement Sessions", url: "https://eclipse-tractusx.github.io/blog/refinement-day-2-R25.03#committeeexpert-groups-and-teams-sessions"}
                 ]
              }
 />
@@ -146,9 +150,11 @@ These are dedicated sync meetings for specific products, as well as open plannin
              meetingLink="/meetings/release-planning-days---release-2503.ics"
              additionalLinks={
                 [
-                    {title: "Release Planning Days (Working Model)", url: "https://catenax-ev.github.io/docs/next/working-model/release-management/planning/release-planning-days"},
-                    {title: "Release Planning Board - Supported (GitHub)", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Asupported-by+label%3A%22Prep-R25.03%22"},
-                    {title: "Timeline", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A25.03+"}
+                    {title: "Release Planning Days (Working Model)", url: "https://catenax-ev.github.io/docs/working-model/release-management/planning/tx-release-planning-days"},
+                    {title: "Release Planning Board - Supported (GitHub)", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/39?filterQuery=label%3A%22Prep-R25.03%22++-status%3ADone+status%3ABacklog"},
+                    {title: "Timeline", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A25.03+"},
+                    {title: "News Blog", url: "https://eclipse-tractusx.github.io/blog/open-planning-R25.03"},
+                    {title: "Detailed Agenda", url: "https://eclipse-tractusx.github.io/blog/open-planning-R25.03#agenda"},
                 ]
              }
 />


### PR DESCRIPTION
## Description

This PR adds a detailed agenda to the open planning news blog and fixes some broken links in the open meetings section.

![image](https://github.com/user-attachments/assets/46d50e34-5764-4240-ac7e-b5a535fffbca)

![image](https://github.com/user-attachments/assets/ec9a91c8-46c7-4a71-90a9-d501f4c7e599)


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
