### PR TITLE
chore: update correct version of irs api for 25.06 and NEXT data chain kits

### DIFF
--- a/docs-kits_versioned_sidebars/version-25.06-sidebars.json
+++ b/docs-kits_versioned_sidebars/version-25.06-sidebars.json
@@ -280,7 +280,7 @@
             {
               "type": "link",
               "label": "Item Relationship Service API",
-              "href": "https://eclipse-tractusx.github.io/api-hub/item-relationship-service/6.0.1/swagger-ui/"
+              "href": "https://eclipse-tractusx.github.io/api-hub/item-relationship-service/7.0.1/swagger-ui/"
             }
           ]
         },

--- a/sidebarsDocsKits.js
+++ b/sidebarsDocsKits.js
@@ -303,7 +303,7 @@ const sidebars = {
               {
                 type: 'link',
                 label: 'Item Relationship Service API',
-                href: 'https://eclipse-tractusx.github.io/api-hub/item-relationship-service/6.0.1/swagger-ui/'
+                href: 'https://eclipse-tractusx.github.io/api-hub/item-relationship-service/7.0.1/swagger-ui/'
               }
             ]
           },


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
- The next version of the KIT and the 25.06 hold a wrong IRS API version. It should be 7.0.1.
<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
