### PR TITLE
Replaced link to catenax-ng

### DIFF
--- a/docs/release/trg-5/trg-5-02.md
+++ b/docs/release/trg-5/trg-5-02.md
@@ -101,7 +101,7 @@ documentation](https://helm.sh/docs/topics/charts/#the-chartyaml-file).
 
 #### The `LICENSE` File
 
-The file **must** contain the [Apache 2.0 License](https://github.com/catenax-ng/foss-example/blob/main/general/LICENSE).
+The file **must** contain the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.txt).
 
 #### The `README.md` File
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Replaced link to the apache license with one that does not point to a catenax-ng Repo, but to apache instead.
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
