### PR TITLE
docs(open-meetings): update office hour and extend meetings for 2025

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -23,7 +23,7 @@ All the times are shown in:
 />
 
 <MeetingInfo title="Community Office Hour"
-             schedule="Every Friday effective 16. Feb 2024 until 31. Dec 2024 from 01:05 pm to 02:00 pm"
+             schedule="Every Friday effective 01. Jan 2025 until 31. Dec 2025 from 10:05 am to 11:00 am"
              description="Open hour meeting for all interests. The goal of the meeting is to inform and share information about different topics."
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MDFiNDJjMmQtNjFkYi00ODdjLTk2NDgtZGMwNTRmYzg3NzM0%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
@@ -44,7 +44,7 @@ All the times are shown in:
 />
 
 <MeetingInfo title="Committer Meeting"
-             schedule="Every 2 weeks on Friday effective 16. Feb 2024 until 31. Dec 2024 from 02:05 pm to 03:00 pm"
+             schedule="Every 2 weeks on Friday effective 01. Jan 2025 until 31. Dec 2025 from 02:05 pm to 03:00 pm"
              description="Open hour meeting for Eclipse Tractus-X committers. The goal of the meeting is to discuss and share specific committer tasks/responsibilities."
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTItNWE1MmMzMWUzNmYw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"


### PR DESCRIPTION
## Description

**This PR should be merged until the end of the year 2024**

It adapts the concrete timeslot for the office hour and extends office hour and committer hour to 2025

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
