### PR TITLE
docs(news-blog): add blog for fourth Eclipse Tractus-x Community Days

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -329,7 +329,7 @@ npm/npmjs/-/glob-parent/5.1.2, ISC, approved, clearlydefined
 npm/npmjs/-/glob-parent/6.0.2, ISC, approved, clearlydefined
 npm/npmjs/-/glob-to-regexp/0.4.1, BSD-2-Clause, approved, clearlydefined
 npm/npmjs/-/glob/7.1.6, ISC, approved, #994
-npm/npmjs/-/glob/7.2.3, ISC, approved, clearlydefined
+npm/npmjs/-/glob/7.2.3, ISC AND (CC-BY-SA-4.0 AND ISC) AND (ISC AND MIT) AND CC-BY-SA-4.0, approved, #19366
 npm/npmjs/-/global-dirs/3.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/global-modules/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/global-prefix/3.0.0, MIT, approved, clearlydefined
@@ -393,7 +393,7 @@ npm/npmjs/-/ieee754/1.2.1, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/-/ignore/5.2.4, MIT, approved, #5907
 npm/npmjs/-/image-size/1.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/immer/9.0.17, MIT, approved, #7037
-npm/npmjs/-/import-fresh/3.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/import-fresh/3.3.0, MIT, approved, #19299
 npm/npmjs/-/import-lazy/2.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/imurmurhash/0.1.4, MIT, approved, clearlydefined
 npm/npmjs/-/indent-string/4.0.0, MIT, approved, clearlydefined
@@ -903,7 +903,7 @@ npm/npmjs/-/trough/2.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/ts-dedent/2.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/ts-interface-checker/0.1.13, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/tslib/2.4.1, 0BSD, approved, #4336
-npm/npmjs/-/type-fest/0.20.2, MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
+npm/npmjs/-/type-fest/0.20.2, CC0-1.0 AND MIT, approved, clearlydefined
 npm/npmjs/-/type-fest/2.19.0, CC0-1.0 OR MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
 npm/npmjs/-/type-is/1.6.18, MIT, approved, clearlydefined
 npm/npmjs/-/typedarray-to-buffer/3.1.5, MIT, approved, clearlydefined
@@ -1280,7 +1280,7 @@ npm/npmjs/@types/ms/0.7.31, MIT, approved, #10811
 npm/npmjs/@types/node/14.18.36, MIT, approved, #4611
 npm/npmjs/@types/node/17.0.45, MIT, approved, clearlydefined
 npm/npmjs/@types/node/18.11.18, MIT, approved, #5746
