### PR TITLE
add step to activate security check

### DIFF
--- a/docs/release/trg-7/trg-7-09.md
+++ b/docs/release/trg-7/trg-7-09.md
@@ -4,6 +4,7 @@ title: TRG 7.09 - Deprecation of Unmaintained Repositories
 
 | Status  | Created     | Post-History                          |
 |---------|-------------|---------------------------------------|
+| Active  | 20-Mar-2025 | Updates security checks               |
 | Active  | 12-Nov-2024 | Initial draft                         |
 
 ## Why
@@ -110,7 +111,8 @@ flowchart TD
     D --> |NO| E[4: Project Lead closes the issue in Github]
     D --> |YES| F[4: Project Lead opens issue in .eclipsefdn]
     F --> G[5:Once reactivated, the Project Lead announces it in the mailing list]
-    G --> H[6: The Issue in sig-infra is closed]
+    G --> H[6: Project lead activates the security checks, runs them, and mitigates potential risks]
+    H --> I[7: The Issue in sig-infra is closed]
 ```
 
 1. The requestor **MUST** create an issue in the [sig-infra](https://github.com/eclipse-tractusx/sig-infra) repository following the template [below](#issue-template-for-reactivation).
@@ -118,7 +120,8 @@ flowchart TD
 3. The requestor **MUST** inform the community within the Office Hour about the petition.
 4. A project lead will open a issue at the [.eclipsefdn](https://github.com/eclipse-tractusx/.eclipsefdn) requesting the reactivation of the repository.
 5. Once the repository is reactivated, the project lead sends a mail to the [tractusx-dev](https://accounts.eclipse.org/mailing-list/tractusx-dev) mailing list announcing the reactivation.
-6. The project lead closes the issue in [sig-infra](https://github.com/eclipse-tractusx/sig-infra).
+6. The project lead activates the security checks, runs them, and mitigates potential risks. 
+7. The project lead closes the issue in [sig-infra](https://github.com/eclipse-tractusx/sig-infra).
 
 ### Issue Template for Reactivation
 

--- a/docs/release/trg-7/trg-7-09.md
+++ b/docs/release/trg-7/trg-7-09.md
@@ -120,7 +120,7 @@ flowchart TD
 3. The requestor **MUST** inform the community within the Office Hour about the petition.
 4. A project lead will open a issue at the [.eclipsefdn](https://github.com/eclipse-tractusx/.eclipsefdn) requesting the reactivation of the repository.
 5. Once the repository is reactivated, the project lead sends a mail to the [tractusx-dev](https://accounts.eclipse.org/mailing-list/tractusx-dev) mailing list announcing the reactivation.
-6. The project lead activates the security checks, runs them, and mitigates potential risks. 
+6. The project lead activates the security checks, runs them, and mitigates potential risks.
 7. The project lead closes the issue in [sig-infra](https://github.com/eclipse-tractusx/sig-infra).
 
 ### Issue Template for Reactivation


### PR DESCRIPTION
## Description
Add step for security checks for reactivation of repositories.
This is needed because security checks are deactivated after 60 days of no changes.

Closes https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/issues/1184

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
