### PR TITLE
docs(release information): add more information to our release description

### DIFF
--- a/src/pages/release-information.md
+++ b/src/pages/release-information.md
@@ -1,15 +1,38 @@
 # Release Information
 
-[Catena-X Standards](https://catena-x.net/de/standard-library) are the foundation for certifying any software product operating in the Catena-X data space. Those standards are the binding reference to obtain a valid certificate. To make adopting the latest Catena-X standards easier, reference implementations are provided through the Eclipse Tractus-X Project. Those Releases are published in a periodic cadence.
+[Catena-X Standards](https://catena-x.net/de/standard-library) are the foundation for certifying any software product operating in the Catena-X data space. These standards are the
+binding reference to obtain a valid certificate. To facilitate the adoption of the latest Catena-X standards, the Eclipse Tractus-X Project provides reference implementations, released
+on a quarterly basis.
 
-We recommend you to visit the [sig-release repo](https://github.com/eclipse-tractusx/sig-release) and start with the [README.md](https://github.com/eclipse-tractusx/sig-release/blob/main/README.md) for a consolidated package on Release-relevant information.
-In addition you may want to check the recent releases for content which was published so far, and check the Changelog(s) for features, known knowns and compatibility.
+## Quarterly Release Cycle
 
-Go to the [sig-release/README.md](https://github.com/eclipse-tractusx/sig-release/blob/main/README.md) for a consolidated package on release-relevant information.
+Eclipse Tractus-X follows a structured release cycle, delivering four releases annually. Each release encompasses several key milestones:
 
-Visit [tractus-x-release/CHANGELOG.md](https://github.com/eclipse-tractusx/tractus-x-release/blob/main/CHANGELOG.md) for our periodic release info.
+- **Refinement Phase:** Initial discussions to outline and prioritize features for the upcoming release.
+- **Refinement Day 1:** Collaborative sessions to refine feature requirements and identify dependencies.
+- **Refinement Day 2:** Continued refinement, focusing on resolving dependencies and finalizing feature scopes.
+- **DRAFT Feature Freeze:** A preliminary cutoff point where feature definitions are solidified, allowing for adjustments before finalization.
+- **Release Planning Days:** Finalization of the release plan, confirming feature inclusion and setting development timelines.
 
 :::tip
-The timelines for the current and next releases, can be found on the [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26/views/35). The milestone filter can be used,
-to select a dedicated release and check the progress of the release.
+For detailed timelines and specific dates of these milestones, refer to the [sig-release milestones](https://github.com/eclipse-tractusx/sig-release/milestones) and the timeline on the
+[Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26/views/35)
 :::
+
+## Feature Submission Process
+
+To propose new features for inclusion in an upcoming release, contributors must utilize the [Feature Template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md).
+This template ensures consistent and comprehensive feature proposals. The `sig-release` repository serves as the management hub for new features in the next release.
+
+:::note
+All other tasks and issues should be created in their respective repositories where the actual work is conducted. These issues must be linked within the feature proposal to maintain traceability and coherence.
+:::
+
+## Additional Resources
+
+- [sig-release Repository](https://github.com/eclipse-tractusx/sig-release): Central hub for release management and feature tracking.
+- [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26/views/35): Monitor the progress of current and upcoming releases.
+- [tractus-x-release/CHANGELOG.md](https://github.com/eclipse-tractusx/tractus-x-release/blob/main/CHANGELOG.md): Access detailed information on periodic releases.
+- [Open Meetings Page](https://eclipse-tractusx.github.io/community/open-meetings/): Find Teams session links and more information for key milestones.
+
+By adhering to these guidelines and utilizing the provided resources, contributors can effectively participate in the Eclipse Tractus-X release process, ensuring alignment with Catena-X standards and contributing to the project's success.


### PR DESCRIPTION
## Description

This PR adds more information about our releases, including phases, milestones, and timelines. The idea is not to provide the information redundant to the working model, but to provide a minimal set of information.

<img width="1900" alt="image" src="https://github.com/user-attachments/assets/cb679dab-de94-4a73-994b-4d0577b590f7">
<img width="1902" alt="image" src="https://github.com/user-attachments/assets/7b2f00bb-41aa-4318-8bfb-b8c33245dd1f">

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
