### PR TITLE
chore: added identity hub weekly & removed CET

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -62,9 +62,9 @@ All the times are shown in:
                     {title: 'industry-core-hub Repository', url: 'https://github.com/eclipse-tractusx/industry-core-hub'},
                     {title: 'tractusx-sdk Repository', url: 'https://github.com/eclipse-tractusx/tractusx-sdk'},
                     {title: 'Planning Board Project', url: 'https://github.com/orgs/eclipse-tractusx/projects/83'},
-                    {title: 'Backend & TX-SDK Weekly - Monday CET 10:00 am to 10:30 am', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODU0ZDk3MjUtNjkzMS00MzQzLWFmZGYtY2Q3YWEzZmVjNmMx%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
-                    {title: 'Frontend Weekly - Tuesday CET 02:00 pm to 02:30 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODUyNWQxMzAtMWE0ZC00Mjc2LTgzYzAtNTc0ZGFiZDllNmQy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
-                    {title: 'Architecture Weekly - Thursday CET 01:00 pm to 02:00 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_YzYyMDUyZjMtMmFlMy00ODMyLWFlZDQtNjMwYWZhOTc3YTVh%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'}
+                    {title: 'Backend & TX-SDK Weekly - Monday CEST 10:00 am to 10:30 am', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODU0ZDk3MjUtNjkzMS00MzQzLWFmZGYtY2Q3YWEzZmVjNmMx%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
+                    {title: 'Frontend Weekly - Tuesday CEST 02:00 pm to 02:30 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODUyNWQxMzAtMWE0ZC00Mjc2LTgzYzAtNTc0ZGFiZDllNmQy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
+                    {title: 'Architecture Weekly - Thursday CEST 01:00 pm to 02:00 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_YzYyMDUyZjMtMmFlMy00ODMyLWFlZDQtNjMwYWZhOTc3YTVh%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'}
                 ]
              }
 />
@@ -74,6 +74,20 @@ All the times are shown in:
              description="Open house meeting to support with anything EDC related. You have questions about EDC, problems running/ configuring EDC in your environment or want to know what´s next in EDC and when to expect? This is the place to ask all these questions."
              contact="lars.blaumeiser@cofinity-x.com"
              sessionLink="https://eclipse.zoom.us/j/85945828202?pwd=YODkCen20BOQV9WNJEeNFM8zaOlxo9.1"
+/>
+
+<MeetingInfo title="Indentity Hub Weekly"
+             schedule="Every Wednesday from CEST 03:00 pm to 04:00 pm"
+             description="Open Meeting to align the development of the Identity Hub (Wallet) and the Issuer Service."
+             contact="mathias.moser@catena-x.net"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NTIxMmIyMmItYTk0NC00YjMxLWFiNDAtOTRlOWM1ZDUxYWRm%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d"
+             additionalLinks={
+                [
+                    {title: 'Identity Hub Matrix Chat', url: 'https://matrix.eecc.de/#/room/#tractusx-identity-hub:matrix.eclipse.org'},
+                    {title: 'tractusx-identityhub Repository', url: 'https://github.com/eclipse-tractusx/tractusx-identityhub'},
+                    {title: 'Planning Board', url: 'https://github.com/orgs/eclipse-tractusx/projects/87/views/1'},
+                ]
+             }
 />
 
 <MeetingInfo title="Portal - Open Meeting"

--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -52,7 +52,7 @@ All the times are shown in:
 ## Product Regular meetings
 
 <MeetingInfo title="Industry Core Hub & Tractus-X SDK Weekly"
-             schedule="Every Tuesday from CET 09:00 am to 09:30 am"
+             schedule="Every Tuesday from 09:00 am to 09:30 am"
              description="Open Meeting to align the development status of the Industry Core Hub [IC-Hub], the data provision & consumption orchestrator & the Tractus-X SDK (a generic dataspace tool box with libraries). Additional Topic Groups (Backend, Frontend & Architecture) Weekly meetings are available in the additional links. "
              contact="mathias.moser@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MGJlYzgzMjktNWE4OS00NjcwLWIyOGYtZDgzYmMzODRiMTgy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d"
@@ -62,9 +62,9 @@ All the times are shown in:
                     {title: 'industry-core-hub Repository', url: 'https://github.com/eclipse-tractusx/industry-core-hub'},
                     {title: 'tractusx-sdk Repository', url: 'https://github.com/eclipse-tractusx/tractusx-sdk'},
                     {title: 'Planning Board Project', url: 'https://github.com/orgs/eclipse-tractusx/projects/83'},
-                    {title: 'Backend & TX-SDK Weekly - Monday CEST 10:00 am to 10:30 am', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODU0ZDk3MjUtNjkzMS00MzQzLWFmZGYtY2Q3YWEzZmVjNmMx%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
-                    {title: 'Frontend Weekly - Tuesday CEST 02:00 pm to 02:30 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODUyNWQxMzAtMWE0ZC00Mjc2LTgzYzAtNTc0ZGFiZDllNmQy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
-                    {title: 'Architecture Weekly - Thursday CEST 01:00 pm to 02:00 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_YzYyMDUyZjMtMmFlMy00ODMyLWFlZDQtNjMwYWZhOTc3YTVh%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'}
+                    {title: 'Backend & TX-SDK Weekly - Monday 10:00 am to 10:30 am', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODU0ZDk3MjUtNjkzMS00MzQzLWFmZGYtY2Q3YWEzZmVjNmMx%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
+                    {title: 'Frontend Weekly - Tuesday 02:00 pm to 02:30 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODUyNWQxMzAtMWE0ZC00Mjc2LTgzYzAtNTc0ZGFiZDllNmQy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
+                    {title: 'Architecture Weekly - Thursday 01:00 pm to 02:00 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_YzYyMDUyZjMtMmFlMy00ODMyLWFlZDQtNjMwYWZhOTc3YTVh%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'}
                 ]
              }
 />
@@ -76,8 +76,8 @@ All the times are shown in:
              sessionLink="https://eclipse.zoom.us/j/85945828202?pwd=YODkCen20BOQV9WNJEeNFM8zaOlxo9.1"
 />
 
-<MeetingInfo title="Indentity Hub Weekly"
-             schedule="Every Wednesday from CEST 03:00 pm to 04:00 pm"
+<MeetingInfo title="Identity Hub Weekly"
+             schedule="Every Wednesday from 03:00 pm to 04:00 pm"
              description="Open Meeting to align the development of the Identity Hub (Wallet) and the Issuer Service."
              contact="mathias.moser@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NTIxMmIyMmItYTk0NC00YjMxLWFiNDAtOTRlOWM1ZDUxYWRm%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d"
@@ -129,7 +129,7 @@ All the times are shown in:
 />
 
 <MeetingInfo title="Semantic Model Modelling - Open Meeting"
-             schedule="Every Monday effective 20. January 2025 from 15:30 am to 16:30 am CET"
+             schedule="Every Monday effective 20. January 2025 from 15:30 am to 16:30 am"
              description="Coordination of the development and alignment of aspect models (sldt-semantic-models) as well as ontologies (sldt-ontology-model)."
              contact="johann.schuetz@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2I5MjM1NzUtZmFmZS00MTI2LTgyMmEtOGZiMDMxNmRlYTA4%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22bf6c04e8-bde4-4ca1-ac15-0f85f440ab48%22%7d"


### PR DESCRIPTION
## Description

The identity hub got a new matrix chat, weekly meeting and planning board.

Also removed the CET from the times, since it is defined in the beginning already

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
