### PR TITLE
fix (IC): Fixed two broken links to OpenAPI specification for Unique ID Push [GH-1068]

### DIFF
--- a/docs-kits/kits/Industry Core Kit/Software Development View/part_uniqueidpush.mdx
+++ b/docs-kits/kits/Industry Core Kit/Software Development View/part_uniqueidpush.mdx
@@ -195,7 +195,7 @@ Keep in mind that usage policies currently aren't technically enforced by the ED
 
 ##### Backend Data Service to Process Unique ID Push Notifications
 
-The receiver must setup a backend data service that provides an HTTP Endpoint for notifications. All endpoints are described in detail in the Unique ID Push Open API specification. The standardized version of this API is [2.0.0](../../../../openApi/industrycore/unique-id-push.yaml). Version [2.1.0](../../../../openApi/industrycore/unique-id-push_2-1-0.yaml) is not (yet) standardized, but backwards compatible, and extends v2.0.0 with the Connect-to-Child feature.
+The receiver must setup a backend data service that provides an HTTP Endpoint for notifications. All endpoints are described in detail in the Unique ID Push Open API specification. The standardized version of this API is [2.0.0](../openapi/unique-id-push.yaml). Version [2.1.0](../openapi/unique-id-push_2-1-0.yaml) is not (yet) standardized, but backwards compatible, and extends v2.0.0 with the Connect-to-Child feature.
 
 #### Notification Sender
 

--- a/docs-kits/kits/Industry Core Kit/page_changelog.mdx
+++ b/docs-kits/kits/Industry Core Kit/page_changelog.mdx
@@ -29,6 +29,16 @@ import Notice from './part_notice.mdx'
 
 All notable changes to this Kit will be documented in this file.
 
+## [2.0.0] - 2025-xx-xx
+
+Compatible for **release 25.03**.
+
+### Changed
+
+- **Development View:**
+  - **Digital Twins:**
+    - Fixed two broken links to OpenAPI specification for Unique ID Push [[GH-1068](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/issues/1068)].
+
 ## [1.2.0] - 2024-10-22
 
 Compatible for **release 24.08**.


### PR DESCRIPTION
## Description

Fixes dead links in Industry Core KIT as reported here: https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/issues/1068

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
