### PR TITLE
fix: remove last references to catenax-ng artifacts from ka kit

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -911,10 +911,10 @@ npm/npmjs/-/typescript/4.9.4, Apache-2.0 AND (CC-BY-4.0 AND LicenseRef-scancode-
 npm/npmjs/-/ua-parser-js/0.7.32, MIT, approved, #18507
 npm/npmjs/-/uc.micro/1.0.6, MIT, approved, #1022
 npm/npmjs/-/unherit/1.1.3, MIT, approved, clearlydefined
-npm/npmjs/-/unicode-canonical-property-names-ecmascript/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/unicode-canonical-property-names-ecmascript/2.0.0, MIT, approved, #19200
 npm/npmjs/-/unicode-match-property-ecmascript/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/unicode-match-property-value-ecmascript/2.1.0, MIT, approved, #4991
-npm/npmjs/-/unicode-property-aliases-ecmascript/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/unicode-property-aliases-ecmascript/2.1.0, MIT AND Unicode-3.0, approved, #19201
 npm/npmjs/-/unified/10.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/unified/9.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/unified/9.2.2, MIT, approved, clearlydefined
@@ -1280,7 +1280,7 @@ npm/npmjs/@types/ms/0.7.31, MIT, approved, #10811
 npm/npmjs/@types/node/14.18.36, MIT, approved, #4611
 npm/npmjs/@types/node/17.0.45, MIT, approved, clearlydefined
 npm/npmjs/@types/node/18.11.18, MIT, approved, #5746
-npm/npmjs/@types/parse-json/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/@types/parse-json/4.0.0, MIT, approved, #19219
 npm/npmjs/@types/parse5/5.0.3, MIT, approved, clearlydefined
 npm/npmjs/@types/parse5/6.0.3, MIT, approved, clearlydefined
 npm/npmjs/@types/prop-types/15.7.5, MIT, approved, #16176

--- a/docs-kits/kits/knowledge-agents/development-view/api.md
+++ b/docs-kits/kits/knowledge-agents/development-view/api.md
@@ -131,7 +131,7 @@ curl --location '${KA-MATCH}/agent/skill?asset=urn%3Acx%3ASkill%3Aconsumer%3ALif
 --data-raw 'PREFIX xsd:           <http://www.w3.org/2001/XMLSchema#> 
 PREFIX rdf:           <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:          <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX cx:            <https://github.com/catenax-ng/product-knowledge/ontology/cx.ttl#>
+PREFIX cx:            <https://w3id.org/catenax/ontology#>
 
 ############################################################################################
 #                  Catena-X Knowledge Agents Sample Federated Skill           
@@ -166,8 +166,8 @@ VALUES (?vin ?troubleCode) { ("@vin"^^xsd:string "@troubleCode"^^xsd:string) }.
         cx:hasConnector ?oemConnector.
 
 ?oemConnector cx:offersAsset ?diagnoseAsset.
-?diagnoseAsset rdf:type <https://raw.githubusercontent.com/catenax-ng/product-knowledge/main/ontology/cx_ontology.ttl#GraphAsset>;
-                rdfs:isDefinedBy <https://raw.githubusercontent.com/catenax-ng/product-knowledge/main/ontology/diagnosis_ontology.ttl>.
+?diagnoseAsset rdf:type <https://w3id.org/catenax/taxonomy#GraphAsset>;
+                rdfs:isDefinedBy <https://w3id.org/catenax/ontology/reliability>.
 
 ####
 # 3. The CONSUMER delegates the following logic to the OEM (connector)
@@ -214,7 +214,7 @@ SERVICE ?oemConnector {
                     ].           
 
     ?tieraConnector cx:offersAsset ?prognosisAsset.
-    ?prognosisAsset rdfs:isDefinedBy <https://raw.githubusercontent.com/catenax-ng/product-knowledge/main/ontology/prognosis_ontology.ttl>.
+    ?prognosisAsset rdfs:isDefinedBy <https://w3id.org/catenax/ontology/behaviour>.
 
     ####
     # 4. The OEM (and not the CONSUMER) delegates to the SUPPLIER (connector)
@@ -277,7 +277,7 @@ curl --location '${KA-BIND}/agent' \
 --data-raw 'PREFIX xsd:           <http://www.w3.org/2001/XMLSchema#> 
 PREFIX rdf:           <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs:          <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX cx:            <https://github.com/catenax-ng/product-knowledge/ontology/cx.ttl#>
+PREFIX cx:            <https://w3id.org/catenax/ontology#>
 
 # Sample Graph Context that is Delegated/Instantiated to a Binding Agent Call
 SELECT ?partType ?description WHERE {

--- a/docs-kits/kits/knowledge-agents/development-view/api.md
+++ b/docs-kits/kits/knowledge-agents/development-view/api.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: API
 ---
 <!--
- * Copyright (c) 2021,2023 T-Systems International GmbH
+ * Copyright (c) 2021,2025 T-Systems International GmbH
  * Copyright (c) 2021,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) 
  * Copyright (c) 2021,2023 Mercedes-Benz AG
  * Copyright (c) 2021,2023 ZF Friedrichshafen AG

--- a/docs-kits/kits/knowledge-agents/development-view/modules.md
+++ b/docs-kits/kits/knowledge-agents/development-view/modules.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: Layers & Modules
 ---
 <!--
- * Copyright (c) 2021,2024 T-Systems International GmbH
+ * Copyright (c) 2021,2025 T-Systems International GmbH
  * Copyright (c) 2021,2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) 
  * Copyright (c) 2021,2023 Mercedes-Benz AG
  * Copyright (c) 2021,2023 ZF Friedrichshafen AG

