### PR TITLE
docs: add meeting minutes for 25th april

### DIFF
--- a/blog-meeting-minutes/2025-04-25-community-hour.md
+++ b/blog-meeting-minutes/2025-04-25-community-hour.md
@@ -1,0 +1,32 @@
+---
+slug: community-office-hour-2025-04-25
+title: Community Office Hour 2025-04-25
+authors:
+    - phil91
+tags: [community, meeting-minutes]
+---
+
+## Office Hour meeting minutes
+
+### Infrastructure
+
+- All products included in the release should create their release check issue.
+
+### Release Management
+
+- A reminder was sent out regarding the alignment meeting scheduled for Wednesday, May 7th.
+- A briefing on the testing phase will take place on Monday, April 28th.
+
+### FOSS
+
+- The Docusaurus migration to version 3.7, including necessary library updates, has been completed. This upgrade included significant cleanup. A detailed description of what changed can be found [here](https://eclipse-tractusx.github.io/blog/docusaurus-upgrade-04-2025).
+
+### Community/Open Planning
+
+- Everyone is encouraged to participate in the Community Days in May 2025.
+- Once the Docusaurus migration is merged, a pull request will be submitted to add a calendar view to the Eclipse Tractus-X website.
+
+### Feedback/Questions/Requests
+
+- No specific topics to discuss
+- The release timelines for TX, CX, and the broader ecosystem are now aligned and available [here](https://catenax-ev.github.io/timelines).

--- a/blog-meeting-minutes/authors.yaml
+++ b/blog-meeting-minutes/authors.yaml
@@ -118,3 +118,9 @@ daniel_miehle:
   url: https://github.com/danielmiehle
   image_url: https://github.com/danielmiehle.png
   email: daniel.miehle@bmw.de
+
+phil91:
+  name: Phil Schneider
+  title: Software Architect, Eclipse Committer
+  url: https://github.com/Phil91
+  image_url: https://github.com/Phil91.png


### PR DESCRIPTION
## Description

* add meeting minutes for the meeting from 25.04.25
* add phil91 to authors

## Pre-review checks

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
