### PR TITLE
fix(trg9): typo in headline

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -730,7 +730,7 @@ npm/npmjs/-/react-live/3.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/react-loadable-ssr-addon-v5-slorber/1.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/react-magic-dropzone/1.0.1, MIT, approved, #6622
 npm/npmjs/-/react-markdown/8.0.5, MIT, approved, #6635
-npm/npmjs/-/react-modal/3.16.1, MIT, approved, clearlydefined
+npm/npmjs/-/react-modal/3.16.1, MIT, approved, #18547
 npm/npmjs/-/react-redux/7.2.9, MIT, approved, #2978
 npm/npmjs/-/react-router-config/5.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/react-router-dom/5.3.4, MIT AND BSD-3-Clause, approved, #3023
@@ -908,7 +908,7 @@ npm/npmjs/-/type-fest/2.19.0, CC0-1.0 OR MIT OR (CC0-1.0 AND MIT), approved, cle
 npm/npmjs/-/type-is/1.6.18, MIT, approved, clearlydefined
 npm/npmjs/-/typedarray-to-buffer/3.1.5, MIT, approved, clearlydefined
 npm/npmjs/-/typescript/4.9.4, Apache-2.0 AND (CC-BY-4.0 AND LicenseRef-scancode-khronos AND LicenseRef-scancode-unicode AND MIT AND W3C-20150513), approved, #4979
-npm/npmjs/-/ua-parser-js/0.7.32, MIT, approved, clearlydefined
+npm/npmjs/-/ua-parser-js/0.7.32, MIT, approved, #18507
 npm/npmjs/-/uc.micro/1.0.6, MIT, approved, #1022
 npm/npmjs/-/unherit/1.1.3, MIT, approved, clearlydefined
 npm/npmjs/-/unicode-canonical-property-names-ecmascript/2.0.0, MIT, approved, clearlydefined

--- a/docs/release/trg-9/_category_.json
+++ b/docs/release/trg-9/_category_.json
@@ -1,3 +1,3 @@
 {
-  "label": "TRG 9 - UX/UX Styleguide"
+  "label": "TRG 9 - UX/UI Styleguide"
 }


### PR DESCRIPTION
## Description

This PR fixes a typo in the headline

Fixes #1100 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
