### PR TITLE
docs(oss tooling): add new tooling section in oss

### DIFF
--- a/docs/oss/tooling.md
+++ b/docs/oss/tooling.md
@@ -1,0 +1,38 @@
+---
+title: Recommended Tooling for Open Source Development
+sidebar_position: 41
+---
+
+Effective open source development depends on selecting tools that align with the community's principles and project requirements. Below are key considerations when choosing such tools.
+This page should provide a list of recommended tools for open source development.
+
+:::note Requirements for Tools in Open Source Development
+
+1. **Open Source Licensing** - Tools should have licenses that permit free use, modification, and distribution, ensuring they align with open source principles.
+2. **Cross-Platform Compatibility** - Tools should function across various operating systems, including Windows, macOS, and Linux, to accommodate diverse development environments.
+3. **Community Support** - Active communities provide valuable resources, plugins, and extensions, enhancing tool functionality and fostering continuous improvement.
+4. **Integration Capabilities** - Seamless integration with other development tools, such as version control systems and continuous integration servers, is essential for streamlined workflows.
+5. **Security Features** - Tools should prioritize security, including regular updates and patches, to protect against vulnerabilities.
+6. **Documentation and Usability** - Comprehensive documentation and an intuitive user interface facilitate ease of use and quick onboarding for new contributors.
+
+:::
+
+## Bruno – A Git-Friendly Open Source API Client
+
+Bruno is an open source API client designed to simplify API development and testing. It offers a minimalist approach compared to traditional API clients, storing API requests and tests in plain text files,
+which enables seamless version control and collaboration.
+
+**Advantages and Benefits:**
+
+- **Local-First and Offline Operation**: Bruno operates entirely offline, storing all data locally. This enhances security and performance, addressing concerns associated with cloud-based API clients.
+- **Git Integration**: By storing collections as plain text files, Bruno allows for easy integration with Git. This design facilitates version control and collaboration, enabling developers to manage API requests alongside their codebase.
+- **Minimalistic and User-Friendly Interface**: Bruno offers a clean and intuitive interface, reducing complexity and focusing on essential features required for API development.
+- **Open Source and Community-Driven**: As an open source tool, Bruno encourages community contributions, fostering continuous improvement and transparency.
+
+For more information and to download Bruno, visit their [official website](https://www.usebruno.com/) or the [manifesto](https://www.usebruno.com/manifesto)
+
+## NOTICE
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+- Copyright (c) 2025 Contributors to the Eclipse Foundation


### PR DESCRIPTION
## Description

This PR adds a new page on our Eclipse Tractus-X webpage. It lists a list (right now only one) of recommended tools for our open-source development.

![image](https://github.com/user-attachments/assets/fcea4c84-5a2e-478b-8209-38c107c338cd)


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

closes https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/issues/1183

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
