### PR TITLE
[Business Partner Kit 24.12]: update api doc link to bpdm app version 6.2.0

### DIFF
--- a/sidebarsDocsKits.js
+++ b/sidebarsDocsKits.js
@@ -241,17 +241,17 @@ const sidebars = {
                         {
                             type: "link",
                             label: "Gate API",
-                            href: 'https://eclipse-tractusx.github.io/api-hub/bpdm/6.2.0-rc5/gate/'
+                            href: 'https://eclipse-tractusx.github.io/api-hub/bpdm/6.2.0/gate/swagger-ui/'
                         },
                         {
                             type: "link",
                             label: "Pool API",
-                            href: 'https://eclipse-tractusx.github.io/api-hub/bpdm/6.2.0-rc5/pool/'
+                            href: 'https://eclipse-tractusx.github.io/api-hub/bpdm/6.2.0/pool/swagger-ui/'
                         },
                         {
                             type: "link",
                             label: "Orchestrator API",
-                            href: 'https://eclipse-tractusx.github.io/api-hub/bpdm/6.2.0-rc5/orchestrator/'
+                            href: 'https://eclipse-tractusx.github.io/api-hub/bpdm/6.2.0/orchestrator/swagger-ui/'
                         },
                         'kits/Business Partner Kit/Software Development View/Use Cases'
                     ]


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request updates development view for business partner kit where swagger api documentation links are updated.
The swagger documentation for all services in BPDM app version 6.2.0 is now linked to business partner kit.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
