### PR TITLE
docs: update TRG 7-04 to unbind DEPENDENCIES file from the main branch

### DIFF
--- a/docs/release/trg-7/trg-7-01.md
+++ b/docs/release/trg-7/trg-7-01.md
@@ -2,20 +2,23 @@
 title: TRG 7.01 - Legal Documentation
 ---
 
-| Status | Created     | Post-History                         |
-|--------|-------------|--------------------------------------|
-| Active | 25-Apr-2024 | Updates for CC-BY-4.0 license        |
-| Active | 24-Aug-2023 | Updated SECURITY.md file             |
-| Active | 20-Jul-2023 | References to TRG 7.07, 7.08 updated |
-| Active | 13-Apr-2023 | Moved from OSS Development           |
+| Status | Created     | Post-History                                    |
+|--------|-------------|-------------------------------------------------|
+| Active | 22-Nov-2024 | Add alternative way to handle DEPENDENCIES file |
+| Active | 25-Apr-2024 | Updates for CC-BY-4.0 license                   |
+| Active | 24-Aug-2023 | Updated SECURITY.md file                        |
+| Active | 20-Jul-2023 | References to TRG 7.07, 7.08 updated            |
+| Active | 13-Apr-2023 | Moved from OSS Development                      |
 
 ## Why
 
