### PR TITLE
fix(broken links): after renaming dcm KIT

### DIFF
--- a/docs-kits/kits/Connector Kit/Adoption View/adoption-view.md
+++ b/docs-kits/kits/Connector Kit/Adoption View/adoption-view.md
@@ -219,7 +219,7 @@ This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses
 
 [BPDM-url]: https://eclipse-tractusx.github.io/docs-kits/next/kits/Business%20Partner%20Kit/Adoption%20View
 
-[DCM-url]: https://eclipse-tractusx.github.io/docs-kits/next/kits/Demand%20and%20Capacity%20Management%20Kit/adoption-view/overview
+[DCM-url]: https://eclipse-tractusx.github.io/docs-kits/next/kits/demand-and-capacity-management-kit/adoption-view/overview
 
 [PURIS-url]: https://github.com/eclipse-tractusx/puris
 

--- a/docs-kits_versioned_docs/version-24.08/kits/Connector Kit/Adoption View/adoption-view.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/Connector Kit/Adoption View/adoption-view.md
@@ -219,7 +219,7 @@ This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses
 
 [BPDM-url]: https://eclipse-tractusx.github.io/docs-kits/next/kits/Business%20Partner%20Kit/Adoption%20View
 
-[DCM-url]: https://eclipse-tractusx.github.io/docs-kits/next/kits/Demand%20and%20Capacity%20Management%20Kit/adoption-view/overview
+[DCM-url]: https://eclipse-tractusx.github.io/docs-kits/next/kits/demand-and-capacity-management-kit/adoption-view/overview
 
 [PURIS-url]: https://github.com/eclipse-tractusx/puris
 

--- a/docs-kits_versioned_docs/version-24.12/kits/Connector Kit/Adoption View/adoption-view.md
+++ b/docs-kits_versioned_docs/version-24.12/kits/Connector Kit/Adoption View/adoption-view.md
@@ -219,7 +219,7 @@ This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses
 
 [BPDM-url]: https://eclipse-tractusx.github.io/docs-kits/next/kits/Business%20Partner%20Kit/Adoption%20View
 
-[DCM-url]: https://eclipse-tractusx.github.io/docs-kits/next/kits/Demand%20and%20Capacity%20Management%20Kit/adoption-view/overview
+[DCM-url]: https://eclipse-tractusx.github.io/docs-kits/next/kits/demand-and-capacity-management-kit/adoption-view/overview
 
 [PURIS-url]: https://github.com/eclipse-tractusx/puris
 

--- a/utils/kitsGallery.js
+++ b/utils/kitsGallery.js
@@ -1,19 +1,19 @@
-/********************************************************************************* 
+/*********************************************************************************
  * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
- * 
+ *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Apache License, Version 2.0 which is available at
  * https://www.apache.org/licenses/LICENSE-2.0.
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
  * under the License.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
@@ -140,7 +140,7 @@ export const kitsGallery = [
     name: 'DCM Kit',
     domain: 'Supply Chain',
     img: DemandandCapacityManagement_Kit,
-    pageRoute: "/docs-kits/kits/Demand%20and%20Capacity%20Management%20Kit/adoption-view/overview"
+    pageRoute: "/docs-kits/kits/demand-and-capacity-management-kit/adoption-view/overview"
   },
   {
     id: 13,


### PR DESCRIPTION
## Description

This PR fixes some broken links to DCM Kit. After the KIT was renamed, the links didn't work any more.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
