### PR TITLE
fix url in e2e bootst example

### DIFF
--- a/docs/tutorials/e2e/boost/provideData.md
+++ b/docs/tutorials/e2e/boost/provideData.md
@@ -43,7 +43,7 @@ curl --location 'http://dataprovider-controlplane.tx.test/management/v3/assets' 
 Just to be sure, that the asset was created succesfully, Bob can check the asset using the following `curl` command:
 
 ```shell
-curl -X POST http://dataprovider-controlplane.tx.test/management/v2/assets/request -H "x-api-key: TEST2" -H "content-type: application/json" | jq
+curl -X POST http://dataprovider-controlplane.tx.test/management/v3/assets/request -H "x-api-key: TEST2" -H "content-type: application/json" | jq
 ```
 
 The result shows the already existing assets and the newly created asset.


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
one url in document about boost data provider section is not correct. this pr fixes the url from /v2/assets to /v3/assets
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
