### PR TITLE
Chores: Fixed last missed IDs in KITs

### DIFF
--- a/docs-kits/kits/eco-pass-kit/success-stories/battery-pass-viewer-app.mdx
+++ b/docs-kits/kits/eco-pass-kit/success-stories/battery-pass-viewer-app.mdx
@@ -1,5 +1,5 @@
 ---
-id: Battery Pass Application Success Story
+id: battery-pass-application-success-story
 title: Battery Pass Application Success Story
 description: 'EcoPass KIT Success Stories'
 sidebar_position: 1

--- a/docs-kits/kits/environmental-and-social-standards-kit/changelog.md
+++ b/docs-kits/kits/environmental-and-social-standards-kit/changelog.md
@@ -1,5 +1,5 @@
 ---
-id: ESS Kit Changelog
+id: changelog
 title: Changelog
 sidebar_position: 1
 ---

--- a/docs-kits/kits/environmental-and-social-standards-kit/documentation.md
+++ b/docs-kits/kits/environmental-and-social-standards-kit/documentation.md
@@ -1,5 +1,5 @@
 ---
-id: ESS Kit Documentation
+id: documentation
 title: Documentation
 description: 'What do I have to implement?'
 sidebar_position: 3

--- a/docs-kits/kits/modular-production-kit/adoption-view.md
+++ b/docs-kits/kits/modular-production-kit/adoption-view.md
@@ -5,7 +5,7 @@ description: 'Modular Production Kit'
 sidebar_position: 2
 ---
 
-![mp kit banner]@site/static/img/kits/modular-production/modular-production-kit-gallery.svg
+![mp kit banner](@site/static/img/kits/modular-production/modular-production-kit-gallery.svg)
 
 ### Modular Production Kit
 

--- a/docs-kits/kits/modular-production-kit/changelog.md
+++ b/docs-kits/kits/modular-production-kit/changelog.md
@@ -5,7 +5,7 @@ description: 'Modular Production Kit'
 sidebar_position: 1
 ---
 
-![mp kit banner]@site/static/img/kits/modular-production/modular-production-kit-gallery.svg
+![mp kit banner](@site/static/img/kits/modular-production/modular-production-kit-gallery.svg)
 
 ### Modular Production Kit
 

--- a/docs-kits/kits/modular-production-kit/software-development-view/software-development-view.md
+++ b/docs-kits/kits/modular-production-kit/software-development-view/software-development-view.md
@@ -5,7 +5,7 @@ description: 'Modular Production Kit'
 sidebar_position: 4
 ---
 
-![mp kit banner]@site/static/img/kits/modular-production/modular-production-kit-gallery.svg
+![mp kit banner](@site/static/img/kits/modular-production/modular-production-kit-gallery.svg)
 
 The following examples show the payload used for exchange. All examples are based on a simple product,
 a box with a lid, that are screwed together with 3 screws.

--- a/docs-kits/kits/supply-chain-disruption-notification-kit/changelog.md
+++ b/docs-kits/kits/supply-chain-disruption-notification-kit/changelog.md
@@ -1,5 +1,5 @@
 ---
-id: Supply Chain Disruption Notifications Changelog
+id: changelog
 title: Changelog
 description: 'Supply Chain Disruption Notifications'
 sidebar_position: 1

--- a/docs-kits_versioned_docs/version-24.08/kits/eco-pass-kit/success-stories/battery-pass-viewer-app.mdx
+++ b/docs-kits_versioned_docs/version-24.08/kits/eco-pass-kit/success-stories/battery-pass-viewer-app.mdx
@@ -1,5 +1,5 @@
 ---
-id: Battery Pass Application Success Story
+id: battery-pass-application-success-story
 title: Battery Pass Application Success Story
 description: 'EcoPass KIT Success Stories'
 sidebar_position: 1

--- a/docs-kits_versioned_docs/version-24.08/kits/environmental-and-social-standards-kit/changelog.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/environmental-and-social-standards-kit/changelog.md
@@ -1,5 +1,5 @@
 ---
-id: ESS Kit Changelog
+id: changelog
 title: Changelog
 sidebar_position: 1
 ---

--- a/docs-kits_versioned_docs/version-24.08/kits/environmental-and-social-standards-kit/documentation.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/environmental-and-social-standards-kit/documentation.md
@@ -1,5 +1,5 @@
 ---
-id: ESS Kit Documentation
+id: documentation
 title: Documentation
 description: 'What do I have to implement?'
 sidebar_position: 3

--- a/docs-kits_versioned_docs/version-24.08/kits/modular-production-kit/adoption-view.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/modular-production-kit/adoption-view.md
@@ -5,7 +5,7 @@ description: 'Modular Production Kit'
 sidebar_position: 2
 ---
 
