### PR TITLE
feat(dash-action): adapt to be executed only on change

### DIFF
--- a/.github/workflows/dash.yaml
+++ b/.github/workflows/dash.yaml
@@ -26,7 +26,8 @@ on:
     branches:
       - main
     paths:
-      - "package-lock.json"
+      - package-lock.json
+      - package.json
 
 permissions:
   contents: write

--- a/.github/workflows/dash.yaml
+++ b/.github/workflows/dash.yaml
@@ -25,6 +25,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "package-lock.json"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description

As discussed in today's office hour, this action should only be triggered, if there is a change (This would probably mean, new libs are introduced and need to be checked.) on package-lock.json -> This reduces waiting time and resources on the Eclipse side/dash side

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
