### PR TITLE
docs(news-blog): add agenda for fourth Eclipse Tractus-x Community Days

### DIFF
--- a/blog/2025-05-22-fourth-community-days.mdx
+++ b/blog/2025-05-22-fourth-community-days.mdx
@@ -41,8 +41,7 @@ expanded range of workshops, challenges and opportunities to collaborate on shap
 #### Agenda
 
 :::info
-The agenda for both days is available [here](https://arena2036.de/files/FinaleBilder/05_Veranstaltungen/ARENA-X/Fourth_Eclipse_Tractus-X_Community_Days/CDs_AGENDA.pdf) and more information about the different
-challenges are available in the [wiki](https://cxwiki.bonnconsulting.io/en/tractus-x-community-days/overview) -> no login needed!
+The agenda for both days is available [here](https://arena2036.de/files/FinaleBilder/05_Veranstaltungen/ARENA-X/Fourth_Eclipse_Tractus-X_Community_Days/CDs_AGENDA.pdf).
 :::
 
 ### Be Part of the Future

--- a/blog/2025-05-22-fourth-community-days.mdx
+++ b/blog/2025-05-22-fourth-community-days.mdx
@@ -41,7 +41,8 @@ expanded range of workshops, challenges and opportunities to collaborate on shap
 #### Agenda
 
 :::info
-Will follow soon
+The agenda for both days is available [here](https://arena2036.de/files/FinaleBilder/05_Veranstaltungen/ARENA-X/Fourth_Eclipse_Tractus-X_Community_Days/CDs_AGENDA.pdf) and more information about the different
+challenges are available in the [wiki](https://cxwiki.bonnconsulting.io/en/tractus-x-community-days/overview) -> no login needed!
 :::
 
 ### Be Part of the Future


### PR DESCRIPTION


## Description
Add agenda for the news page "Join us in May 2025 for the Fourth Eclipse Tractus-X Community Days!"

<img width="1428" alt="Bildschirmfoto 2025-03-21 um 21 01 10" src="https://github.com/user-attachments/assets/4f4a01f4-1247-4df8-96d5-4dce5e87fc67" />


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
