### PR TITLE
Update identity hub open meeting description

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -78,7 +78,7 @@ All the times are shown in:
 
 <MeetingInfo title="Identity Hub Weekly"
              schedule="Every Wednesday from 03:00 pm to 04:00 pm"
-             description="Open Meeting to align the development of the Identity Hub (Wallet) and the Issuer Service."
+             description="Open Meeting to align the development of the TX Identity Hub"
              contact="mathias.moser@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NTIxMmIyMmItYTk0NC00YjMxLWFiNDAtOTRlOWM1ZDUxYWRm%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d"
              additionalLinks={


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Update the description of the Identity Hub open meeting to be more clear.

- clarified that it's about the TX distribution of the Eclipse-EDC Identity Hub
- removed "issuer service" since [tractusx-issuerservice](https://github.com/eclipse-tractusx/tractusx-issuerservice) has been deprecated and there's a risk of mistaking it for [ssi-credential-issuer](https://github.com/eclipse-tractusx/ssi-credential-issuer)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
