### PR TITLE
Chore(knowledge-agents): Fix wrong ID of Changelog

### DIFF
--- a/docs-kits/kits/knowledge-agents/changelog.md
+++ b/docs-kits/kits/knowledge-agents/changelog.md
@@ -1,5 +1,5 @@
 ---
-id: Knowledge Agent Changelog
+id: changelog
 title: Changelog
 description: 'Knowledge Agent'
 sidebar_position: 1

--- a/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/changelog.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/knowledge-agents/changelog.md
@@ -1,5 +1,5 @@
 ---
-id: Knowledge Agent Changelog
+id: changelog
 title: Changelog
 description: 'Knowledge Agent'
 sidebar_position: 1

--- a/docs-kits_versioned_docs/version-24.12/kits/knowledge-agents/changelog.md
+++ b/docs-kits_versioned_docs/version-24.12/kits/knowledge-agents/changelog.md
@@ -1,5 +1,5 @@
 ---
-id: Knowledge Agent Changelog
+id: changelog
 title: Changelog
 description: 'Knowledge Agent'
 sidebar_position: 1

--- a/docs-kits_versioned_docs/version-25.03/kits/knowledge-agents/changelog.md
+++ b/docs-kits_versioned_docs/version-25.03/kits/knowledge-agents/changelog.md
@@ -1,5 +1,5 @@
 ---
-id: Knowledge Agent Changelog
+id: changelog
 title: Changelog
 description: 'Knowledge Agent'
 sidebar_position: 1

--- a/docs-kits_versioned_sidebars/version-24.08-sidebars.json
+++ b/docs-kits_versioned_sidebars/version-24.08-sidebars.json
@@ -426,7 +426,7 @@
       "link": { "type": "generated-index" },
       "collapsed": true,
       "items": [
-        "kits/knowledge-agents/Knowledge Agent Changelog",
+        "kits/knowledge-agents/changelog",
         "kits/knowledge-agents/adoption-view/intro",
         {
           "type": "category",

--- a/docs-kits_versioned_sidebars/version-24.12-sidebars.json
+++ b/docs-kits_versioned_sidebars/version-24.12-sidebars.json
@@ -440,7 +440,7 @@
       "link": { "type": "generated-index" },
       "collapsed": true,
       "items": [
-        "kits/knowledge-agents/Knowledge Agent Changelog",
+        "kits/knowledge-agents/changelog",
         "kits/knowledge-agents/adoption-view/intro",
         {
           "type": "category",

--- a/docs-kits_versioned_sidebars/version-25.03-sidebars.json
+++ b/docs-kits_versioned_sidebars/version-25.03-sidebars.json
@@ -452,7 +452,7 @@
       "link": { "type": "generated-index" },
       "collapsed": true,
       "items": [
-        "kits/knowledge-agents/Knowledge Agent Changelog",
+        "kits/knowledge-agents/changelog",
         "kits/knowledge-agents/adoption-view/intro",
         {
           "type": "category",

--- a/sidebarsDocsKits.js
+++ b/sidebarsDocsKits.js
@@ -488,7 +488,7 @@ const sidebars = {
         link: { type: 'generated-index' },
         collapsed: true,
         items: [
-          'kits/knowledge-agents/Knowledge Agent Changelog',
+          'kits/knowledge-agents/changelog',
           'kits/knowledge-agents/adoption-view/intro',
           {
             type: 'category',


### PR DESCRIPTION
The ID of the changelog from the knowledge agents kit has been overlooked during the upgrade. This PR fixes the ID.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
