### PR TITLE
docs(open planning): add detailed agenda

### DIFF
--- a/blog/2025-03-20-release-planning-R25.09.mdx
+++ b/blog/2025-03-20-release-planning-R25.09.mdx
@@ -136,23 +136,25 @@ Here’s the plan for the day:
 The planning sessions will be driven by our [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26/views/28), which organizes features based on their **Topic/Product** field.
 :::
 
-| Time              | Committee                                 | Features |
-|-------------------|-------------------------------------------|----------|
-| 09:30 – 09:35     | DPP                                       | 1        |
-| 09:35 – 09:45     | Circularity                               | 2        |
-| 09:45 – 10:45     | Dataspace Connectivity                    | 10       |
-| 10:45 – 11:15     | BPDM                                      | 5        |
-| 11:15 – 11:20     | Digital Twin (DT)                         | 1        |
-| 11:20 – 11:25     | SSI                                       | 1        |
-| 11:25 – 12:00     | Portal                                    | 7        |
-| 12:00 – 13:00     | Lunch Break                               | –        |
-| 13:00 – 13:10     | Traceability                              | 2        |
-| 13:10 – 13:20     | DCM                                       | 2        |
-| 13:20 – 13:30     | PURIS                                     | 2        |
-| 13:30 – 13:40     | Industry Core                             | 2        |
-| 13:40 – 13:50     | Digital Twin                              | 1        |
-| 13:50 – 13:55     | Testmanagement                            | 1        |
-| 13:55 – 14:00     | Engineering                               | 1        |
+| Time              | Topics                                                        | [Features](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22)                                     |
+|-------------------|---------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 09:05 – 09:30     | Open Planning - Vision & Introduction                         |                                                                                                                                                                                          |
+| 09:30 – 09:35     | DPP                                                           | [1](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22&sliceBy%5Bvalue%5D=DPP)                     |
+| 09:35 – 09:45     | Circularity                                                   | [2](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22&sliceBy%5Bvalue%5D=Circularity)             |
+| 09:45 – 10:45     | Dataspace Connectivity                                        | [10](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22&sliceBy%5Bvalue%5D=Dataspace+Connectivity) |
+| 10:45 – 11:15     | BPDM                                                          | [5](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22&sliceBy%5Bvalue%5D=BPDM)                    |
+| 11:15 – 11:20     | Digital Twin (DT)                                             | [1](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22&sliceBy%5Bvalue%5D=DT)                      |
+| 11:20 – 11:25     | SSI                                                           | [1](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22&sliceBy%5Bvalue%5D=SSI)                     |
+| 11:25 – 12:00     | Portal                                                        | [7](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22&sliceBy%5Bvalue%5D=Portal)                  |
+| **12:00 – 13:00** | **Lunch Break**                                               | **ENJOY!!!!**                                                                                                                                                                            |
+| 13:00 – 13:10     | Traceability                                                  | [2](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22&sliceBy%5Bvalue%5D=Traceability)            |
+| 13:10 – 13:20     | DCM                                                           | [2](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22&sliceBy%5Bvalue%5D=DCM)                     |
+| 13:20 – 13:30     | PURIS                                                         | [2](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22&sliceBy%5Bvalue%5D=PURIS)                   |
+| 13:30 – 13:40     | Industry Core                                                 | [2](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22&sliceBy%5Bvalue%5D=IC)                      |
+| 13:40 – 13:50     | Digital Twin                                                  | [1](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22&sliceBy%5Bvalue%5D=DT)                      |
+| 13:50 – 13:55     | Testmanagement                                                | [1](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22&sliceBy%5Bvalue%5D=Testmanagement)          |
+| 13:55 – 14:00     | Engineering                                                   | [1](https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.09%22&sliceBy%5Bvalue%5D=Engineering)             |
+| 14:00 – 14:30     | Feedback Retro / Open Planning Wrap-up / Summary & Next Steps |                                                                                                                                                                                          |
 
 :::warning[**Please note:**]
 - The agenda provides a **rough time structure** to help guide the session. The **timings are not fixed** and can be adjusted depending on the flow of the discussion.


### PR DESCRIPTION
## Description

This pull request updates the agenda for the release planning day R25.09. The changes improve clarity and usability by refining the session descriptions and adding links to feature details for each topic.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