-![mp kit banner]@site/static/img/kits/modular-production/modular-production-kit-gallery.svg
+![mp kit banner](@site/static/img/kits/modular-production/modular-production-kit-gallery.svg)
 
 ### Modular Production Kit
 

--- a/docs-kits_versioned_docs/version-24.08/kits/modular-production-kit/changelog.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/modular-production-kit/changelog.md
@@ -5,7 +5,7 @@ description: 'Modular Production Kit'
 sidebar_position: 1
 ---
 
-![mp kit banner]@site/static/img/kits/modular-production/modular-production-kit-gallery.svg
+![mp kit banner](@site/static/img/kits/modular-production/modular-production-kit-gallery.svg)
 
 ### Modular Production Kit
 

--- a/docs-kits_versioned_docs/version-24.08/kits/modular-production-kit/software-development-view/software-development-view.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/modular-production-kit/software-development-view/software-development-view.md
@@ -5,7 +5,7 @@ description: 'Modular Production Kit'
 sidebar_position: 4
 ---
 
-![mp kit banner]@site/static/img/kits/modular-production/modular-production-kit-gallery.svg
+![mp kit banner](@site/static/img/kits/modular-production/modular-production-kit-gallery.svg)
 
 The following examples show the payload used for exchange. All examples are based on a simple product,
 a box with a lid, that are screwed together with 3 screws.

--- a/docs-kits_versioned_docs/version-24.08/kits/supply-chain-disruption-notification-kit/changelog.md
+++ b/docs-kits_versioned_docs/version-24.08/kits/supply-chain-disruption-notification-kit/changelog.md
@@ -1,5 +1,5 @@
 ---
-id: Supply Chain Disruption Notifications Changelog
+id: changelog
 title: Changelog
 description: 'Supply Chain Disruption Notifications'
 sidebar_position: 1

--- a/docs-kits_versioned_docs/version-24.12/kits/eco-pass-kit/success-stories/battery-pass-viewer-app.mdx
+++ b/docs-kits_versioned_docs/version-24.12/kits/eco-pass-kit/success-stories/battery-pass-viewer-app.mdx
@@ -1,5 +1,5 @@
 ---
-id: Battery Pass Application Success Story
+id: battery-pass-application-success-story
 title: Battery Pass Application Success Story
 description: 'EcoPass KIT Success Stories'
 sidebar_position: 1

--- a/docs-kits_versioned_docs/version-24.12/kits/environmental-and-social-standards-kit/changelog.md
+++ b/docs-kits_versioned_docs/version-24.12/kits/environmental-and-social-standards-kit/changelog.md
@@ -1,5 +1,5 @@
 ---
-id: ESS Kit Changelog
+id: changelog
 title: Changelog
 sidebar_position: 1
 ---

--- a/docs-kits_versioned_docs/version-24.12/kits/environmental-and-social-standards-kit/documentation.md
+++ b/docs-kits_versioned_docs/version-24.12/kits/environmental-and-social-standards-kit/documentation.md
@@ -1,5 +1,5 @@
 ---
-id: ESS Kit Documentation
+id: documentation
 title: Documentation
 description: 'What do I have to implement?'
 sidebar_position: 3

--- a/docs-kits_versioned_docs/version-24.12/kits/modular-production-kit/adoption-view.md
+++ b/docs-kits_versioned_docs/version-24.12/kits/modular-production-kit/adoption-view.md
@@ -5,7 +5,7 @@ description: 'Modular Production Kit'
 sidebar_position: 2
 ---
 
-![mp kit banner]@site/static/img/kits/modular-production/modular-production-kit-gallery.svg
+![mp kit banner](@site/static/img/kits/modular-production/modular-production-kit-gallery.svg)
 
 ### Modular Production Kit
 

--- a/docs-kits_versioned_docs/version-24.12/kits/modular-production-kit/changelog.md
+++ b/docs-kits_versioned_docs/version-24.12/kits/modular-production-kit/changelog.md
@@ -5,7 +5,7 @@ description: 'Modular Production Kit'
 sidebar_position: 1
 ---
 
-![mp kit banner]@site/static/img/kits/modular-production/modular-production-kit-gallery.svg
+![mp kit banner](@site/static/img/kits/modular-production/modular-production-kit-gallery.svg)
 
 ### Modular Production Kit
 

--- a/docs-kits_versioned_docs/version-24.12/kits/modular-production-kit/software-development-view/software-development-view.md
+++ b/docs-kits_versioned_docs/version-24.12/kits/modular-production-kit/software-development-view/software-development-view.md
@@ -5,7 +5,7 @@ description: 'Modular Production Kit'
 sidebar_position: 4
 ---
 
