### PR TITLE
chore(trg-change-log): delete TRG change log

### DIFF
--- a/docs/release/trg-0/trg-0.md
+++ b/docs/release/trg-0/trg-0.md
@@ -1,28 +1,6 @@
 ---
-title: TRG 0 - Changelog & Drafts
+title: TRG 0 - Drafts
 ---
-
-## Index of Tractus-X Release Guidelines (TRGs)
-
-| Created      | Post-History                                                                                |
-|--------------|---------------------------------------------------------------------------------------------|
-| 28-Jul-2025  | Harmonize TRG 7.06 - 7.08, integrate 7.08 into 7.07, clean up 7.06                          |
-| 22-Jan-2024  | Remove TRG 3.01 - Supported Version, TRG has been superseded by [Helm Test Workflow](https://eclipse-tractusx.github.io/docs/release/trg-5/trg-5-09/) former TRG can be found [here](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/commit/90d54f420c2b075a808972b6664ded2047d22444) |
-| 10-Jan-2024  | Remove TRG 2.02 - Repo permission, since specified in our "OSS - How to contribute" already |
-| 04-Dec-2023  | TRG 7.06 update Shared UI Components / NPM library                                          |
-| 09-Oct-2023  | TRG 4.06 add base image for hashicorp vault                                                 |
-| 29-Sep-2023  | TRG 4.02 / 06 add Alpine Linux to list of container base images                             |
-| 20-Sep-2023  | Adjust PostgreSQL version in TRG 5.07                                                       |
-| 24-Aug-2023  | Move updated TRG 7.01 to active                                                             |
-| 20-Jul-2023  | TRG 7.07 / 08 for OSS documentation improved, section added for documentation under CC-BY-4.0 |
-| 6-Jun-2023   | Extend helm test example workflow (5.09) for k8s versions (5.10) and upgradeability (5.11)  |
-| 2-Jun-2023   | Add recommendation for implementing legal notice in frontend apps (7.06)                    |
-| 9-May-2023   | Make DockerHub registry mandatory (4.05), Describe mandatory notice for Docker images (4.06)|
-| 8-May-2023   | Move TRG 7.00-7.07 out of Draft to Final                                                    |
-| 7-Mar-2023   | Remove author column, reorder post-history latest first, cleanup formatting across all TRGs |
-| 7-Mar-2023   | Move TRG 2.05, 5.09, 5.10 and 5.11 out of Draft to Prerelease                               |
-| 23-Feb-2023  | Add draft "Helm Action"                                                                     |
-| 13-Sep-2022  | Initial contribution                                                                        |
 
 ## Index by Category
 


### PR DESCRIPTION
## Description

As already discussed in the office hour, the change log is not needed (redundant) -> this PR deletes the overall TRG changelog

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
