### PR TITLE
docs(product-list): cleanup product list

### DIFF
--- a/utils/products.js
+++ b/utils/products.js
@@ -65,8 +65,6 @@ export const products = [
     ],
     committers: [
       "https://github.com/agg3fe",
-      "https://github.com/bs-jokri",
-      "https://github.com/LuLeRoemer",
       "https://github.com/tunacicek",
     ],
     mailTo:
@@ -83,10 +81,6 @@ export const products = [
       "https://github.com/eclipse-tractusx/sldt-discovery-finder",
     ],
     committers: [
-      "https://github.com/agg3fe",
-      "https://github.com/bs-jokri",
-      "https://github.com/LuLeRoemer",
-      "https://github.com/tunacicek",
     ],
     mailTo:
       "tractusx-dev@eclipse.org?subject=Request Semantic Layer & Digital Twin Team",
@@ -252,10 +246,6 @@ export const products = [
       "https://github.com/eclipse-tractusx/sldt-ontology-model",
     ],
     committers: [
-      "https://github.com/agg3fe",
-      "https://github.com/bs-jokri",
-      "https://github.com/LuLeRoemer",
-      "https://github.com/tunacicek",
     ],
     mailTo:
       "tractusx-dev@eclipse.org?subject=Request Semantic Layer & Digital Twin Team",

--- a/utils/products.js
+++ b/utils/products.js
@@ -121,7 +121,8 @@ export const products = [
       "https://github.com/eclipse-tractusx/knowledge-agents-aas-bridge",
       "https://github.com/eclipse-tractusx/knowledge-agents-edc",
     ],
-    committers: ["https://github.com/almadigabor"],
+    committers: [
+    ],
     mailTo: "tractusx-dev@eclipse.org?subject=Request knowledge-agents Team",
     hasBoard: false,
     showVersion: true,

--- a/utils/products.js
+++ b/utils/products.js
@@ -187,6 +187,9 @@ export const products = [
       "https://github.com/ntruchsess",
       "https://github.com/oyo",
       "https://github.com/Phil91",
+      "https://github.com/typecastcloud",
+      "https://github.com/saadanzari",
+      "https://github.com/dhiren-singh-007",
     ],
     mailTo:
       "tractusx-dev@eclipse.org?subject=Request Portal and Marketplaces Team",

--- a/utils/products.js
+++ b/utils/products.js
@@ -119,10 +119,8 @@ export const products = [
     ],
     committers: [
       "https://github.com/ds-jhartmann",
-      "https://github.com/mkanal",
-      "https://github.com/ds-lcapellino",
       "https://github.com/ds-mwesener",
-      "https://github.com/ds-jkreutzfeld",
+      "https://github.com/mkanal",
     ],
     mailTo:
       "tractusx-dev@eclipse.org?subject=Request Item Relationship Service Team",
