### PR TITLE
fix(notice section): delete redundant NOTICE section

### DIFF
--- a/docs-kits/kits/traceability-kit/software-development-view/parts/aspect-models.mdx
+++ b/docs-kits/kits/traceability-kit/software-development-view/parts/aspect-models.mdx
@@ -324,18 +324,3 @@ A resistance measurement is only meaningful if the voltage and current have been
   }
 ]
 ```
-## NOTICE
-This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
-- SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: 2023 BASF SE
-- SPDX-FileCopyrightText: 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-- SPDX-FileCopyrightText: 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST & Fraunhofer IML)
-- SPDX-FileCopyrightText: 2023 German Edge Cloud GmbH & Co. KG
-- SPDX-FileCopyrightText: 2023 Mercedes Benz AG
-- SPDX-FileCopyrightText: 2023 Robert Bosch Manufacturing Solutions GmbH
-- SPDX-FileCopyrightText: 2023 SAP SE
-- SPDX-FileCopyrightText: 2023 Siemens AG
-- SPDX-FileCopyrightText: 2023 T-Systems International GmbH
-- SPDX-FileCopyrightText: 2023 ZF Friedrichshafen AG
-- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
-- Source URL: https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs-kits/kits/traceability-kit (latest version)


### PR DESCRIPTION
## Description

This PR is just a small fix. Since the `aspect-model.mdx` is imported into `data-provider.mdx` the NOTICE section was duplicated. This PR deletes the duplicate section.

> note to myself -> discussion is needed about usage of import from "textblocks"

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