-![mp kit banner]@site/static/img/kits/modular-production/modular-production-kit-gallery.svg
+![mp kit banner](@site/static/img/kits/modular-production/modular-production-kit-gallery.svg)
 
 The following examples show the payload used for exchange. All examples are based on a simple product,
 a box with a lid, that are screwed together with 3 screws.

--- a/docs-kits_versioned_docs/version-24.12/kits/supply-chain-disruption-notification-kit/changelog.md
+++ b/docs-kits_versioned_docs/version-24.12/kits/supply-chain-disruption-notification-kit/changelog.md
@@ -1,5 +1,5 @@
 ---
-id: Supply Chain Disruption Notifications Changelog
+id: changelog
 title: Changelog
 description: 'Supply Chain Disruption Notifications'
 sidebar_position: 1

--- a/docs-kits_versioned_docs/version-25.03/kits/eco-pass-kit/success-stories/battery-pass-viewer-app.mdx
+++ b/docs-kits_versioned_docs/version-25.03/kits/eco-pass-kit/success-stories/battery-pass-viewer-app.mdx
@@ -1,5 +1,5 @@
 ---
-id: Battery Pass Application Success Story
+id: battery-pass-application-success-story
 title: Battery Pass Application Success Story
 description: 'EcoPass KIT Success Stories'
 sidebar_position: 1

--- a/docs-kits_versioned_docs/version-25.03/kits/environmental-and-social-standards-kit/changelog.md
+++ b/docs-kits_versioned_docs/version-25.03/kits/environmental-and-social-standards-kit/changelog.md
@@ -1,5 +1,5 @@
 ---
-id: ESS Kit Changelog
+id: changelog
 title: Changelog
 sidebar_position: 1
 ---

--- a/docs-kits_versioned_docs/version-25.03/kits/environmental-and-social-standards-kit/documentation.md
+++ b/docs-kits_versioned_docs/version-25.03/kits/environmental-and-social-standards-kit/documentation.md
@@ -1,5 +1,5 @@
 ---
-id: ESS Kit Documentation
+id: documentation
 title: Documentation
 description: 'What do I have to implement?'
 sidebar_position: 3

--- a/docs-kits_versioned_docs/version-25.03/kits/modular-production-kit/adoption-view.md
+++ b/docs-kits_versioned_docs/version-25.03/kits/modular-production-kit/adoption-view.md
@@ -5,7 +5,7 @@ description: 'Modular Production Kit'
 sidebar_position: 2
 ---
 
-![mp kit banner]@site/static/img/kits/modular-production/modular-production-kit-gallery.svg
+![mp kit banner](@site/static/img/kits/modular-production/modular-production-kit-gallery.svg)
 
 ### Modular Production Kit
 

--- a/docs-kits_versioned_docs/version-25.03/kits/modular-production-kit/changelog.md
+++ b/docs-kits_versioned_docs/version-25.03/kits/modular-production-kit/changelog.md
@@ -5,7 +5,7 @@ description: 'Modular Production Kit'
 sidebar_position: 1
 ---
 
-![mp kit banner]@site/static/img/kits/modular-production/modular-production-kit-gallery.svg
+![mp kit banner](@site/static/img/kits/modular-production/modular-production-kit-gallery.svg)
 
 ### Modular Production Kit
 

--- a/docs-kits_versioned_docs/version-25.03/kits/modular-production-kit/software-development-view/software-development-view.md
+++ b/docs-kits_versioned_docs/version-25.03/kits/modular-production-kit/software-development-view/software-development-view.md
@@ -5,7 +5,7 @@ description: 'Modular Production KIT'
 sidebar_position: 4
 ---
 
-![mp kit banner]@site/static/img/kits/modular-production/modular-production-kit-gallery.svg
+![mp kit banner](@site/static/img/kits/modular-production/modular-production-kit-gallery.svg)
 
 The following examples show the payload used for exchange. All examples are based on a simple product,
 a box with a lid, that are screwed together with 3 screws.

--- a/docs-kits_versioned_docs/version-25.03/kits/supply-chain-disruption-notification-kit/changelog.md
+++ b/docs-kits_versioned_docs/version-25.03/kits/supply-chain-disruption-notification-kit/changelog.md
@@ -1,5 +1,5 @@
 ---
-id: Supply Chain Disruption Notifications Changelog
+id: changelog
 title: Changelog
 description: 'Supply Chain Disruption Notifications'
 sidebar_position: 1


### PR DESCRIPTION
Next to some last wrong IDs within the KITs I found and fixed an issue where the Modular Pruduction KIT Icon has been embedded incorrectly.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
