### PR TITLE
chore(trgs): make sure the files are display in right order

### DIFF
--- a/docs/release/trg-0/trg-0-template.md
+++ b/docs/release/trg-0/trg-0-template.md
@@ -1,6 +1,6 @@
 ---
 title: TRG 0 - (WIP) Template
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 :::caution

--- a/docs/release/trg-0/trg-0.md
+++ b/docs/release/trg-0/trg-0.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 0 - Drafts
+sidebar_position: 1
 ---
 
 ## Index by Category

--- a/docs/release/trg-0/trg-9-01.md
+++ b/docs/release/trg-0/trg-9-01.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 9.01 - KITS
+sidebar_position: 3
 ---
 
 | Status     | Created      | Post-History                           |

--- a/docs/release/trg-1/trg-1-05.md
+++ b/docs/release/trg-1/trg-1-05.md
@@ -1,6 +1,6 @@
 ---
 title: TRG 1.05 - Architecture Documentation
-sidebar_position: 1
+sidebar_position: 5
 ---
 
 | Status   | Created     | Post-History                                          |

--- a/docs/release/trg-1/trg-1-06.md
+++ b/docs/release/trg-1/trg-1-06.md
@@ -1,6 +1,6 @@
 ---
 title: TRG 1.06 - Administrator's Guide
-sidebar_position: 1
+sidebar_position: 6
 ---
 
 | Status | Created     | Post-History                                          |

--- a/docs/release/trg-1/trg-1-07.md
+++ b/docs/release/trg-1/trg-1-07.md
@@ -1,6 +1,6 @@
 ---
 title: TRG 1.07 - End User Manual
-sidebar_position: 1
+sidebar_position: 7
 ---
 
 | Status | Created     | Post-History                                          |

--- a/docs/release/trg-1/trg-1-08.md
+++ b/docs/release/trg-1/trg-1-08.md
@@ -1,6 +1,6 @@
 ---
 title: TRG 1.08 - Interface documentation (APIs)
-sidebar_position: 1
+sidebar_position: 8
 ---
 
 | Status | Created     | Post-History                                          |

--- a/docs/release/trg-1/trg-1-09.md
+++ b/docs/release/trg-1/trg-1-09.md
@@ -1,6 +1,6 @@
 ---
 title: TRG 1.09 - Migration Guide
-sidebar_position: 1
+sidebar_position: 9
 ---
 
 :::caution

--- a/docs/release/trg-1/trg-1-1.md
+++ b/docs/release/trg-1/trg-1-1.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 1.01 - README.md
+sidebar_position: 1
 ---
 
 | Status | Created      | Post-History                             |

--- a/docs/release/trg-1/trg-1-2.md
+++ b/docs/release/trg-1/trg-1-2.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 1.02 - INSTALL.md
+sidebar_position: 2
 ---
 
 | Status | Created      | Post-History                                        |

--- a/docs/release/trg-1/trg-1-3.md
+++ b/docs/release/trg-1/trg-1-3.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 1.03 - CHANGELOG.md
+sidebar_position: 3
 ---
 
 | Status | Created      | Post-History                             |