--- a/docs-kits/kits/knowledge-agents/development-view/modules.md
+++ b/docs-kits/kits/knowledge-agents/development-view/modules.md
@@ -37,7 +37,7 @@ For more information see
 * Our [Reference Implementation](reference)
 * The [Deployment](../operation-view/deployment) guide
 
-In this context generic building blocks were defined (see next figure) which can be implemented with different open source or [COTS](https://en.wikipedia.org/wiki/Commercial_off-the-shelf) solutions. In the scope of Catena-X project these building blocks are instantiated with a reference implementation based on open source components (the Knowledge Agents KIT). The detailed architecture following this reference implementation can be found here: <https://catenax-ng.github.io/product-knowledge/docs/architecture>.
+In this context generic building blocks were defined (see next figure) which can be implemented with different open source or [COTS](https://en.wikipedia.org/wiki/Commercial_off-the-shelf) solutions. In the scope of Catena-X project these building blocks are instantiated with a reference implementation based on open source components (the Knowledge Agents KIT). The detailed architecture following this reference implementation can be found [here](architecture).
 
 [![Architecture High-Level](/img/knowledge-agents/layer_architecture_small.png)](/img/knowledge-agents/layer_architecture.png)
 
@@ -193,7 +193,7 @@ The Federated Catalogue is an RDF data storage facility for the Matchmaking Agen
 
 The Federated Catalogue should initially download the complete Semantic Model that has been released for the target environment. It should also contain a list of business partners and their roles which form the surrounding dataspace neighborhood of the tenant. For that purpose, It could use GPDM (Business Partner Data Management) and Self-Description Hub services in order to lookup EDC addresses and additional domain information (sites, geo addresses). It should then be frequently updated with “live” information by invoking the EDC data management API to regularly obtain catalogue information.
 
-The portion of the Semantic Model describing these meta-data (Business Partners, Sites, Addresses, Use Cases, Use Case Roles, Connectors & Assets) is called the Common domain ontology and is mandatory for all releases/excerpts of the Semantic Model (<https://raw.githubusercontent.com/catenax-ng/product-knowledge/main/ontology/common_ontology.ttl>).
+The portion of the Semantic Model describing these meta-data (Business Partners, Sites, Addresses, Use Cases, Use Case Roles, Connectors & Assets) is called the Common domain ontology and is mandatory for all releases/excerpts of the Semantic Model (<https://w3id.org/catenax/ontology>).
 
 ## Virtualization Layer (Non-Standard Relevant)
 

--- a/docs-kits/kits/knowledge-agents/operation-view/ka_conformity_scripts.postman_collection.json
+++ b/docs-kits/kits/knowledge-agents/operation-view/ka_conformity_scripts.postman_collection.json
@@ -3761,7 +3761,7 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "https://raw.githubusercontent.com/catenax-ng/product-knowledge/main/ontology/:model",
+											"raw": "https://raw.githubusercontent.com/big-data-spaces/ontology/refs/heads/main/ontology/:model",
 											"protocol": "https",
 											"host": [
 												"raw",
@@ -3769,8 +3769,10 @@
 												"com"
 											],
 											"path": [
-												"catenax-ng",
-												"product-knowledge",
+												"big-data-spaces",
+												"ontology",
+												"refs",
+												"heads",
 												"main",
 												"ontology",
 												":model"
@@ -3778,7 +3780,7 @@
 											"variable": [
 												{
 													"key": "model",
-													"value": "cx_ontology.ttl"
+													"value": "common_ontology.ttl"
 												}
 											]
 										}
@@ -3791,7 +3793,7 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "https://api.github.com/repos/catenax-ng/product-knowledge/contents/ontology?ref=release/v0.7.4",
+											"raw": "https://api.github.com/repos/big-data-spaces/ontology/contents/ontology?ref=release/24.03",
 											"protocol": "https",
 											"host": [
 												"api",
@@ -3800,15 +3802,15 @@
 											],
 											"path": [
 												"repos",
-												"catenax-ng",
-												"product-knowledge",
+												"big-data-spaces",
+												"ontology",
 												"contents",
 												"ontology"
 											],
 											"query": [
 												{
 													"key": "ref",
-													"value": "release/v0.7.4"
+													"value": "release/v24.03"
 												},
 												{
 													"key": "ref",

--- a/docs-kits/kits/knowledge-agents/operation-view/ka_conformity_scripts.postman_collection.json
+++ b/docs-kits/kits/knowledge-agents/operation-view/ka_conformity_scripts.postman_collection.json
@@ -2,7 +2,7 @@
 	"info": {
 		"_postman_id": "0ad1b7a6-734c-4289-9221-667fc56a21da",
 		"name": "KA Conformity Assessment Scripts (R24.08)",
-		"description": "(C) 2021,2023 Contributors to the Eclipse Foundation\n\nSPDX-LICENSE-IDENTIFIER: CC-BY-4.0",
+		"description": "(C) 2021,2025 Contributors to the Eclipse Foundation\n\nSPDX-LICENSE-IDENTIFIER: CC-BY-4.0",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "2757771",
 		"_collection_link": "https://www.postman.com/catena-x/workspace/catena-x-knowledge-agents/collection/2757771-0ad1b7a6-734c-4289-9221-667fc56a21da?action=share&source=collection_link&creator=2757771"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Removed remaining references to catenax-ng from the agents kit.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