-npm/npmjs/@types/parse-json/4.0.0, MIT AND (JSON AND MIT), restricted, #19219
+npm/npmjs/@types/parse-json/4.0.0, MIT, approved, #19219
 npm/npmjs/@types/parse5/5.0.3, MIT, approved, clearlydefined
 npm/npmjs/@types/parse5/6.0.3, MIT, approved, clearlydefined
 npm/npmjs/@types/prop-types/15.7.5, MIT, approved, #16176

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -911,10 +911,10 @@ npm/npmjs/-/typescript/4.9.4, Apache-2.0 AND (CC-BY-4.0 AND LicenseRef-scancode-
 npm/npmjs/-/ua-parser-js/0.7.32, MIT, approved, #18507
 npm/npmjs/-/uc.micro/1.0.6, MIT, approved, #1022
 npm/npmjs/-/unherit/1.1.3, MIT, approved, clearlydefined
-npm/npmjs/-/unicode-canonical-property-names-ecmascript/2.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/unicode-canonical-property-names-ecmascript/2.0.0, MIT, approved, #19200
 npm/npmjs/-/unicode-match-property-ecmascript/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/unicode-match-property-value-ecmascript/2.1.0, MIT, approved, #4991
-npm/npmjs/-/unicode-property-aliases-ecmascript/2.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/unicode-property-aliases-ecmascript/2.1.0, MIT AND Unicode-3.0, approved, #19201
 npm/npmjs/-/unified/10.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/unified/9.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/unified/9.2.2, MIT, approved, clearlydefined
@@ -1280,7 +1280,7 @@ npm/npmjs/@types/ms/0.7.31, MIT, approved, #10811
 npm/npmjs/@types/node/14.18.36, MIT, approved, #4611
 npm/npmjs/@types/node/17.0.45, MIT, approved, clearlydefined
 npm/npmjs/@types/node/18.11.18, MIT, approved, #5746
-npm/npmjs/@types/parse-json/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/@types/parse-json/4.0.0, MIT AND (JSON AND MIT), restricted, #19219
 npm/npmjs/@types/parse5/5.0.3, MIT, approved, clearlydefined
 npm/npmjs/@types/parse5/6.0.3, MIT, approved, clearlydefined
 npm/npmjs/@types/prop-types/15.7.5, MIT, approved, #16176

--- a/blog/2025-05-22-fourth-community-days.mdx
+++ b/blog/2025-05-22-fourth-community-days.mdx
@@ -1,0 +1,56 @@
+---
+title: Join us in May 2025 for the Fourth Eclipse Tractus-X Community Days!
+description: The Eclipse Tractus-X Community Days - Empowering the Catena-X Data Space
+slug: community-days-05-2025
+date: 2025-01-30T08:00
+hide_table_of_contents: false
+authors:
+  - name: Stephan Bauer
+    title: Platform Domain Manager
+    url: https://github.com/stephanbcbauer
+    image_url: https://github.com/stephanbcbauer.png
+    email: stephan.bauer@catena-x.net
+---
+
+import RenderImage from './RenderImage'
+
+![eclipse tractus x logo](@site/static/img/tractus-x-community-days-24-12.png)
+
+Dear Eclipse Tractus-X- and Dataspace-Community,
+
+Following the overwhelming positivity of the third Eclipse Tractus-X Community Days, we are pleased to announce the fourth edition, scheduled for May 22-23, 2025,
+at ARENA2036 in Stuttgart, Germany. Because of the high demand we have expanded our capacity, this year's event will welcome even more participants and feature an
+expanded range of workshops, challenges, and opportunities to collaborate on shaping the future of open-source development in manufacturing and beyond.
+
+<!--truncate-->
+
+### Why Attend?
+
+- **Global Collaboration:** Connect with participants from across the world, including contributors to Manufacturing-X initiatives like Factory-X, Chem-X, Aerospace-X, and more.
+- **Hands-On Innovation:** Participate in interactive workshops and challenges using the latest tools and services from Eclipse Tractus-X.
+- **Expanded Opportunities:** With more space and sessions, this year promises unparalleled opportunities to learn, network, and contribute.
+- **Inspiring Insights:** Hear from industry leaders and pioneers in open-source collaboration and data ecosystems.
+
+### Recap Third Eclipse Tractus-X Community Days
+
+<iframe width="100%" height="550" src="https://www.youtube.com/embed/IBv8PsCS0E8" title="YouTube video player"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+#### Agenda
+
+:::info
+Will follow soon
+:::
+
+### Be Part of the Future
+
+Whether you're a developer, project manager, or solution provider, the Eclipse Tractus-X Community Days offer an unparalleled forum for collaboration, creativity, and contribution
+to the future of data spaces.
+
+:::info
+**Save the date: May 22-23, 2025** and register [here](https://eveeno.com/272304835)
+:::
+
+Let's continue driving open-source innovation together!

--- a/blog/2025-05-22-fourth-community-days.mdx
+++ b/blog/2025-05-22-fourth-community-days.mdx
@@ -29,7 +29,7 @@ expanded range of workshops, challenges, and opportunities to collaborate on sha
 - **Global Collaboration:** Connect with participants from across the world, including contributors to Manufacturing-X initiatives like Factory-X, Chem-X, Aerospace-X, and more.
 - **Hands-On Innovation:** Participate in interactive workshops and challenges using the latest tools and services from Eclipse Tractus-X.
 - **Expanded Opportunities:** With more space and sessions, this year promises unparalleled opportunities to learn, network, and contribute.
-- **Inspiring Insights:** Hear from industry leaders and pioneers in open-source collaboration and data ecosystems.
+- **Inspiring Insights:** Hear from industry leaders and pioneers in open-source collaboration and data ecosystems like Boris Otto, Director at Fraunhofer ISST. 
 
 ### Recap Third Eclipse Tractus-X Community Days
 

--- a/blog/2025-05-22-fourth-community-days.mdx
+++ b/blog/2025-05-22-fourth-community-days.mdx
@@ -20,16 +20,16 @@ Dear Eclipse Tractus-X- and Dataspace-Community,
 
 Following the overwhelming positivity of the third Eclipse Tractus-X Community Days, we are pleased to announce the fourth edition, scheduled for May 22-23, 2025,
 at ARENA2036 in Stuttgart, Germany. Because of the high demand we have expanded our capacity, this year's event will welcome even more participants and feature an
-expanded range of workshops, challenges, and opportunities to collaborate on shaping the future of open-source development in manufacturing and beyond.
+expanded range of workshops, challenges and opportunities to collaborate on shaping the future of open-source development in manufacturing and beyond.
 
 <!--truncate-->
 
 ### Why Attend?
 
-- **Global Collaboration:** Connect with participants from across the world, including contributors to Manufacturing-X initiatives like Factory-X, Chem-X, Aerospace-X, and more.
+- **Global Collaboration:** Connect with participants from across the world, including contributors to Manufacturing-X initiatives like Factory-X, Chem-X, Aerospace-X and more.
 - **Hands-On Innovation:** Participate in interactive workshops and challenges using the latest tools and services from Eclipse Tractus-X.
 - **Expanded Opportunities:** With more space and sessions, this year promises unparalleled opportunities to learn, network, and contribute.
-- **Inspiring Insights:** Hear from industry leaders and pioneers in open-source collaboration and data ecosystems like Boris Otto, Director at Fraunhofer ISST. 
+- **Inspiring Insights:** Hear from industry leaders and pioneers in open-source collaboration and data ecosystems like Boris Otto, Director at Fraunhofer ISST.
 
 ### Recap Third Eclipse Tractus-X Community Days
 
@@ -46,7 +46,7 @@ Will follow soon
 
 ### Be Part of the Future
 
-Whether you're a developer, project manager, or solution provider, the Eclipse Tractus-X Community Days offer an unparalleled forum for collaboration, creativity, and contribution
+Whether you're a developer, project manager or solution provider, the Eclipse Tractus-X Community Days offer an unparalleled forum for collaboration, creativity and contribution
 to the future of data spaces.
 
 :::info

--- a/utils/newsTitles.js
+++ b/utils/newsTitles.js
@@ -1,5 +1,10 @@
 export const newsTitles = [
     {
+        date: "22.05.2025",
+        title: "Fourth Eclipse Tractus-X Community Days",
+        blogLink: "/blog/community-days-05-2025"
+    },
+    {
         date: "16.12.2024",
         title: "Third Eclipse Tractus-X Community Days Recap",
         blogLink: "/blog/community-days-recap-12-2024"


### PR DESCRIPTION
## Description

This PR adds a news BLOG for our fourth Eclipse Tractus-X Community Days and looks like

![image](https://github.com/user-attachments/assets/c902d487-1d13-453b-87e4-11683ad0afe0)
![image](https://github.com/user-attachments/assets/970ae206-8998-4081-8847-58f314061587)
![image](https://github.com/user-attachments/assets/31b9662e-636e-4bfe-8141-245fb3a45e82)

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
