### PR TITLE
docs(release-planning): add needed information for release planning 25.06

### DIFF
--- a/blog/2025-02-19-release-planning-R25.06.mdx
+++ b/blog/2025-02-19-release-planning-R25.06.mdx
@@ -148,7 +148,7 @@ feature requesters are encouraged to attend and actively engage in the discussio
 
 Here’s the plan for the day:
 - **09:05 - 09:30**: Open Planning - Vision & Introduction
-- **09:45 - 16:00**: Joint Open Planning (all teams)
+- **09:30 - 16:00**: Joint Open Planning (all teams)
 - **16:00 - 16:30**: Confidence Vote & Feedback Retro
 - **16:30 - 17:00**: Open Planning Wrap-Up / Summary & Next Steps
 

--- a/blog/2025-02-19-release-planning-R25.06.mdx
+++ b/blog/2025-02-19-release-planning-R25.06.mdx
@@ -1,0 +1,177 @@
+---
+title: Release Planning for Release 25.06
+description: Eclipse Tractus-X Community Update - Release Planning for Release 25.06
+slug: release-planning-R25.06
+date: 2024-12-13T11:00
+hide_table_of_contents: false
+authors:
+  - name: Stephan Bauer
+    title: Eclipse Tractus-X Project Lead
+    url: https://github.com/stephanbcbauer
+    image_url: https://github.com/stephanbcbauer.png
+    email: stephan.bauer@catena-x.net
+---
+
+import RenderImage from './RenderImage'
+
+![eclipse tractus x logo](@site/static/img/Tractus-X_openplanning.png)
+
+Hello, Eclipse Tractus-X Community!
+
+We are thrilled to invite you to a series of important sessions designed to drive collaboration, alignment, and planning for Eclipse Tractus-X Release R25.06.
+These meetings are essential to ensure a well-structured and successful release. Mark your calendars and come prepared to contribute!
+
+The overall teams session link and more links can be found on our [open-meetings](https://eclipse-tractusx.github.io/community/open-meetings#one-time-meetings) page.
+
+We look forward to seeing you all there!!!
+
+<!--truncate-->
+
+## Refinement Day 1 for R25.06
+
+During the refinement sessions, each group will focus on the first steps of skeleton-building for their features ( based on the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md) ),
+mapping them to the related roadmap items. Don’t worry about completing every section of the feature template just yet — this is a time for brainstorming and forming initial ideas.
+
+It's essential, however, to use the **feature template** and identify **dependencies** with other components or groups, which will help us add the correct labels to the features.
+You’re encouraged to collaborate across groups as needed, and we’ll provide **Teams sessions** for each group to work in.
+
+- **Date:** Wednesday, 22nd January 2025
+- **Time:** 09:05 - 12:00
+- **Main Teams Link:** [Join the session](https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODVmYWM1OGYtNjdkYS00ODgxLWI1YWEtMjAwZGJjY2NjNGIw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+
+### Agenda
+
+Here’s the plan for the day:
+- **09:05 - 09:30**: Welcome, Introduction, and Expectations
+- **09:30 - 11:15**: Refinement in dedicated groups, grouped by expert groups
+- **11:15 - 11:45**: Presenting the results, grouped by expert groups
+- **11:45 - 12:00**: Closing and Next Steps
+
+During the refinement sessions, each group will focus on the first steps of skeleton-building for their features (based on the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md),
+mapping them to the related roadmap items. Don’t worry about completing every section of the feature template just yet — this is a time for brainstorming and forming initial ideas.
+
+It's essential, however, to use the **feature template** and identify **dependencies** with other components or groups, which will help us add the correct labels to the features.
+You’re encouraged to collaborate across groups as needed, and we’ll provide **Teams sessions** for each group to work in.
+
+### Group Work & Presenting Results
+
+The goal of the refinement is to **identify the first ideas and dependencies** within your group. The **General Teams session** will be available for any questions that come up during this collaborative work.
+
+Important for the session:
+- Use the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md) to structure your work
+- Identify dependencies with other components or groups and add the correct labels to the features
+- Use the supported-by field to map the feature with your expert group
+
+At the end of the refinement session, we’ll regroup and present the progress made. Each expert group will present their refined features, focusing on what’s been developed so far and the key insights.
+
+### Group and Teams Sessions
+
+:::tip
+The sessions for the different groups / components / dependencies can be used to sync within the underlying expert groups. Feel free to switch between groups if necessary!
+:::
+
+- [Breakout 1](#placeholder-link-1)
+- [Breakout 2](#placeholder-link-2)
+- [Breakout 3](#placeholder-link-3)
+
+## Refinement Day 2 for R25.06
+
+During the refinement sessions, each group will focus on resolving **identified dependencies** from Refinement Day 1, which are visible via the **related labels** on the features.
+While further feature refinement is allowed, the emphasis is on addressing and coordinating **dependencies** between groups and components.
+
+Our working Board for the day is the [Release Planning - R25.06 - Preparation](https://github.com/orgs/eclipse-tractusx/projects/26/views/36)
+
+You’re encouraged to collaborate across groups as needed, and we’ll provide **Teams sessions** (we will use the same sessions from Refinement Day 1) for each group to work in.
+It might be the case for some experts to jump into different other groups to resolve dependencies.
+
+- **Date:** Wednesday, 12th February 2025
+- **Time:** 09:05 - 12:00
+- **Main Teams Link:** [Join the session](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MWVjNTkwNTEtYTFiZS00ODI5LWE4MTgtMzE5MWM2ZGIwMzgw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+
+### Agenda
+
+Here’s the plan for the day:
+- **09:05 - 09:30**: Welcome, Introduction, and Expectations
+- **09:30 - 11:15**: Refinement in dedicated groups, grouped by expert groups
+- **11:15 - 11:45**: Presenting the results, grouped by expert groups
+- **11:45 - 12:00**: Closing and Next Steps
+
+### Group Work & Presenting Results
+
+During the refinement sessions, each group will focus on resolving **identified dependencies** from Refinement Day 1, which are visible via the **related labels** on the features.
+While further feature refinement is allowed, the emphasis is on addressing and coordinating **dependencies** between groups and components.
+
+Our working Board for the day is the [Release Planning - R25.06 - Preparation](https://github.com/orgs/eclipse-tractusx/projects/26/views/36)
+
+You’re encouraged to collaborate across groups as needed, and we’ll provide **Teams sessions** (we will use the same sessions from Refinement Day 1) for each group to work in.
+It might be the case for some experts to jump into different other groups to resolve dependencies.
+
+Important for the session:
+- Use the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md) to structure your work
+- Identify dependencies with other components or groups and add the correct labels to the features
+- Use the supported-by field to map the feature with your expert group
+- help each other to solve/analyze dependencies
+
+At the end of the refinement session, we’ll regroup and present the progress made. Each expert group will present their refined features, focusing on what’s been developed so far and the key insights.
+
+:::note
+If the feature is ready refined, the status should be set to `Backlog`-> this should be an alignment, between the requesting Expert Group/Committee and the open-source community.
+:::
+
+### Group and Teams Sessions
+
+:::tip
+The sessions for the different groups / components / dependencies can be used to sync within the underlying expert groups. Feel free to switch between groups if necessary!
+:::
+
+- [Breakout 1](#placeholder-link-1)
+- [Breakout 2](#placeholder-link-2)
+- [Breakout 3](#placeholder-link-3)
+
+## Open Planning for R25.06
+
+- **Date:** Wednesday, 19th February 2025
+- **Time:** 09:05 - 17:00
+- **Teams Link:** [Join the session](https://teams.microsoft.com/l/meetup-join/19%3ameeting_NGRkMWIxOTctYTg3ZC00MWExLTk5NjYtMjBjZjYzYWFmZDMx%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
+
+**Who Should Attend**:
+- Contributors and Committers from the open-source community
+- Expert Group and Committee members
+- Feature requesters and stakeholders
+
+:::note
+Your participation is crucial to ensure the success of the release planning. Expert Groups, Committees, the open-source community (contributor and committer),
+feature requesters are encouraged to attend and actively engage in the discussions.
+:::
+
+### Agenda
+
+Here’s the plan for the day:
+- **09:05 - 09:30**: Open Planning - Vision & Introduction
+- **09:45 - 16:00**: Joint Open Planning (all teams)
+- **16:00 - 16:30**: Confidence Vote & Feedback Retro
+- **16:30 - 17:00**: Open Planning Wrap-Up / Summary & Next Steps
+
+The planning sessions will be driven by our [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Asupported-by+label%3A%22Prep-R25.06%22+status%3ABacklog), which organizes features based on their **supported-by** field.
+
+### Prerequisites for features to be considered in Open Planning
+
+For a feature to be included in the Open Planning, the following conditions must be met:
+- **Status must be 'Backlog'** – Committers and Expert Groups can set this status after the feature is fully refined.
+- **All categories in the feature template must be filled** – Do not delete any sections from the template.
+- **Milestone is NOT set** – This will be assigned during the Open Planning session.
+- **Contributor and Committer must be assigned**.
+- **Supported-by must be set**.
+
+During the session, if there is a common alignment among the participants, the feature milestone can be set to **25.06**, meaning it will be developed in the upcoming release.
+
+### Important Notes and Hints
+
+- Keep the board clean – there are still features with older milestones that have not yet been completed.
+- Do not delete any sections from the feature template, except for KITs.
+- For KITs, only the Contributor, Committer, and Description fields need to be filled.
+
+For any questions or further information, feel free to reach out via our [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) or join us in the Tractus-X [Matrix channel](https://matrix.to/#/#automotive.tractusx:matrix.eclipse.org).
+
+We look forward to your participation and collaboration! 🚀
+

--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -106,3 +106,61 @@ All the times are shown in:
                 ]
              }
 />
+
+<MeetingInfo title="Refinement Phase - Release 25.06"
+             schedule="Thursday, 9. January 2025 to Monday, 17. February 2025"
+             description="Please be aware that the Refinement Phase is to keep you aware of the overall timeline during the Release Process and does not constitute an actual meeting. It serves informational purposes only. During this time, the necessary people/groups should come together and work (refine) the future features. Feature authors take care of organising appointments and communicating with the relevant contacts themselves. The Teams Session link can be used. Be aware: The link and the shared content is available to everyone."
+             contact="stephan.bauer@catena-x.net"
+             additionalLinks={
+                 [
+                     {title: "Release Planning Board - Preparation (GitHub)", url: "https://github.com/orgs/eclipse-tractusx/projects/28/views/19?filterQuery=label%3A%22Prep-R25.06%22+-status%3ADone"},
+                     {title: "sig-release repository (GitHub)", url: "https://github.com/eclipse-tractusx/sig-release"},
+                     {title: "Timeline", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A%2225.06%22"}
+                 ]
+             }
+/>
+
+<MeetingInfo title="Refinement Day 1 - Release 25.06"
+             schedule="Wednesday, 22. January 2025, 09:05 AM to 12:00 PM"
+             description="Based on a predefined agenda (depending on the features on the board), individual dependencies are discussed and also documented directly on the feature. If the refinement of the features has already been carried out 'in the refinement phase' and the Definition of Entry (DoE) has already reached, this meeting can also be used as synchronisation."
+             contact="stephan.bauer@catena-x.net"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODVmYWM1OGYtNjdkYS00ODgxLWI1YWEtMjAwZGJjY2NjNGIw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
+             additionalLinks={
+                 [
+                     {title: "Release Planning Board - Supported (GitHub)", url: "https://github.com/orgs/eclipse-tractusx/projects/28/views/19?filterQuery=label%3A%22Prep-R25.06%22+-status%3ADone"},
+                     {title: "Timeline", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A%2225.06%22"},
+                     {title: "News Blog", url: "https://eclipse-tractusx.github.io/blog/release-planning-R25.06"},
+                     {title: "Refinement Sessions (TBD)", url: "https://eclipse-tractusx.github.io/blog/release-planning-R25.06"}
+                 ]
+             }
+/>
+
+<MeetingInfo title="Refinement Day 2 - Release 25.06"
+             schedule="Wednesday, 12. February 2025, 09:05 AM to 12:00 PM"
+             description="Based on a predefined agenda (depending on the features on the board), individual dependencies are discussed and also documented directly on the feature. If the refinement of the features has already been carried out 'in the refinement phase' and the Definition of Entry (DoE) has already reached, this meeting can also be used as synchronisation."
+             contact="stephan.bauer@catena-x.net"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MWVjNTkwNTEtYTFiZS00ODI5LWE4MTgtMzE5MWM2ZGIwMzgw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
+             additionalLinks={
+                 [
+                     {title: "Release Planning Board - Supported (GitHub)", url: "https://github.com/orgs/eclipse-tractusx/projects/28/views/19?filterQuery=label%3A%22Prep-R25.06%22+-status%3ADone"},
+                     {title: "Timeline", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A%2225.06%22"},
+                     {title: "News Blog", url: "https://eclipse-tractusx.github.io/blog/release-planning-R25.06"},
+                     {title: "Refinement Sessions (TBD)", url: "https://eclipse-tractusx.github.io/blog/release-planning-R25.06"}
+                 ]
+             }
+/>
+
+<MeetingInfo title="Open Planning Day - Release 25.06"
+             schedule="Wednesday, 19. February 2025, 09:05 AM to 05:00 PM"
+             description="The goal for this meeting is planning of the intended work content for the next release - which contains also preparation of future release content, refactoring, general architectural work, tool & process improvements, and feature planning for the next Tractus-X release."
+             contact="stephan.bauer@catena-x.net"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NGRkMWIxOTctYTg3ZC00MWExLTk5NjYtMjBjZjYzYWFmZDMx%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
+             additionalLinks={
+                 [
+                     {title: "Release Planning Board - Supported (GitHub)", url: "https://github.com/orgs/eclipse-tractusx/projects/28/views/39?filterQuery=label%3A%22Prep-R25.06%22+-status%3ADone"},
+                     {title: "Timeline", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A%2225.06%22"},
+                     {title: "News Blog", url: "https://eclipse-tractusx.github.io/blog/release-planning-R25.06"},
+                     {title: "Detailed Agenda", url: "https://eclipse-tractusx.github.io/blog/release-planning-R25.06"}
+                 ]
+             }
+/>

--- a/utils/newsTitles.js
+++ b/utils/newsTitles.js
@@ -1,27 +1,7 @@
 export const newsTitles = [
-  {
-    date: "18.11.2024",
-    title: "Eclipse Tractus-X Release 25.03 Planning Recap",
-    blogLink: "/blog/open-planning-recap-R25.03"
-  },
-  {
-    date: "13.11.2024",
-    title: "Open Planning for Release 25.03",
-    blogLink: "/blog/open-planning-R25.03"
-  },
-  {
-    date: "06.11.2024",
-    title: "Refinement Day 2 for Release 25.03",
-    blogLink: "/blog/refinement-day-2-R25.03"
-  },
-  {
-    date: "16.10.2024",
-    title: "Refinement Day 1 for Release 25.03",
-    blogLink: "/blog/refinement-day-1-R25.03"
-  },
-  {
-    date: "05.12.2024",
-    title: "Third Eclipse Tractus-X Community Days",
-    blogLink: "/blog/community-days-12-2024"
-  },
+    {
+        date: "19.02.2025",
+        title: "Tractus-X Community Update - Release Planning for Release 25.06",
+        blogLink: "/blog/release-planning-R25.06"
+    },
 ]


### PR DESCRIPTION
## Description

This pull request introduces updates to the release planning documentation and related community meeting information for the upcoming Eclipse Tractus-X Release 25.06.

- Updates to Release Planning Documentation
- Updates to Community Open Meetings
- Updates to News Titles

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