-Eclipse Tractus-X is an open source project hosted by the Eclipse Foundation licensed under the Apache License 2.0 ([Apache-2.0](https://spdx.org/licenses/Apache-2.0)). For non-code the default license is the Creative Commons Attribution 4.0 International ([CC-BY-4.0](https://spdx.org/licenses/CC-BY-4.0.html)).
+Eclipse Tractus-X is an open source project hosted by the Eclipse Foundation licensed under the Apache License 2.0
+([Apache-2.0](https://spdx.org/licenses/Apache-2.0)). For non-code the default license is the Creative Commons Attribution 4.0 International ([CC-BY-4.0](https://spdx.org/licenses/CC-BY-4.0.html)).
 
 The legal obligations of the content must be observed in all forms of which the content is available.
 
-This page contains information about legal documentation requirements in your repositories. The source of truth is always the [Eclipse Foundation Project Handbook](https://www.eclipse.org/projects/handbook/#legaldoc).
+This page contains information about legal documentation requirements in your repositories. The source of truth is always
+the [Eclipse Foundation Project Handbook](https://www.eclipse.org/projects/handbook/#legaldoc).
 
 :::info
 
@@ -30,10 +33,13 @@ The following files must be part of your repository root folder:
 - LICENSE
 - LICENSE_non-code
 - NOTICE.md
-- DEPENDENCIES
 - SECURITY.md
 - CONTRIBUTING.md
 - CODE_OF_CONDUCT.md
+
+While the following can be omitted if appropriate actions are taken:
+
+- [DEPENDENCIES](#dependencies-file)
 
 For examples look to the [Eclipse Tractus-X GitHub Organisation](https://github.com/eclipse-tractusx), e.g. the [sig-infra](https://github.com/eclipse-tractusx/sig-infra).
 
@@ -75,22 +81,29 @@ Do the following changes:
 
 - Add both licenses to the "Declared Project Licenses" sections, see [example](https://github.com/eclipse-tractusx/sig-infra/blob/main/NOTICE.md)
 - Add the link to your repository
-- Add the link(s) to your SBOM, e.g. the DEPENDENCY file (one or more)
+- Add the link(s) to your SBOM, e.g. the DEPENDENCIES file (one or more)
 - Add information for third party content checks, if not covered by the Dash Tool (e.g. IP checks for icons, fonts, ...)
 
 [Further information](trg-7-04.md#checking-other-content-fonts-images-) and see the [Handbook#legaldoc-notice](https://www.eclipse.org/projects/handbook/#legaldoc-notice).
 
-### DEPENDENCY FILE
+### DEPENDENCIES FILE
 
 :::info
 
-Third-party dependencies need to be checked regularly to reflect your code changes. The DEPENDENCY file must be updated accordingly. This is recommended for every contribution (e.g. PR) whenever possible.
+Third-party dependencies need to be checked regularly to reflect your code changes. The DEPENDENCIES file must be updated
+accordingly. This is recommended for every contribution (e.g. PR).
 
 :::
 
 - Create it with the [Eclipse Dash License Tool](https://www.eclipse.org/projects/handbook/#ip-license-tool)
 
-If different technologies / package managers (e.g. npm and maven) are used you are free to have several dependency files. Use the naming convention DEPENDENCY_XYZ, e.g. DEPENDENCY_FRONTEND and DEPENDENCY_BACKEND.
+If different technologies / package managers (e.g. npm and maven) are used you are free to have several dependency files.
+Use the naming convention `DEPENDENCIES_XYZ`, e.g. `DEPENDENCIES_FRONTEND` and `DEPENDENCIES_BACKEND`.
+
+These files can be kept either checked in the git repository or published to a static location (e.g. GitHub Pages) and
+linked in the [NOTICE file](#notice-file) .
+It is advisable to run the check after every commit or during the nightly, surely it is mandatory to run it before the
+release, ensuring that no `rejected` or `restricted` dependencies are being part of delivered artifacts.
 
 [Further information](trg-7-04.md)
 

--- a/docs/release/trg-7/trg-7-01.md
+++ b/docs/release/trg-7/trg-7-01.md
@@ -13,12 +13,12 @@ title: TRG 7.01 - Legal Documentation
 ## Why
 
 Eclipse Tractus-X is an open source project hosted by the Eclipse Foundation licensed under the Apache License 2.0
-([Apache-2.0](https://spdx.org/licenses/Apache-2.0)). For non-code the default license is the Creative Commons Attribution 4.0 International ([CC-BY-4.0](https://spdx.org/licenses/CC-BY-4.0.html)).
+([Apache-2.0](https://spdx.org/licenses/Apache-2.0)). For non-code the default license is the Creative Commons Attribution
+4.0 International ([CC-BY-4.0](https://spdx.org/licenses/CC-BY-4.0.html)).
 
 The legal obligations of the content must be observed in all forms of which the content is available.
 
-This page contains information about legal documentation requirements in your repositories. The source of truth is always
-the [Eclipse Foundation Project Handbook](https://www.eclipse.org/projects/handbook/#legaldoc).
+This page contains information about legal documentation requirements in your repositories. The source of truth is always the [Eclipse Foundation Project Handbook](https://www.eclipse.org/projects/handbook/#legaldoc).
 
 :::info
 
@@ -37,7 +37,8 @@ The following files must be part of your repository root folder:
 - CONTRIBUTING.md
 - CODE_OF_CONDUCT.md
 
-While the following can be omitted if appropriate actions are taken:
+The following file **must** be present on root level for every released version but can be omitted in the main branch
+if appropriate actions are taken:
 
 - [DEPENDENCIES](#dependencies-file)
 
@@ -97,7 +98,7 @@ accordingly. This is recommended for every contribution (e.g. PR).
 
 - Create it with the [Eclipse Dash License Tool](https://www.eclipse.org/projects/handbook/#ip-license-tool)
 
-If different technologies / package managers (e.g. npm and maven) are used you are free to have several dependency files.
+If different technologies / package managers (e.g. npm and maven) are used you are free to have several dependencies files.
 Use the naming convention `DEPENDENCIES_XYZ`, e.g. `DEPENDENCIES_FRONTEND` and `DEPENDENCIES_BACKEND`.
 
 These files can be kept either checked in the git repository or published to a static location (e.g. GitHub Pages) and

--- a/docs/release/trg-7/trg-7-01.md
+++ b/docs/release/trg-7/trg-7-01.md
@@ -102,7 +102,7 @@ If different technologies / package managers (e.g. npm and maven) are used you a
 Use the naming convention `DEPENDENCIES_XYZ`, e.g. `DEPENDENCIES_FRONTEND` and `DEPENDENCIES_BACKEND`.
 
 These files can be kept either checked in the git repository or published to a static location (e.g. GitHub Pages) and
-linked in the [NOTICE file](#notice-file) .
+linked in the [NOTICE file](#notice-file).
 It is advisable to run the check after every commit or during the nightly, surely it is mandatory to run it before the
 release, ensuring that no `rejected` or `restricted` dependencies are being part of delivered artifacts.
 

--- a/docs/release/trg-7/trg-7-04.md
+++ b/docs/release/trg-7/trg-7-04.md
@@ -30,7 +30,7 @@ All third-party content has to be checked and approved by the Eclipse Foundation
 - Creating an IP issue manually (e.g. fonts, images, ...)
 - Using the Eclipse Dash License Tool to creat IP issues in an automated way (libraries)
 
-All third party content used has to be documented in the NOTICE file or in the DEPENDENCY file. [Further information](/docs/release/trg-7/trg-7-01.md)
+All third party content used has to be documented in the NOTICE file or in the DEPENDENCIES file. [Further information](/docs/release/trg-7/trg-7-01.md)
 
 :::info
 
@@ -56,7 +56,7 @@ You can request the status of your used libraries via the [Dash Licence Tool](ht
 - Create an issue in YOUR repository with the links to the IP Lab issues, [Example](https://github.com/eclipse-tractusx/daps-registration-service/issues/28)
 - Track your [issues](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues?search=automotive.tractusx&sort=created_date&state=opened)
 - Provide support if an issue is labeled with "Help wanted"
-- Add the summary as DEPENDENCY file to the according repository (root level)
+- Add the summary as DEPENDENCIES file to the according repository (root level)
 
 **Example usage:**
 


### PR DESCRIPTION
## Description
Modify TRG 7.04 to describe how the DEPENDENCIES file could be not checked in the git repository but uploaded on a static content.

As discussed in: https://github.com/orgs/eclipse-tractusx/projects/61/views/6?pane=issue&itemId=83404189

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
