### PR TITLE
chore: added new office hour structure + removed hours from ICHUB

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -13,32 +13,7 @@ All the times are shown in:
 
 :::
 
-## Regular meetings
-
-<MeetingInfo title="Industry Core Hub & Tractus-X SDK Weekly"
-             schedule="Every Tuesday from CET 09:00 am to 10:00 am"
-             description="Open Meeting to align the development status of the Industry Core Hub [IC-Hub], the data provision & consumption orchestrator & the Tractus-X SDK (a generic dataspace tool box with libraries). Additional Topic Groups (Backend, Frontend & Architecture) Weekly meetings are available in the additional links. "
-             contact="mathias.moser@catena-x.net"
-             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MGJlYzgzMjktNWE4OS00NjcwLWIyOGYtZDgzYmMzODRiMTgy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d"
-             additionalLinks={
-                [
-                    {title: 'Industry Core Hub Matrix Chat', url: 'https://matrix.to/#/#tractusx-industry-core-hub:matrix.eclipse.org'},
-                    {title: 'industry-core-hub Repository', url: 'https://github.com/eclipse-tractusx/industry-core-hub'},
-                    {title: 'tractusx-sdk Repository', url: 'https://github.com/eclipse-tractusx/tractusx-sdk'},
-                    {title: 'Planning Board Project', url: 'https://github.com/orgs/eclipse-tractusx/projects/83'},
-                    {title: 'Backend & TX-SDK Weekly - Tuesday CET 10:00 am to 11:00 am', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODU0ZDk3MjUtNjkzMS00MzQzLWFmZGYtY2Q3YWEzZmVjNmMx%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
-                    {title: 'Frontend Weekly - Tuesday CET 02:00 pm to 03:00 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODUyNWQxMzAtMWE0ZC00Mjc2LTgzYzAtNTc0ZGFiZDllNmQy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
-                    {title: 'Architecture Weekly - Thursday CET 01:00 pm to 02:00 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_YzYyMDUyZjMtMmFlMy00ODMyLWFlZDQtNjMwYWZhOTc3YTVh%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'}
-                ]
-             }
-/>
-
-<MeetingInfo title="EDC Weekly | Extended"
-             schedule="Every Tuesday from 10:30 am to 11:00 am"
-             description="Open house meeting to support with anything EDC related. You have questions about EDC, problems running/ configuring EDC in your environment or want to know what´s next in EDC and when to expect? This is the place to ask all these questions."
-             contact="lars.blaumeiser@cofinity-x.com"
-             sessionLink="https://eclipse.zoom.us/j/85945828202?pwd=YODkCen20BOQV9WNJEeNFM8zaOlxo9.1"
-/>
+## General Office Hours
 
 <MeetingInfo title="Community Office Hour"
              schedule="Every Friday effective 01. Jan 2025 until 31. Dec 2025 from 10:05 am to 11:00 am"
@@ -72,6 +47,33 @@ All the times are shown in:
                     {title: 'Timelines', url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/35'},
                 ]
              }
+/>
+
+## Product Regular meetings
+
+<MeetingInfo title="Industry Core Hub & Tractus-X SDK Weekly"
+             schedule="Every Tuesday from CET 09:00 am to 09:30 am"
+             description="Open Meeting to align the development status of the Industry Core Hub [IC-Hub], the data provision & consumption orchestrator & the Tractus-X SDK (a generic dataspace tool box with libraries). Additional Topic Groups (Backend, Frontend & Architecture) Weekly meetings are available in the additional links. "
+             contact="mathias.moser@catena-x.net"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MGJlYzgzMjktNWE4OS00NjcwLWIyOGYtZDgzYmMzODRiMTgy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d"
+             additionalLinks={
+                [
+                    {title: 'Industry Core Hub Matrix Chat', url: 'https://matrix.to/#/#tractusx-industry-core-hub:matrix.eclipse.org'},
+                    {title: 'industry-core-hub Repository', url: 'https://github.com/eclipse-tractusx/industry-core-hub'},
+                    {title: 'tractusx-sdk Repository', url: 'https://github.com/eclipse-tractusx/tractusx-sdk'},
+                    {title: 'Planning Board Project', url: 'https://github.com/orgs/eclipse-tractusx/projects/83'},
+                    {title: 'Backend & TX-SDK Weekly - Monday CET 10:00 am to 10:30 am', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODU0ZDk3MjUtNjkzMS00MzQzLWFmZGYtY2Q3YWEzZmVjNmMx%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
+                    {title: 'Frontend Weekly - Tuesday CET 02:00 pm to 02:30 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODUyNWQxMzAtMWE0ZC00Mjc2LTgzYzAtNTc0ZGFiZDllNmQy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
+                    {title: 'Architecture Weekly - Thursday CET 01:00 pm to 02:00 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_YzYyMDUyZjMtMmFlMy00ODMyLWFlZDQtNjMwYWZhOTc3YTVh%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'}
+                ]
+             }
+/>
+
+<MeetingInfo title="EDC Weekly | Extended"
+             schedule="Every Tuesday from 10:30 am to 11:00 am"
+             description="Open house meeting to support with anything EDC related. You have questions about EDC, problems running/ configuring EDC in your environment or want to know what´s next in EDC and when to expect? This is the place to ask all these questions."
+             contact="lars.blaumeiser@cofinity-x.com"
+             sessionLink="https://eclipse.zoom.us/j/85945828202?pwd=YODkCen20BOQV9WNJEeNFM8zaOlxo9.1"
 />
 
 <MeetingInfo title="Portal - Open Meeting"


### PR DESCRIPTION

## Description
I have added a new section for the "general" office hours in the topic, and added the product office hours below.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