@@ -369,12 +367,10 @@ export const products = [
       "The project provides a business application for tracking parts along the supply chain. [...]",
     githubRepo: [
       "https://github.com/eclipse-tractusx/traceability-foss",
-      "https://github.com/eclipse-tractusx/traceability-foss-backend",
     ],
     committers: [
+      "https://github.com/ds-jhartmann",
       "https://github.com/ds-mwesener",
-      "https://github.com/ds-mmaul",
-      "https://github.com/ds-lcapellino",
       "https://github.com/mkanal",
     ],
     mailTo: "tractusx-dev@eclipse.org?subject=Request Trace-X Team",

--- a/utils/products.js
+++ b/utils/products.js
@@ -157,7 +157,7 @@ export const products = [
   {
     productName: "Policy Hub",
     productDescription:
-      "The Policy Hub enables data providers, consumers and app providers to access a single-point-of-truth [...]",
+      "The Policy Hub is the source for Catena-X policies, attributes and templates for policy rules.",
     githubRepo: ["https://github.com/eclipse-tractusx/policy-hub"],
     committers: [
       "https://github.com/evegufy",
@@ -171,7 +171,7 @@ export const products = [
   {
     productName: "Portal & Marketplaces",
     productDescription:
-      "The Portal facilitates the operations for dataspace members (companies), [...]",
+      "The Portal  provides functionalities such as company registration, connector registration and marketplaces.",
     githubRepo: [
       "https://github.com/eclipse-tractusx/portal",
       "https://github.com/eclipse-tractusx/portal-backend",

--- a/utils/products.js
+++ b/utils/products.js
@@ -1,14 +1,5 @@
 export const products = [
   {
-    productName: "api-hub",
-    productDescription: "Welcome to the API Hub repository, a centralized location for hosting and viewing API documentation for the Tractus-X organization. This repository automates the collection of OpenAPI specifications from GitHub releases, generates Swagger UI documentation, and publishes it on GitHub Pages.",
-    githubRepo: ["https://github.com/eclipse-tractusx/api-hub"],
-    committers: ["https://github.com/tomaszbarwicki"],
-    mailTo: "tractusx-dev@eclipse.org?subject=Request api-hub Team",
-    hasBoard: false,
-    showVersion: true,
-  },
-  {
     productName: "bpn-did-resolution-service",
     productDescription: "Tractus-X Resolver Service for BPN <> DID resolution",
     githubRepo: [
@@ -142,8 +133,6 @@ export const products = [
       "https://github.com/eclipse-tractusx/managed-service-orchestrator",
     ],
     committers: [
-      "https://github.com/almadigabor",
-      "https://github.com/tomaszbarwicki",
     ],
     mailTo:
       "tractusx-dev@eclipse.org?subject=Request managed-service-orchestrator Team",
@@ -159,8 +148,6 @@ export const products = [
       "https://github.com/eclipse-tractusx/managed-simple-data-exchanger-frontend",
     ],
     committers: [
-      "https://github.com/almadigabor",
-      "https://github.com/tomaszbarwicki",
     ],
     mailTo:
       "tractusx-dev@eclipse.org?subject=Request managed-simple-data-exchanger Team",
@@ -228,7 +215,6 @@ export const products = [
       "https://github.com/eclipse-tractusx/sd-factory",
     ],
     committers: [
-      "https://github.com/tomaszbarwicki",
       "https://github.com/almadigabor",
     ],
     mailTo:

--- a/utils/products.js
+++ b/utils/products.js
@@ -9,36 +9,18 @@ export const products = [
     showVersion: true,
   },
   {
-    productName: "Tractus-X SDK",
-    productDescription:
-      "A powerful middleware that simplifies the usage and application development using multi-target versions of the EDC, DTR and Data Sources",
+    productName: "bpn-did-resolution-service",
+    productDescription: "Tractus-X Resolver Service for BPN <> DID resolution",
     githubRepo: [
-      "https://github.com/eclipse-tractusx/tractusx-sdk"
+      "https://github.com/eclipse-tractusx/bpn-did-resolution-service",
     ],
     committers: [
-      "https://github.com/matbmoser",
-      "https://github.com/CDiezRodriguez",
-      "https://github.com/mgarciaLKS",
+      "https://github.com/paullatzelsperger",
+      "https://github.com/wolf4ood",
+      "https://github.com/jimmarino",
     ],
     mailTo:
-      "mathias.moser@catena-x.net?subject=Request Tractus-X SDK Team",
-    hasBoard: false,
-    showVersion: true,
-  },
-    {
-    productName: "Industry Core Hub",
-    productDescription:
-      "A data provision & consumption lightweight orchestrator, giving an example of usage of the Tractus-X SDK and providing an UI workbench for your to share data easily with Tractus-X compliant technology and following the Catena-X industry core standards.",
-    githubRepo: [
-      "https://github.com/eclipse-tractusx/industry-core-hub"
-    ],
-    committers: [
-      "https://github.com/matbmoser",
-      "https://github.com/CDiezRodriguez",
-      "https://github.com/mgarciaLKS",
-    ],
-    mailTo:
-      "mathias.moser@catena-x.net?subject=Request Industry Core Hub Team",
+      "tractusx-dev@eclipse.org?subject=Request bpn-did-resolution-service Team",
     hasBoard: false,
     showVersion: true,
   },
@@ -61,35 +43,9 @@ export const products = [
     showVersion: true,
   },
   {
-    productName: "bpn-did-resolution-service",
-    productDescription: "Tractus-X Resolver Service for BPN <> DID resolution",
-    githubRepo: [
-      "https://github.com/eclipse-tractusx/bpn-did-resolution-service",
-    ],
-    committers: [
-      "https://github.com/paullatzelsperger",
-      "https://github.com/wolf4ood",
-      "https://github.com/jimmarino",
-    ],
-    mailTo:
-      "tractusx-dev@eclipse.org?subject=Request bpn-did-resolution-service Team",
-    hasBoard: false,
-    showVersion: true,
-  },
-  {
-    productName: "demand-capacity-mgmt",
-    productDescription: "TBD",
-    githubRepo: ["https://github.com/eclipse-tractusx/demand-capacity-mgmt"],
-    committers: ["https://github.com/nitin-vavdiya"],
-    mailTo:
-      "tractusx-dev@eclipse.org?subject=Request demand-capacity-mgmt Team",
-    hasBoard: false,
-    showVersion: true,
-  },
-  {
     productName: "Digital Product Pass",
     productDescription:
-    "The Digital Product Pass (DPP) Application provides an easy way to request and visualize product passports from an economic operator using the Catena-X Network. By scanning a QR code or introducing a manufacturerPartId and partInstanceId (productId) passports can be displayed for different products like Batteries (Battery Pass), Transmissions (Transmision Pass) and any other product by simply using the Generic Digital Product Passport Model. Additionally components like the dpp-backend have the power to retrieve any aspect submodel content, which is registered in a Digital Twin using the Catena-X Network, and the dpp-verification add-on enables certification + verification of Catena-X Instance/Type Aspect Models",
+      "The Digital Product Pass (DPP) Application provides an easy way to request and visualize product passports from an economic operator using the Catena-X Network. [...]",
     githubRepo: ["https://github.com/eclipse-tractusx/digital-product-pass"],
     committers: [
       "https://github.com/matbmoser",
@@ -101,25 +57,63 @@ export const products = [
     showVersion: true,
   },
   {
-    productName: "Self-Description Factory",
+    productName: "Digital Twin Registry",
     productDescription:
-      "Generates Self-Description (SD) documents based on input data from the Onboarding Tool, ensuring accurate representation of entities within the network",
+      "This product provides standards and services to manage digital twins.",
     githubRepo: [
-      "https://github.com/eclipse-tractusx/sd-factory",
+      "https://github.com/eclipse-tractusx/sldt-digital-twin-registry"
     ],
     committers: [
-      "https://github.com/tomaszbarwicki",
-      "https://github.com/almadigabor",
+      "https://github.com/agg3fe",
+      "https://github.com/bs-jokri",
+      "https://github.com/LuLeRoemer",
+      "https://github.com/tunacicek",
     ],
     mailTo:
-      "tractusx-dev@eclipse.org?subject=Request IDS Essential Services Team",
+      "tractusx-dev@eclipse.org?subject=Request Semantic Layer & Digital Twin Team",
+    hasBoard: false,
+    showVersion: true,
+  },
+  {
+    productName: "Discovery Services",
+    productDescription:
+      "The project provides applications for the discovery services. [...]",
+    githubRepo: [
+      "https://github.com/eclipse-tractusx/sldt-bpn-discovery",
+      "https://github.com/eclipse-tractusx/sldt-discovery-finder",
+    ],
+    committers: [
+      "https://github.com/agg3fe",
+      "https://github.com/bs-jokri",
+      "https://github.com/LuLeRoemer",
+      "https://github.com/tunacicek",
+    ],
+    mailTo:
+      "tractusx-dev@eclipse.org?subject=Request Semantic Layer & Digital Twin Team",
+    hasBoard: false,
+    showVersion: true,
+  },
+  {
+    productName: "Industry Core Hub",
+    productDescription:
+      "A data provision & consumption lightweight orchestrator, [...]",
+    githubRepo: [
+      "https://github.com/eclipse-tractusx/industry-core-hub"
+    ],
+    committers: [
+      "https://github.com/matbmoser",
+      "https://github.com/CDiezRodriguez",
+      "https://github.com/mgarciaLKS",
+    ],
+    mailTo:
+      "mathias.moser@catena-x.net?subject=Request Industry Core Hub Team",
     hasBoard: false,
     showVersion: true,
   },
   {
     productName: "Item Relationship Service",
     productDescription:
-      "The project provides a service for ad-hoc data chains across n-tier values chains for different use cases based on the EDC.",
+      "The project provides a service for ad-hoc data chains across n-tier values chains [...]",
     githubRepo: [
       "https://github.com/eclipse-tractusx/item-relationship-service",
     ],
@@ -151,7 +145,7 @@ export const products = [
   },
   {
     productName: "managed-service-orchestrator",
-    productDescription: "It is a prototype implementation for service provider. This service will help service provider to set up DFT/SDE with EDC and EDC as service in service provider environment.",
+    productDescription: "It is a prototype implementation for service provider. [...]",
     githubRepo: [
       "https://github.com/eclipse-tractusx/managed-service-orchestrator",
     ],
@@ -184,7 +178,7 @@ export const products = [
   {
     productName: "Policy Hub",
     productDescription:
-      "The Policy Hub enables data providers, consumers and app providers to access a single-point-of-truth for Catena-X policies, attributes and templates for policy rules.",
+      "The Policy Hub enables data providers, consumers and app providers to access a single-point-of-truth [...]",
     githubRepo: ["https://github.com/eclipse-tractusx/policy-hub"],
     committers: [
       "https://github.com/evegufy",
@@ -198,7 +192,7 @@ export const products = [
   {
     productName: "Portal & Marketplaces",
     productDescription:
-      "The Portal facilitates the operations for dataspace members (companies), it includes functionalities such as registration, technical onboarding and marketplaces.",
+      "The Portal facilitates the operations for dataspace members (companies), [...]",
     githubRepo: [
       "https://github.com/eclipse-tractusx/portal",
       "https://github.com/eclipse-tractusx/portal-backend",
@@ -235,50 +229,29 @@ export const products = [
     showVersion: true,
   },
   {
-    productName: "Digital Twin Registry",
+    productName: "Self-Description Factory",
     productDescription:
-        "This product provides standards and services to manage digital twins.",
+      "Generates Self-Description (SD) documents based on input data from the Onboarding Tool, [...]",
     githubRepo: [
-      "https://github.com/eclipse-tractusx/sldt-digital-twin-registry"
+      "https://github.com/eclipse-tractusx/sd-factory",
     ],
     committers: [
-      "https://github.com/agg3fe",
-      "https://github.com/bs-jokri",
-      "https://github.com/LuLeRoemer",
-      "https://github.com/tunacicek",
+      "https://github.com/tomaszbarwicki",
+      "https://github.com/almadigabor",
     ],
     mailTo:
-        "tractusx-dev@eclipse.org?subject=Request Semantic Layer & Digital Twin Team",
+      "tractusx-dev@eclipse.org?subject=Request IDS Essential Services Team",
     hasBoard: false,
     showVersion: true,
   },
   {
     productName: "Semantic Layer",
     productDescription:
-        "The project provides methods and tooling to build semantic models (e.g., semantic hub).",
+      "The project provides methods and tooling to build semantic models (e.g., semantic hub).",
     githubRepo: [
       "https://github.com/eclipse-tractusx/sldt-semantic-hub",
       "https://github.com/eclipse-tractusx/sldt-semantic-models",
       "https://github.com/eclipse-tractusx/sldt-ontology-model",
-    ],
-    committers: [
-      "https://github.com/agg3fe",
-      "https://github.com/bs-jokri",
-      "https://github.com/LuLeRoemer",
-      "https://github.com/tunacicek",
-    ],
-    mailTo:
-        "tractusx-dev@eclipse.org?subject=Request Semantic Layer & Digital Twin Team",
-    hasBoard: false,
-    showVersion: true,
-  },
-  {
-    productName: "Discovery Services",
-    productDescription:
-      "The project provides applications for the discovery services. The Discovery Finder is used to find an endpoint to a BPN Discovery for a certain type while BPN Discovery finds the endpoint of a provider EDC.",
-    githubRepo: [
-      "https://github.com/eclipse-tractusx/sldt-bpn-discovery",
-      "https://github.com/eclipse-tractusx/sldt-discovery-finder",
     ],
     committers: [
       "https://github.com/agg3fe",
@@ -343,24 +316,6 @@ export const products = [
     showVersion: true,
   },
   {
-    productName: "Trace-X",
-    productDescription:
-      "The project provides a business application for tracking parts along the supply chain. It uses quality notifications in a standardized way to notify customers or suppliers about detected faulty parts. It is based on the Catena-X standards for serialized and non-serialized hardware and software components.",
-    githubRepo: [
-      "https://github.com/eclipse-tractusx/traceability-foss",
-      "https://github.com/eclipse-tractusx/traceability-foss-backend",
-    ],
-    committers: [
-      "https://github.com/ds-mwesener",
-      "https://github.com/ds-mmaul",
-      "https://github.com/ds-lcapellino",
-      "https://github.com/mkanal",
-    ],
-    mailTo: "tractusx-dev@eclipse.org?subject=Request Trace-X Team",
-    hasBoard: false,
-    showVersion: true,
-  },
-  {
     productName: "Tractus-X EDC",
     productDescription:
       "The project provides the pre-built control- and data-plane docker images and helm charts of the Eclipse Dataspace Connector Project.",
@@ -379,6 +334,23 @@ export const products = [
     showVersion: true,
   },
   {
+    productName: "Tractus-X SDK",
+    productDescription:
+      "A powerful middleware that simplifies the usage and application development using multi-target versions of the EDC, DTR and Data Sources",
+    githubRepo: [
+      "https://github.com/eclipse-tractusx/tractusx-sdk"
+    ],
+    committers: [
+      "https://github.com/matbmoser",
+      "https://github.com/CDiezRodriguez",
+      "https://github.com/mgarciaLKS",
+    ],
+    mailTo:
+      "mathias.moser@catena-x.net?subject=Request Tractus-X SDK Team",
+    hasBoard: false,
+    showVersion: true,
+  },
+  {
     productName: "tractusx-profiles",
     productDescription: "Defines Credential and Policy Profiles for Tractus-X.",
     githubRepo: ["https://github.com/eclipse-tractusx/tractusx-profiles"],
@@ -392,11 +364,20 @@ export const products = [
     showVersion: true,
   },
   {
-    productName: "vas-country-risk",
-    productDescription: "The Catena-X Country Risk project is a web application that calculates a risk score per country based on information regarding corruption, political stability, economic risk, and social and structural figures.",
-    githubRepo: ["https://github.com/eclipse-tractusx/vas-country-risk"],
-    committers: [],
-    mailTo: "tractusx-dev@eclipse.org?subject=Request vas-country-risk Team",
+    productName: "Trace-X",
+    productDescription:
+      "The project provides a business application for tracking parts along the supply chain. [...]",
+    githubRepo: [
+      "https://github.com/eclipse-tractusx/traceability-foss",
+      "https://github.com/eclipse-tractusx/traceability-foss-backend",
+    ],
+    committers: [
+      "https://github.com/ds-mwesener",
+      "https://github.com/ds-mmaul",
+      "https://github.com/ds-lcapellino",
+      "https://github.com/mkanal",
+    ],
+    mailTo: "tractusx-dev@eclipse.org?subject=Request Trace-X Team",
     hasBoard: false,
     showVersion: true,
   },

--- a/utils/products.js
+++ b/utils/products.js
@@ -288,7 +288,9 @@ export const products = [
     productName: "testdata-provider",
     productDescription: "Testdata Provider",
     githubRepo: ["https://github.com/eclipse-tractusx/testdata-provider"],
-    committers: ["https://github.com/ds-lcapellino"],
+    committers: [
+      
+    ],
     mailTo: "tractusx-dev@eclipse.org?subject=Request testdata-provider Team",
     hasBoard: false,
     showVersion: true,

--- a/utils/products.js
+++ b/utils/products.js
@@ -189,6 +189,7 @@ export const products = [
       "https://github.com/typecastcloud",
       "https://github.com/saadanzari",
       "https://github.com/dhiren-singh-007",
+      "https://github.com/manojava-gk",
     ],
     mailTo:
       "tractusx-dev@eclipse.org?subject=Request Portal and Marketplaces Team",

--- a/utils/products.js
+++ b/utils/products.js
@@ -15,9 +15,9 @@ export const products = [
       "https://github.com/eclipse-tractusx/bpn-did-resolution-service",
     ],
     committers: [
-      "https://github.com/paullatzelsperger",
-      "https://github.com/wolf4ood",
-      "https://github.com/jimmarino",
+      "https://github.com/lgblaumeiser",
+      "https://github.com/ndr-brt",
+      "https://github.com/rafaelmag110",
     ],
     mailTo:
       "tractusx-dev@eclipse.org?subject=Request bpn-did-resolution-service Team",
@@ -322,10 +322,9 @@ export const products = [
       "https://github.com/eclipse-tractusx/tractusx-edc-template",
     ],
     committers: [
-      "https://github.com/paullatzelsperger",
-      "https://github.com/wolf4ood",
+      "https://github.com/rafaelmag110",
       "https://github.com/ndr-brt",
-      "https://github.com/jimmarino",
+      "https://github.com/lgblaumeiser",
     ],
     mailTo: "tractusx-dev@eclipse.org?subject=Request Tractus-X EDC Team",
     hasBoard: true,
@@ -353,9 +352,7 @@ export const products = [
     productDescription: "Defines Credential and Policy Profiles for Tractus-X.",
     githubRepo: ["https://github.com/eclipse-tractusx/tractusx-profiles"],
     committers: [
-      "https://github.com/jimmarino",
       "https://github.com/arnoweiss",
-      "https://github.com/wolf4ood",
     ],
     mailTo: "tractusx-dev@eclipse.org?subject=Request tractusx-profiles Team",
     hasBoard: false,

--- a/utils/products.js
+++ b/utils/products.js
@@ -9,6 +9,7 @@ export const products = [
       "https://github.com/lgblaumeiser",
       "https://github.com/ndr-brt",
       "https://github.com/rafaelmag110",
+      "https://github.com/bmg13"
     ],
     mailTo:
       "tractusx-dev@eclipse.org?subject=Request bpn-did-resolution-service Team",
@@ -289,7 +290,7 @@ export const products = [
     productDescription: "Testdata Provider",
     githubRepo: ["https://github.com/eclipse-tractusx/testdata-provider"],
     committers: [
-      
+
     ],
     mailTo: "tractusx-dev@eclipse.org?subject=Request testdata-provider Team",
     hasBoard: false,
@@ -306,7 +307,8 @@ export const products = [
     committers: [
       "https://github.com/rafaelmag110",
       "https://github.com/ndr-brt",
-      "https://github.com/lgblaumeiser",
+      "https://github.com/bmg13",
+      "https://github.com/lgblaumeiser"
     ],
     mailTo: "tractusx-dev@eclipse.org?subject=Request Tractus-X EDC Team",
     hasBoard: true,

--- a/utils/products.js
+++ b/utils/products.js
@@ -306,7 +306,7 @@ export const products = [
   {
     productName: "Tractus-X EDC",
     productDescription:
-      "The project provides the pre-built control- and data-plane docker images and helm charts of the Eclipse Dataspace Connector Project.",
+      "The project provides the pre-built control- and data-plane docker images and helm charts of the Connector Project.",
     githubRepo: [
       "https://github.com/eclipse-tractusx/tractusx-edc",
       "https://github.com/eclipse-tractusx/tractusx-edc-template",

--- a/utils/products.js
+++ b/utils/products.js
@@ -20,8 +20,7 @@ export const products = [
     productDescription:
       "The project provides core services for querying, adding, and changing business partner data in the Catena-X data space. Currently, BPDM consists of the Pool and Gate API.",
     githubRepo: [
-      "https://github.com/eclipse-tractusx/bpdm",
-      "https://github.com/eclipse-tractusx/bpdm-certificate-management",
+      "https://github.com/eclipse-tractusx/bpdm"
     ],
     committers: [
       "https://github.com/nicoprow",


### PR DESCRIPTION
## Description

Our product list is not up-to-date. This PR should help to clean it up. Two archived products were deleted, and the order was fixed. 

In the end, we should have a clean list of the Tractus-X products (real products) ⇾ including a list (for each product) of ACTIVE committer (who feel responsible for this specific product)

This is important for Release management and also for Test management

What is needed from @eclipse-tractusx/automotive-tractusx-committers 
- [x] check the list of products ⇾ is something missing? Or should some products not be on the list?
- [x] are the committers correct? Is your name tagged on the correct product?
- [x] delete your name if you are not active/responsible any more
- [ ] **Please correct directly on THIS branch ⇾ BIG THANKS FOR YOUR SUPPORT**

Expected result, after PR is merged ⇾ clear overview about the products/committers ⇾ is there any product without a committer?

Productlist -> checked and up-to-date??
- [X] bpn-did-resolution-service
- [x] Business Partner Data Management
- [X] Digital Product Pass
- [X] Digital Twin Registry
- [X] Discovery Services -> NO COMMITTER
- [X] Industry Core Hub
- [X] Item Relationship Service
- [X] knowledge-agents -> NO COMMITTER
- [X] managed-service-orchestrator -> NO COMMITTER
- [X] managed-simple-data-exchanger -> NO COMMITTER
- [x] Policy Hub
- [x] Portal & Marketplaces
- [X] Predictive Unit Real-Time Information Service
- [X] Self-Description Factory
- [X] Semantic Layer -> NO COMMITTER
- [x] SSI-agent-lib
- [x] ssi-authority-schema-registry
- [x] ssi-credential-issuer
- [x] testdata-provider -> NO COMMITTER
- [X] Tractus-X EDC
- [X] Tractus-X SDK
- [ ] tractusx-profiles
- [X] Trace-X

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
