### PR TITLE
chore: added tractusx-sdk to open meetings

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -22,17 +22,18 @@ All the times are shown in:
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODA1N2ExNTktNDFmZi00ODQ5LWE2OTctZTAzNDJkMDA5ZTlh%40thread.v2/0?context=%7b%22Tid%22%3a%2220185250-6c9a-44a7-a177-8af209dbbd71%22%2c%22Oid%22%3a%22d0878ee8-8a41-4c3d-8ae0-c04499bedadc%22%7d"
 />
 
-<MeetingInfo title="[IC-Hub] Industry Core Hub Weekly"
+<MeetingInfo title="Industry Core Hub & Tractus-X SDK Weekly"
              schedule="Every Tuesday from CET 09:00 am to 10:00 am"
-             description="Open Meeting to align the development status of the Industry Core Hub, the data provision & consumption orchestrator. Additional Topic Groups (Backend, Frontend & Architecture) Weekly meetings are available in the additional links. "
+             description="Open Meeting to align the development status of the Industry Core Hub [IC-Hub], the data provision & consumption orchestrator & the Tractus-X SDK (a generic dataspace tool box with libraries). Additional Topic Groups (Backend, Frontend & Architecture) Weekly meetings are available in the additional links. "
              contact="mathias.moser@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MGJlYzgzMjktNWE4OS00NjcwLWIyOGYtZDgzYmMzODRiMTgy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d"
              additionalLinks={
                 [
                     {title: 'Industry Core Hub Matrix Chat', url: 'https://matrix.to/#/#tractusx-industry-core-hub:matrix.eclipse.org'},
-                    {title: '`industry-core-hub` Repository', url: 'https://github.com/eclipse-tractusx/industry-core-hub'},
+                    {title: 'industry-core-hub Repository', url: 'https://github.com/eclipse-tractusx/industry-core-hub'},
+                    {title: 'tractusx-sdk Repository', url: 'https://github.com/eclipse-tractusx/tractusx-sdk'},
                     {title: 'Planning Board Project', url: 'https://github.com/orgs/eclipse-tractusx/projects/83'},
-                    {title: 'Backend Weekly - Tuesday CET 10:00 am to 11:00 am', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODU0ZDk3MjUtNjkzMS00MzQzLWFmZGYtY2Q3YWEzZmVjNmMx%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
+                    {title: 'Backend & TX-SDK Weekly - Tuesday CET 10:00 am to 11:00 am', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODU0ZDk3MjUtNjkzMS00MzQzLWFmZGYtY2Q3YWEzZmVjNmMx%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
                     {title: 'Frontend Weekly - Tuesday CET 02:00 pm to 03:00 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODUyNWQxMzAtMWE0ZC00Mjc2LTgzYzAtNTc0ZGFiZDllNmQy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
                     {title: 'Architecture Weekly - Thursday CET 01:00 pm to 02:00 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_YzYyMDUyZjMtMmFlMy00ODMyLWFlZDQtNjMwYWZhOTc3YTVh%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'}
                 ]


### PR DESCRIPTION
## Description

As defined in this design decision: https://github.com/eclipse-tractusx/industry-core-hub/blob/main/docs/architecture/decision-records/0002-tractus-x-sdk.md

The industry core hub will in parallel develop in another repository a reusable tool box for the EDC, DTR and the Submodel Server.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
