### PR TITLE
chore: updated trufflehog workflow,  added missing flags

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown --debug
+          extra_args: --filter-entropy=4 --results=verified,unknown --debug --only-verified
       
       - name: Scan Results Status
         if: steps.trufflehog.outcome == 'failure'

--- a/docs/release/trg-8/trg-8-03.md
+++ b/docs/release/trg-8/trg-8-03.md
@@ -22,15 +22,15 @@ Configure your GitHub Actions to include:
 - `schedule`: Schedule the workflow to run at least once a week with `0 0 * * 0`.
 - `push` and `pull_request`: Activate the workflow on both push and pull request events targeting the branch that contains the code for the currently supported version, which may not necessarily be the main branch. This is the branch from which new releases will be made.
 
-Note: `extra_args: --filter-entropy=4 --results=verified,unknown`
+Note: `extra_args: --filter-entropy=4 --results=verified,unknown --only-verified`
 
-Including `extra_args: --filter-entropy=4 --results=verified,unknown` in the GitHub Actions workflow ensures that TruffleHog focuses on detecting high-entropy strings, which are more likely to be sensitive information such as passwords or API keys. This setup also instructs TruffleHog to report both verified secrets and potential but unverified secrets, providing a comprehensive security scan that helps identify and address all possible vulnerabilities in the code.
+Including `extra_args: --filter-entropy=4 --results=verified,unknown --only-verified` in the GitHub Actions workflow ensures that TruffleHog focuses on detecting high-entropy strings, which are more likely to be sensitive information such as passwords or API keys. This setup also instructs TruffleHog to report both verified secrets and potential but unverified secrets, providing a comprehensive security scan that helps identify and address all possible vulnerabilities in the code. The `--only-verified` flag reduces the appearance of false positives, because only the verified secrets will appear.
 
 Including `run: exit 1` in a step of a GitHub Actions workflow, as demonstrated below, commands the workflow to halt execution. This ensures that should TruffleHog uncover any secrets during its scan, the workflow promptly terminates in failure.
 
 GitHub Actions allows you to define workflows to automatically run TruffleHog scans on your code. You'll see the output that triggered the failure directly in the logs.
 
-Here’s how you can set it up:
+To comply with this TRG, simply create a file under the path: `.github/workflows/trufflehog.yaml` with the following content: 
 
 ```yml
 ###############################################################

--- a/docs/release/trg-8/trg-8-03.md
+++ b/docs/release/trg-8/trg-8-03.md
@@ -30,7 +30,7 @@ Including `run: exit 1` in a step of a GitHub Actions workflow, as demonstrated 
 
 GitHub Actions allows you to define workflows to automatically run TruffleHog scans on your code. You'll see the output that triggered the failure directly in the logs.
 
-To comply with this TRG, simply create a file under the path: `.github/workflows/trufflehog.yaml` with the following content: 
+To comply with this TRG, simply create a file under the path: `.github/workflows/trufflehog.yaml` with the following content:
 
 ```yml
 ###############################################################

--- a/docs/release/trg-8/trg-8-03.md
+++ b/docs/release/trg-8/trg-8-03.md
@@ -33,6 +33,25 @@ GitHub Actions allows you to define workflows to automatically run TruffleHog sc
 Here’s how you can set it up:
 
 ```yml
+###############################################################
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
 name: "TruffleHog"
 
 on:
@@ -64,13 +83,13 @@ jobs:
 
       - name: TruffleHog OSS
         id: trufflehog
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@7e78ca385fb82c19568c7a4b341c97d57d9aa5e1
         continue-on-error: true
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown --debug
-      
+          extra_args: --filter-entropy=4 --results=verified,unknown --debug --only-verified
+
       - name: Scan Results Status
         if: steps.trufflehog.outcome == 'failure'
         run: exit 1  # Set workflow run to failure if TruffleHog finds secrets 


### PR DESCRIPTION
## Description
The Trufflehog workflow shall be updated to the latest configuration proposed by  @RoKrish14. 

Now the `--only-verified` is required so that the false positives are not appearing often.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
