### PR TITLE
docs: delete reference to catena-x ng

### DIFF
--- a/docs/release/trg-5/trg-5-02.md
+++ b/docs/release/trg-5/trg-5-02.md
@@ -53,8 +53,7 @@ Structure](../trg-2/trg-2-3.md).
 It is **mandatory to add a valid license/copyright header** to each file (except of rendered files, e.g. Markdown files) in the
 Git repository!
 
-For further details, please refer to [How to make your Catena-X product OSS
-ready](https://github.com/catenax-ng/foss-example#how-to-make-your-catenax-product-oss-ready).
+For further details, please refer to [TRG 2.03](../trg-2/trg-2-3.md).
 
 :::
 


### PR DESCRIPTION
## Description

This PR replaces one "small" reference to Catena-X NG, since we would like to archive the  Catena-X NG GitHub ORG as soon as possible.

This PR adds value to #1026 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
