### PR TITLE
doc(open-meeting): adjusted open meeting for bpdm

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -74,7 +74,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 />
 
 <MeetingInfo title="BPDM - Open Meeting"
-             schedule="Every Wednesday effective 4. Dec 2024 until 28. May 2025 from 09:45 am to 10:15 am CEST"
+             schedule="Every Wednesday effective 4. Dec 2024 until 28. May 2025 from 09:45 am to 10:15 am CET"
              description="Coordination of feature refinement and development for bpdm product."
              contact="maximilian.ong@mercedes-benz.com"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NjYxNGZkNzctMjVmZi00MTU4LThhNWYtOGUwMTFiODJlMWU4%40thread.v2/0?context=%7b%22Tid%22%3a%229652d7c2-1ccf-4940-8151-4a92bd474ed0%22%2c%22Oid%22%3a%22efb1321e-4b62-4eb3-9d3f-88bee0686fc1%22%7d"

--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -74,7 +74,7 @@ These are dedicated sync meetings for specific products, as well as open plannin
 />
 
 <MeetingInfo title="BPDM - Open Meeting"
-             schedule="Every Wednesday effective 4. Dec 2024 until 28. May 2025 from 10:45 am to 11:15 am CEST"
+             schedule="Every Wednesday effective 4. Dec 2024 until 28. May 2025 from 09:45 am to 10:15 am CEST"
              description="Coordination of feature refinement and development for bpdm product."
              contact="maximilian.ong@mercedes-benz.com"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NjYxNGZkNzctMjVmZi00MTU4LThhNWYtOGUwMTFiODJlMWU4%40thread.v2/0?context=%7b%22Tid%22%3a%229652d7c2-1ccf-4940-8151-4a92bd474ed0%22%2c%22Oid%22%3a%22efb1321e-4b62-4eb3-9d3f-88bee0686fc1%22%7d"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request just adjusts the timing for BPDM - Open Meeting.
`Every Wednesday effective 4. Dec 2024 until 28. May 2025 from 09:45 am to 10:15 am CET`
<img width="996" alt="image" src="https://github.com/user-attachments/assets/9a2109b6-505d-4931-82af-e775eae65793">




## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
