### PR TITLE
docs: Remove identity hub open meeting

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -15,13 +15,6 @@ All the times are shown in:
 
 ## Regular meetings
 
-<MeetingInfo title="Identity Hub - Open Meeting"
-             schedule="Bi-weekly on Tuesday (in even weeks) from 10:35 am to 11:30 am CET"
-             description="Open meeting to align and coordinate development of the Identity Hub in Tractus-X."
-             contact="marcel.ruland@cofinity-x.com"
-             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODA1N2ExNTktNDFmZi00ODQ5LWE2OTctZTAzNDJkMDA5ZTlh%40thread.v2/0?context=%7b%22Tid%22%3a%2220185250-6c9a-44a7-a177-8af209dbbd71%22%2c%22Oid%22%3a%22d0878ee8-8a41-4c3d-8ae0-c04499bedadc%22%7d"
-/>
-
 <MeetingInfo title="Industry Core Hub & Tractus-X SDK Weekly"
              schedule="Every Tuesday from CET 09:00 am to 10:00 am"
              description="Open Meeting to align the development status of the Industry Core Hub [IC-Hub], the data provision & consumption orchestrator & the Tractus-X SDK (a generic dataspace tool box with libraries). Additional Topic Groups (Backend, Frontend & Architecture) Weekly meetings are available in the additional links. "


### PR DESCRIPTION
## Description

Removes the identity hub open meeting from the open meetings page, since it is no longer needed.
