### PR TITLE
Update Logistics KIT adoption-view.md - Typo for broken link

### DIFF
--- a/docs-kits/kits/logistics-kit/adoption-view.md
+++ b/docs-kits/kits/logistics-kit/adoption-view.md
@@ -61,7 +61,7 @@ In the following section, all aspect models that are part of Logistic KIT are do
 
 ### Packing List
 
-The aspect provides the information of the [packed goods inside of a Transport Unit]((https://github.com/eclipse-tractusx/sldt-semantic-models/blob/main/io.catenax.packing_list/1.0.0/PackingList.ttl)).
+The aspect provides the information of the [packed goods inside of a Transport Unit](https://github.com/eclipse-tractusx/sldt-semantic-models/blob/main/io.catenax.packing_list/1.0.0/PackingList.ttl).
 
 ### IotSensorData
 


### PR DESCRIPTION
## Description
A minor typo leads to a broken link in the new Logistics KIT Adoption View at https://eclipse-tractusx.github.io/docs-kits/kits/logistics-kit/adoption-view in Section "Packing List".

Link target was intended for https://github.com/eclipse-tractusx/sldt-semantic-models/blob/main/io.catenax.packing_list/1.0.0/PackingList.ttl

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
