### PR TITLE
fix: mobile browser style in home page

### DIFF
--- a/src/components/AboutUsCard/styles.module.css
+++ b/src/components/AboutUsCard/styles.module.css
@@ -114,6 +114,7 @@
     justify-content: flex-start;
     align-items: center;
     text-align: center;
+    width: 100%;
   }
 
   .img {

--- a/src/components/NewsTicker/styles.module.css
+++ b/src/components/NewsTicker/styles.module.css
@@ -103,6 +103,11 @@
   .introduction {
     padding: 0 1rem;
     font-size: smaller;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
   }
 
   .arrow_container {


### PR DESCRIPTION
## Description

news section description overriding with other content issue resolved. show full length text on about us card in home page

#1267 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
