### PR TITLE
docs(open meetings): delete redundante content

### DIFF
--- a/blog/2025-02-19-release-planning-R25.06.mdx
+++ b/blog/2025-02-19-release-planning-R25.06.mdx
@@ -18,22 +18,20 @@ import RenderImage from './RenderImage'
 
 Hello, Eclipse Tractus-X Community!
 
-We are thrilled to invite you to a series of important sessions designed to drive collaboration, alignment, and planning for Eclipse Tractus-X Release R25.06.
-These meetings are essential to ensure a well-structured and successful release. Mark your calendars and come prepared to contribute!
+Collaboration drives the success of Eclipse Tractus-X, and we are excited to invite you to the **Release Planning sessions for R25.06**! These sessions are your chance to shape the roadmap, align with the community, and ensure a well-structured release.
 
-The overall teams session link and more links can be found on our [open-meetings](https://eclipse-tractusx.github.io/community/open-meetings#one-time-meetings) page.
+**Key Information:**
+- 📅 **Dates and Times**: Listed for each session below.
+- 📂 **Resources**: Visit our [**open meetings page**](https://eclipse-tractusx.github.io/community/open-meetings#one-time-meetings) for all session links and additional documentation.
+- 🔗 **Preparation Materials**: Ensure readiness by reviewing the provided templates, guidelines and your own features.
 
-We look forward to seeing you all there!!!
+We look forward to seeing you there and working together to make R25.06 a success!
 
 <!--truncate-->
 
 ## Refinement Day 1 for R25.06
 
-During the refinement sessions, each group will focus on the first steps of skeleton-building for their features ( based on the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md) ),
-mapping them to the related roadmap items. Don’t worry about completing every section of the feature template just yet — this is a time for brainstorming and forming initial ideas.
-
-It's essential, however, to use the **feature template** and identify **dependencies** with other components or groups, which will help us add the correct labels to the features.
-You’re encouraged to collaborate across groups as needed, and we’ll provide **Teams sessions** for each group to work in.
+The first Refinement Day sets the foundation for R25.06. Expert groups will brainstorm, refine features, and identify key dependencies for roadmap alignment.
 
 - **Date:** Wednesday, 22nd January 2025
 - **Time:** 09:05 - 12:00
@@ -41,30 +39,26 @@ You’re encouraged to collaborate across groups as needed, and we’ll provide 
 
 ### Agenda
 
-Here’s the plan for the day:
 - **09:05 - 09:30**: Welcome, Introduction, and Expectations
-- **09:30 - 11:15**: Refinement in dedicated groups, grouped by expert groups
-- **11:15 - 11:45**: Presenting the results, grouped by expert groups
+- **09:30 - 11:15**: Refinement in dedicated groups
+- **11:15 - 11:45**: Group presentations on progress
 - **11:45 - 12:00**: Closing and Next Steps
+
+### Preparation Checklist
+
+- Review the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md).
+- Prepare initial ideas for features.
+- Identify potential dependencies with other groups or components.
+- Familiarize yourself with related roadmap items.
+- Use the supported-by field to map the feature with your expert group
+
+### Group and Teams Sessions
 
 During the refinement sessions, each group will focus on the first steps of skeleton-building for their features (based on the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md),
 mapping them to the related roadmap items. Don’t worry about completing every section of the feature template just yet — this is a time for brainstorming and forming initial ideas.
 
 It's essential, however, to use the **feature template** and identify **dependencies** with other components or groups, which will help us add the correct labels to the features.
 You’re encouraged to collaborate across groups as needed, and we’ll provide **Teams sessions** for each group to work in.
-
-### Group Work & Presenting Results
-
-The goal of the refinement is to **identify the first ideas and dependencies** within your group. The **General Teams session** will be available for any questions that come up during this collaborative work.
-
-Important for the session:
-- Use the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md) to structure your work
-- Identify dependencies with other components or groups and add the correct labels to the features
-- Use the supported-by field to map the feature with your expert group
-
-At the end of the refinement session, we’ll regroup and present the progress made. Each expert group will present their refined features, focusing on what’s been developed so far and the key insights.
-
-### Group and Teams Sessions
 
 :::tip
 The sessions for the different groups / components / dependencies can be used to sync within the underlying expert groups. Feel free to switch between groups if necessary!
