### PR TITLE
Adapt alignment day

### DIFF
--- a/blog/2025-03-20-release-planning-R25.09.mdx
+++ b/blog/2025-03-20-release-planning-R25.09.mdx
@@ -6,6 +6,7 @@ date: 2025-03-20T17:00
 hide_table_of_contents: false
 authors:
   - theresa_hilger
+  - stephan_bauer
 ---
 
 import RenderImage from './RenderImage'
@@ -74,42 +75,35 @@ You’re encouraged to collaborate across groups as needed, and we’ll provide 
 The sessions for the different groups / components / dependencies can be used to sync within the underlying expert groups. Feel free to switch between groups if necessary!
 :::
 
-## Refinement Day 2 for R25.09
+## Alignment Day for R25.09
 
-The second Refinement Day focuses on resolving **dependencies** identified during Refinement Day 1. Groups will refine their features further, ensuring alignment across components.
+The Alignment Day replaces the previously planned Refinement Day 2. It focuses on addressing **open questions** and unresolved **dependencies** from features planned for Release 25.09. Participation is only required if you have open topics to discuss.
 
-- **Date:** Wednesday, 30th April 2025
-- **Time:** 09:05 - 12:00
+- **Date:** Wednesday, 30th April 2025  
+- **Time:** 09:05 - 12:00  
 - **Main Teams Link:** [Join the session](https://teams.microsoft.com/l/meetup-join/19%3ameeting_YzhlNTU3ZTYtYTA4Ni00NWFhLTgxMDMtMWFmYTRkYmVkZWNj%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d)
 
-### Agenda
+## Agenda
 
-- **09:05 - 09:30**: Welcome and recap of Refinement Day 1 results
-- **09:30 - 11:15**: Group work on resolving dependencies
-- **11:15 - 11:45**: Group presentations on resolved dependencies
-- **11:45 - 12:00**: Closing and Next Steps
+:::info
+The agenda itself is dependent on the labled features.
+:::
 
-### Key Focus Areas
+- 09:05 - 09:30: Welcome and overview of `Open Discussion` features  
+- 09:30 - 11:30: Group discussions and breakout sessions as needed  
+- 11:30 - 12:00: Optional closing and documentation of decisions
 
-- Use the [feature template](https://github.com/eclipse-tractusx/sig-release/issues/new?assignees=&labels=&projects=&template=1_feature_template.md).
-- Add labels for identified dependencies.
-- Collaborate across groups to resolve issues.
-- Use the supported-by field to map the feature with your expert group.
-- Status `Backlog`-> this should be an alignment, between the requesting Expert Group/Committee and the open-source community.
+## Key Focus Areas
+
+- Only features labeled `Open Discussion` will be considered for the agenda.  
+- The label must be added at least 3 days prior to the event.  
+- This is not a planning or refinement session — it’s a space to align on open questions and clarify remaining uncertainties.  
+- Feature owners should be ready to describe their needs or concerns.  
+- Component developers can use this session to clarify what is expected from them.  
 
 ### Group and Teams Sessions
 
-During the refinement sessions, each group will focus on resolving **identified dependencies** from Refinement Day 1, which are visible via the **related labels** on the features.
-While further feature refinement is allowed, the emphasis is on addressing and coordinating **dependencies** between groups and components.
-
-Our working Board for the day is the [Release Planning - R25.09 - Preparation](https://github.com/orgs/eclipse-tractusx/projects/26/views/40)
-
-You’re encouraged to collaborate across groups as needed, and we’ll provide **Teams sessions** (we will use the same sessions from Refinement Day 1) for each group to work in.
-It might be the case for some experts to jump into different other groups to resolve dependencies.
-
-:::tip
-The sessions for the different groups / components / dependencies can be used to sync within the underlying expert groups. Feel free to switch between groups if necessary!
-:::
+Due to the fact, that we are working along an agenda, there will be no group sessions.
 
 ## Open Planning for R25.09
 
@@ -159,4 +153,3 @@ During the session, if there is a common alignment among the participants, the f
 For any questions or further information, feel free to reach out via our [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) or join us in the Tractus-X [Matrix channel](https://matrix.to/#/#automotive.tractusx:matrix.eclipse.org).
 
 We look forward to your participation and collaboration! 🚀
-


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Since the Refinement Day 1 and 2 have been removed and replaced by the Alignment Day, the Tractus-X page had to be adapted


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
