### PR TITLE
add description of planning process

### DIFF
--- a/docs/oss/planning-process.md
+++ b/docs/oss/planning-process.md
@@ -1,0 +1,36 @@
+---
+title: Release Planning Process
+sidebar_position: 21
+---
+
+The development of open source components in Eclipse Tractus-X is a collaborative effort in the open source community. Therefore all items that go into a release need to be carefully planned and reviewed. During the release planning all features must be:
+
+- [created](#issue-creation),
+- [refined](#refine-issue),
+- [approved](#issue-approval-open-planning)
+
+in order to enter a release.
+
+## Issue creation
+
+- **Responsible**: Any contributor
+- **Description**: Anybody can contribute to a use case by creating a feature proposal in Tractus X. The person creating the feature proposal is the 'Requester' and is going to be responsbile for the feature proposal through the process. The feature author has to continuously refine the feature until it contains the requested content, so that it can be validated. All features must be created in sig-release by filling out a [template](https://github.com/eclipse-tractusx/sig-release/issues/new/choose).
+- **Outcome**: List of intended issues for the next release
+
+## Refine issue
+
+- **Responsible**: Requester
+- **Description**: After creating the issue the requester has to continuously refine the feature until it contains the requested content, so that it can be validated by the community. Once the issue is sufficiently it must be submitted for validation in the Open Planning.
+- **Outcome**: List of issues, that fulfill the quality requirements and can be presented to the community
+
+## Issue approval (Open Planning)
+
+- **Responsible**: Requester and Committers
+- **Description**: During the Open Planning all items for upcoming release are validated and planned. All issue that were handed in on time are going to be presented to the audience by the requester or a delegate. The Open Planning is the last chance to provide feedback about the scope of the issue. After the presentation of the issue, the committers are going to prioritize the issue. An issue becomes part of the upcoming release only by receiving the commitment by the committees and not by being presented in the Open Planning!
+- **Outcome**:
+  - Prioritized backlog: Decision by committer group Committed, prioritized backlog for the next release.
+  - Resource commitment: Teams and individuals commit to the work they will deliver, fostering accountability and setting clear expectations for the upcoming release.
+  - Updated roadmap: The project's roadmap is updated to reflect the decisions made during the release planning, providing transparency to stakeholders and the community.
+  - Decisions are documented: All decisions and commitments made during the planning are documented in the decision board or directly in the comment section of a feature.
+  - Communication plan: After the planning a communication via mailing-list will be done by the project lead including the relevant links and decisions.
+  


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
- Previously the planning process for T-X was described in the working modell for C-X
- The content is now moved to where it belongs
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
