### PR TITLE
fix(naming consistency): rename DevHub -> Developer Hub

### DIFF
--- a/utils/carouselCommunityInfo.js
+++ b/utils/carouselCommunityInfo.js
@@ -13,7 +13,7 @@ export const carouselCommunityInfo = [
     },
     {
         id: 1,
-        title: "DevHub",
+        title: "Developer Hub",
         navigate: "/docs/developer",
         icon: codeIcon
     },


### PR DESCRIPTION
## Description

This PR just renames the `DevHub` section into `Developer Hub`, cause thats the name we use everywhere else.
Small CleanUp

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