@@ -76,13 +70,7 @@ The sessions for the different groups / components / dependencies can be used to
 
 ## Refinement Day 2 for R25.06
 
-During the refinement sessions, each group will focus on resolving **identified dependencies** from Refinement Day 1, which are visible via the **related labels** on the features.
-While further feature refinement is allowed, the emphasis is on addressing and coordinating **dependencies** between groups and components.
-
-Our working Board for the day is the [Release Planning - R25.06 - Preparation](https://github.com/orgs/eclipse-tractusx/projects/26/views/36)
-
-You’re encouraged to collaborate across groups as needed, and we’ll provide **Teams sessions** (we will use the same sessions from Refinement Day 1) for each group to work in.
-It might be the case for some experts to jump into different other groups to resolve dependencies.
+The second Refinement Day focuses on resolving **dependencies** identified during Refinement Day 1. Groups will refine their features further, ensuring alignment across components.
 
 - **Date:** Wednesday, 12th February 2025
 - **Time:** 09:05 - 12:00
@@ -90,13 +78,20 @@ It might be the case for some experts to jump into different other groups to res
 
 ### Agenda
 
-Here’s the plan for the day:
-- **09:05 - 09:30**: Welcome, Introduction, and Expectations
-- **09:30 - 11:15**: Refinement in dedicated groups, grouped by expert groups
-- **11:15 - 11:45**: Presenting the results, grouped by expert groups
+- **09:05 - 09:30**: Welcome and recap of Refinement Day 1 results
+- **09:30 - 11:15**: Group work on resolving dependencies
+- **11:15 - 11:45**: Group presentations on resolved dependencies
 - **11:45 - 12:00**: Closing and Next Steps
 
-### Group Work & Presenting Results
+### Key Focus Areas
+
+- Use the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md).
+- Add labels for identified dependencies.
+- Collaborate across groups to resolve issues.
+- Use the supported-by field to map the feature with your expert group.
+- Status `Backlog`-> this should be an alignment, between the requesting Expert Group/Committee and the open-source community.
+
+### Group and Teams Sessions
 
 During the refinement sessions, each group will focus on resolving **identified dependencies** from Refinement Day 1, which are visible via the **related labels** on the features.
 While further feature refinement is allowed, the emphasis is on addressing and coordinating **dependencies** between groups and components.
@@ -105,20 +100,6 @@ Our working Board for the day is the [Release Planning - R25.06 - Preparation](h
 
 You’re encouraged to collaborate across groups as needed, and we’ll provide **Teams sessions** (we will use the same sessions from Refinement Day 1) for each group to work in.
 It might be the case for some experts to jump into different other groups to resolve dependencies.
-
-Important for the session:
-- Use the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md) to structure your work
-- Identify dependencies with other components or groups and add the correct labels to the features
-- Use the supported-by field to map the feature with your expert group
-- help each other to solve/analyze dependencies
-
-At the end of the refinement session, we’ll regroup and present the progress made. Each expert group will present their refined features, focusing on what’s been developed so far and the key insights.
-
-:::note
-If the feature is ready refined, the status should be set to `Backlog`-> this should be an alignment, between the requesting Expert Group/Committee and the open-source community.
-:::
-
-### Group and Teams Sessions
 
 :::tip
 The sessions for the different groups / components / dependencies can be used to sync within the underlying expert groups. Feel free to switch between groups if necessary!
@@ -129,6 +110,8 @@ The sessions for the different groups / components / dependencies can be used to
 - [Breakout 3](#placeholder-link-3)
 
 ## Open Planning for R25.06
+
+The Open Planning session finalizes the roadmap for R25.06, prioritizing features and aligning all participants on deliverables for the release.
 
 - **Date:** Wednesday, 19th February 2025
 - **Time:** 09:05 - 17:00


### PR DESCRIPTION
## Description

This pull request aims to improve clarity and structure for the Eclipse Tractus-X Release R25.06 planning sessions.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
