### PR TITLE
Update .tractusx to allow API-Hub to ingest DCM KIT APIs

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -7,3 +7,7 @@ repositories:
   url: "https://github.com/eclipse-tractusx/eclipse-tractusx.github.io"
 openApiSpecs:
 - "https://raw.githubusercontent.com/eclipse-tractusx/eclipse-tractusx.github.io/main/openApi/dt/kit_digital-twin-kit-submodel-api_openAPI.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/eclipse-tractusx.github.io/main/openApi/dcm/IdBasedComment.yaml.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/eclipse-tractusx.github.io/main/openApi/dcm/IdBasedRequestForUpdate.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/eclipse-tractusx.github.io/main/openApi/dcm/WeekBasedCapacityGroup.yaml"
+- "https://raw.githubusercontent.com/eclipse-tractusx/eclipse-tractusx.github.io/main/openApi/dcm/WeekBasedMaterialDemand.yaml"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Following https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-08/ :
Modifies .tractusx to allow API-Hub to ingest APIs so that the DCM KIT can migrate to the API-Hub
YAMLs: https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/openApi/dcm

<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
  - This PR does not introduce new dependencies 
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
  - As a config file https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/blob/main/.tractusx does currently have neither header. I did not add a header.