### PR TITLE
fix: light and dark theme community product page

### DIFF
--- a/src/components/ProductOverview/styles.module.css
+++ b/src/components/ProductOverview/styles.module.css
@@ -5,7 +5,7 @@
 
 .product_overview {
   width: 100%;
-  height: auto;;
+  height: auto;
 }
 
 .container {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -375,3 +375,8 @@
     width: 40%;
   }
 }
+
+.MuiAccordionSummary-root,
+.MuiAccordionDetails-root {
+     background-color: var(--ifm-background-color) !important;
+}


### PR DESCRIPTION
## Description

community product page is now supported with light and dark theme

https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/issues/1306

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
