### PR TITLE
doc: add TRG regarding application testing

### DIFF
--- a/docs/release/trg-10/_category_.json
+++ b/docs/release/trg-10/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "TRG 10 - Application Testing"
+}

--- a/docs/release/trg-10/trg-10-01.md
+++ b/docs/release/trg-10/trg-10-01.md
@@ -13,7 +13,7 @@ Ensure that all released software components meet sufficient test coverage to gu
 This guideline applies to all software components and projects that are part of the Tractus-X release process.
 ## Description
 
-#### 1. Minimum Requirements
+### 1. Minimum Requirements
 
 1.1. **Code Coverage Threshold**
 
@@ -28,7 +28,7 @@ This guideline applies to all software components and projects that are part of 
   - Are purely generated or boilerplate code or Entity classes.
 - All exceptions should be documented and approved by the project leadership team.
 
-#### 2. Analysis and Reporting
+### 2. Analysis and Reporting
 
 2.1. **Tools for Code Coverage Measurement**
 
@@ -40,7 +40,7 @@ This guideline applies to all software components and projects that are part of 
 - Code coverage should be measured at least once before each release.
 - Coverage measurement results should  be integrated into CI/CD pipelines and automated as part of the release process.
 
-#### 3. Quality Assurance
+### 3. Quality Assurance
 
 3.1. **Code Review Requirements**
 
@@ -50,6 +50,3 @@ This guideline applies to all software components and projects that are part of 
 3.2. **Risk Analysis**
 
 - If the coverage value falls below 80%, the potential risks should be documented and approved by the release management team.
-
-
-

--- a/docs/release/trg-10/trg-10-01.md
+++ b/docs/release/trg-10/trg-10-01.md
@@ -11,6 +11,7 @@ sidebar_position: 1
 
 Ensure that all released software components meet sufficient test coverage to guarantee quality, stability, and reliability.
 This guideline applies to all software components and projects that are part of the Tractus-X release process.
+
 ## Description
 
 ### 1. Minimum Requirements

--- a/docs/release/trg-10/trg-10-01.md
+++ b/docs/release/trg-10/trg-10-01.md
@@ -1,0 +1,55 @@
+---
+title: TRG 10.01 - Code Coverage
+sidebar_position: 1
+---
+
+| Status | Created     | Post-History  |
+|--------|-------------|---------------|
+| Draft  | 18-Dec-2024 | Create draft |
+
+## Why
+
+Ensure that all released software components meet sufficient test coverage to guarantee quality, stability, and reliability.
+This guideline applies to all software components and projects that are part of the Tractus-X release process.
+## Description
+
+#### 1. Minimum Requirements
+
+1.1. **Code Coverage Threshold**
+
+- The minimum threshold for code coverage (line coverage) should be **80%**.
+- This includes both unit tests and integration tests.
+
+1.2. **Exceptions**
+
+- Certain code sections may be excluded from coverage if they:
+  - Depend on hardware that cannot be simulated.
+  - Are experimental or prototypes.
+  - Are purely generated or boilerplate code or Entity classes.
+- All exceptions should be documented and approved by the project leadership team.
+
+#### 2. Analysis and Reporting
+
+2.1. **Tools for Code Coverage Measurement**
+
+- Recommended tools: [JaCoCo, SonarCloud]
+- The tool used should be specified and documented within the project.
+
+2.2. **Regular Review**
+
+- Code coverage should be measured at least once before each release.
+- Coverage measurement results should  be integrated into CI/CD pipelines and automated as part of the release process.
+
+#### 3. Quality Assurance
+
+3.1. **Code Review Requirements**
+
+- Reviewers should ensure that new or modified code sections are sufficiently tested.
+- Code changes that lower the overall coverage below the threshold may only be accepted in exceptional cases.
+
+3.2. **Risk Analysis**
+
+- If the coverage value falls below 80%, the potential risks should be documented and approved by the release management team.
+
+
+


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
This PR introduces a new TRG in regard to application testing. Currently, there is no TRG that covers application testing before a release.
https://github.com/eclipse-tractusx/sig-release/issues/970

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