@@ -40,7 +41,7 @@ All notable changes to this project will be documented in this file see also the
 
 - add API reference documentation (#issue, #pull-request)
 
-## [v2.0.1](https://github.com/eclipse-tractusx/digital-product-pass/releases/tag/v2.0.1)  (your currently released semantic version) 
+## [v2.0.1](https://github.com/eclipse-tractusx/digital-product-pass/releases/tag/v2.0.1)  (your currently released semantic version)
 
 ### Added
 
@@ -50,7 +51,7 @@ All notable changes to this project will be documented in this file see also the
 
 - bump Java version (#issue, #pull-request)
 
-... 
+...
 
 ### Security
 

--- a/docs/release/trg-1/trg-1-4.md
+++ b/docs/release/trg-1/trg-1-4.md
@@ -1,5 +1,6 @@
 ---
-title: TRG 1.04 - Diagrams as code / Editable static files 
+title: TRG 1.04 - Diagrams as code / Editable static files
+sidebar_position: 4
 ---
 
 | Status | Created      | Post-History                                             |

--- a/docs/release/trg-2/trg-2-1.md
+++ b/docs/release/trg-2/trg-2-1.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 2.01 - Default Branch
+sidebar_position: 1
 ---
 
 | Status | Created      | Post-History    |

--- a/docs/release/trg-2/trg-2-3.md
+++ b/docs/release/trg-2/trg-2-3.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 2.03 - Repo structure
+sidebar_position: 2
 ---
 
 | Status | Created     | Post-History                                  |

--- a/docs/release/trg-2/trg-2-4.md
+++ b/docs/release/trg-2/trg-2-4.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 2.04 - Leading product repository
+sidebar_position: 3
 ---
 
 | Status | Created     | Post-History                                   |

--- a/docs/release/trg-2/trg-2-5.md
+++ b/docs/release/trg-2/trg-2-5.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 2.05 - Repository metafile
+sidebar_position: 4
 ---
 
 | Status     | Created     | Post-History           |

--- a/docs/release/trg-3/trg-3-2.md
+++ b/docs/release/trg-3/trg-3-2.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 3.02 - Persist Data
+sidebar_position: 1
 ---
 
 | Status | Created     | Post-History      |

--- a/docs/release/trg-4/trg-4-01.md
+++ b/docs/release/trg-4/trg-4-01.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 4.01 - Image tagging
+sidebar_position: 1
 ---
 
 | Status | Created     | Post-History                                       |
@@ -104,7 +105,7 @@ jobs:
         with:
           images: |
             ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
-          # Automatically prepare image tags; See action docs for more examples. 
+          # Automatically prepare image tags; See action docs for more examples.
           # semver patter will generate tags like these for example :1 :1.2 :1.2.3
           tags: |
             type=ref,event=branch
@@ -133,13 +134,13 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       # https://github.com/peter-evans/dockerhub-description
-      # Important step to push image description to DockerHub 
+      # Important step to push image description to DockerHub
       - name: Update Docker Hub description
         if: github.event_name != 'pull_request'
         uses: peter-evans/dockerhub-description@v3
         with:
-          # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'   
-          # readme-filepath: path/to/dedicated/notice-for-docker-image.md 
+          # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'
+          # readme-filepath: path/to/dedicated/notice-for-docker-image.md
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}

--- a/docs/release/trg-4/trg-4-02.md
+++ b/docs/release/trg-4/trg-4-02.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 4.02 - Base Images
+sidebar_position: 2
 ---
 
 | Status | Created     | Post-History                                                                    |
@@ -121,7 +122,7 @@ base image for your application that contains all dependent tools.
 :::warning Do not update or install additional packages
 
 ```Dockerfile
-# Call for feedback: Does this example make sense at all or 
+# Call for feedback: Does this example make sense at all or
 # should it be removed?
 FROM alpine:3.18.2
 

--- a/docs/release/trg-4/trg-4-03.md
+++ b/docs/release/trg-4/trg-4-03.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 4.03 - Non-root container
+sidebar_position: 3
 ---
 
 | Status | Created      | Post-History                     |

--- a/docs/release/trg-4/trg-4-04.md
+++ b/docs/release/trg-4/trg-4-04.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 4.04 - Image signing
+sidebar_position: 4
 ---
 
 | Status | Created      | Post-History    |

--- a/docs/release/trg-4/trg-4-05.md
+++ b/docs/release/trg-4/trg-4-05.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 4.05 - Container registries
+sidebar_position: 5
 ---
 
 | Status | Created      | Post-History                                                            |

--- a/docs/release/trg-4/trg-4-06.md
+++ b/docs/release/trg-4/trg-4-06.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 4.06 - Notice for docker images
+sidebar_position: 6
 ---
 
 | Status | Created     | Post-History    |

--- a/docs/release/trg-4/trg-4-07.md
+++ b/docs/release/trg-4/trg-4-07.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 4.07 - Read-only filesystems
+sidebar_position: 7
 ---
 
 | Status | Created       | Post-History                 |

--- a/docs/release/trg-4/trg-4-08.md
+++ b/docs/release/trg-4/trg-4-08.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 4.08 - Multi-platform images
+sidebar_position: 8
 ---
 
 | Status | Created     | Post-History                              |

--- a/docs/release/trg-5/trg-5-01.md
+++ b/docs/release/trg-5/trg-5-01.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 5.01 - Helm Chart requirements
+sidebar_position: 1
 ---
 
 | Status | Created     | Post-History                |

--- a/docs/release/trg-5/trg-5-02.md
+++ b/docs/release/trg-5/trg-5-02.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 5.02 - Chart structure
+sidebar_position: 2
 ---
 
 | Status | Created     | Post-History                                           |
@@ -68,7 +69,7 @@ chartName/
   values.yaml          # mandatory
   crds/                # optional
   templates/           # mandatory, except of umbrella Helm charts
-  templates/NOTES.txt  # optional 
+  templates/NOTES.txt  # optional
 ```
 
 For further details on Helm chart basics, please refer to [Helm documentation](https://helm.sh/docs/topics/charts/).
@@ -115,14 +116,14 @@ The README.md file **must** contain:
   - Helm 3.2.0+
   - PV provisioner support in the underlying infrastructure
   ```
-  
+
 - a section of "TL;DR" that includes the helm commands to add and install the helm chart, Example:
 
   ```shell
   helm repo add my-repo https://charts.bitnami.com/bitnami
   helm install my-release my-repo/postgresql
   ```
-  
+
 - documentation of default values for this Helm chart ([_helm-docs_](https://github.com/norwoodj/helm-docs#helm-docs)
   may help).
 

--- a/docs/release/trg-5/trg-5-03.md
+++ b/docs/release/trg-5/trg-5-03.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 5.03 - Version strategy
+sidebar_position: 3
 ---
 
 | Status | Created     | Post-History    |

--- a/docs/release/trg-5/trg-5-04.md
+++ b/docs/release/trg-5/trg-5-04.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 5.04 - Resource Management
+sidebar_position: 4
 ---
 
 | Status | Created     | Post-History                                 |

--- a/docs/release/trg-5/trg-5-05.md
+++ b/docs/release/trg-5/trg-5-05.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 5.05 - Chart Values
+sidebar_position: 5
 ---
 
 | Status | Created     | Post-History           |

--- a/docs/release/trg-5/trg-5-06.md
+++ b/docs/release/trg-5/trg-5-06.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 5.06 - Application Configuration
+sidebar_position: 6
 ---
 
 | Status | Created     | Post-History    |

--- a/docs/release/trg-5/trg-5-07.md
+++ b/docs/release/trg-5/trg-5-07.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 5.07 - Chart Dependencies
+sidebar_position: 7
 ---
 
 | Status | Created     | Post-History              |

--- a/docs/release/trg-5/trg-5-08.md
+++ b/docs/release/trg-5/trg-5-08.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 5.08 - Product Helm Chart
+sidebar_position: 8
 ---
 
 | Status | Created     | Post-History |

--- a/docs/release/trg-5/trg-5-09.md
+++ b/docs/release/trg-5/trg-5-09.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 5.09 - Helm test
+sidebar_position: 9
 ---
 
 | Status     | Created     | Post-History                                    |

--- a/docs/release/trg-5/trg-5-10.md
+++ b/docs/release/trg-5/trg-5-10.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 5.10 - Kubernetes versions
+sidebar_position: 10
 ---
 
 | Status     | Created     | Post-History       |

--- a/docs/release/trg-5/trg-5-11.md
+++ b/docs/release/trg-5/trg-5-11.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 5.11 - Upgradeability
+sidebar_position: 11
 ---
 
 | Status     | Created     | Post-History       |

--- a/docs/release/trg-6/trg-6-1.md
+++ b/docs/release/trg-6/trg-6-1.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 6.01 - Released Helm Chart
+sidebar_position: 1
 ---
 
 | Status | Created     | Post-History    |

--- a/docs/release/trg-7/trg-7-00.md
+++ b/docs/release/trg-7/trg-7-00.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 7.00 - Recurring activities for each PR
+sidebar_position: 1
 ---
 
 | Status | Created     | Post-History                         |

--- a/docs/release/trg-7/trg-7-01.md
+++ b/docs/release/trg-7/trg-7-01.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 7.01 - Legal Documentation
+sidebar_position: 2
 ---
 
 | Status | Created     | Post-History                                    |

--- a/docs/release/trg-7/trg-7-02.md
+++ b/docs/release/trg-7/trg-7-02.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 7.02 - License and Copyright header
+sidebar_position: 3
 ---
 
 | Status | Created     | Post-History                                       |

--- a/docs/release/trg-7/trg-7-03.md
+++ b/docs/release/trg-7/trg-7-03.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 7.03 - IP checks for project content
+sidebar_position: 4
 ---
 
 | Status | Created     | Post-History                  |

--- a/docs/release/trg-7/trg-7-04.md
+++ b/docs/release/trg-7/trg-7-04.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 7.04 - IP checks for 3rd party content
+sidebar_position: 5
 ---
 
 | Status | Created     | Post-History                  |

--- a/docs/release/trg-7/trg-7-05.md
+++ b/docs/release/trg-7/trg-7-05.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 7.05 - Legal information for distributions
+sidebar_position: 6
 ---
 
 | Status | Created     | Post-History                  |

--- a/docs/release/trg-7/trg-7-06.md
+++ b/docs/release/trg-7/trg-7-06.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 7.06 - Legal notice for end user content
+sidebar_position: 7
 ---
 
 | Status | Created     | Post-History                               |

--- a/docs/release/trg-7/trg-7-07.md
+++ b/docs/release/trg-7/trg-7-07.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 7.07 - Legal notice for non-code (e.g. KITS, documentation, images, slidesets, issue content)
+sidebar_position: 8
 ---
 
 | Status | Created     | Post-History                  |

--- a/docs/release/trg-7/trg-7-08.md
+++ b/docs/release/trg-7/trg-7-08.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 7.08 - Legal notice for KIT documentation (CC-BY-4.0)
+sidebar_position: 9
 ---
 
 | Status | Created     | Post-History                          |

--- a/docs/release/trg-7/trg-7-09.md
+++ b/docs/release/trg-7/trg-7-09.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 7.09 - Deprecation of Unmaintained Repositories
+sidebar_position: 10
 ---
 
 | Status  | Created     | Post-History                          |
@@ -106,7 +107,7 @@ In case a repository you are maintaining or want to maintain got deprecated afte
 ```mermaid
 flowchart TD
     A[1: Requestor creates an issue in the sig-infra repository following a template] --> B[2: Requestors send an email to the tractusx-dev mailing list informing of responsible committer, issue id and reason for reactivation]
-    B --> C[3: Requestor informs the community in the office hour] 
+    B --> C[3: Requestor informs the community in the office hour]
     C --> D{Reactivation Criteria Fulfilled?}
     D --> |NO| E[4: Project Lead closes the issue in Github]
     D --> |YES| F[4: Project Lead opens issue in .eclipsefdn]
@@ -126,7 +127,7 @@ flowchart TD
 ### Issue Template for Reactivation
 
 ```markdown
-Title: Request for repository [<REPOSITORY_NAME>] reactivation 
+Title: Request for repository [<REPOSITORY_NAME>] reactivation
 Content:
 ## Context
 

--- a/docs/release/trg-8/trg-8-01.md
+++ b/docs/release/trg-8/trg-8-01.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 8.01 - CodeQL
+sidebar_position: 1
 ---
 
 | Status | Created     | Post-History    |

--- a/docs/release/trg-8/trg-8-02.md
+++ b/docs/release/trg-8/trg-8-02.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 8.02 - KICS
+sidebar_position: 2
 ---
 
 | Status | Created     | Post-History    |

--- a/docs/release/trg-8/trg-8-03.md
+++ b/docs/release/trg-8/trg-8-03.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 8.03 - TruffleHog
+sidebar_position: 3
 ---
 
 | Status | Created     | Post-History                                                  |
@@ -92,5 +93,5 @@ jobs:
 
       - name: Scan Results Status
         if: steps.trufflehog.outcome == 'failure'
-        run: exit 1  # Set workflow run to failure if TruffleHog finds secrets 
+        run: exit 1  # Set workflow run to failure if TruffleHog finds secrets
 ```

--- a/docs/release/trg-8/trg-8-04.md
+++ b/docs/release/trg-8/trg-8-04.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 8.04 - Trivy
+sidebar_position: 4
 ---
 
 | Status | Created     | Post-History    |

--- a/docs/release/trg-8/trg-8-05.md
+++ b/docs/release/trg-8/trg-8-05.md
@@ -1,5 +1,6 @@
 ---
 title: TRG 8.05 - Dependabot
+sidebar_position: 5
 ---
 
 | Status | Created      | Post-History                      |


### PR DESCRIPTION

## Description

depending on the filename, in some cases the TRGs are not shown in the correct order ⇾ This PR adds the `side_postion` information to each TRG

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
