### PR TITLE
doc(open-meeting): adjusted open meeting teams link for bpdm

### DIFF
--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -117,10 +117,10 @@ All the times are shown in:
 />
 
 <MeetingInfo title="BPDM - Open Meeting"
-             schedule="Every Wednesday effective 4. Dec 2024 until 29. Oct 2025 from 10:00 am to 10:30 am"
+             schedule="Every Wednesday from 10:00 am to 10:30 am"
              description="Coordination of feature refinement and development for bpdm product."
-             contact="maximilian.ong@mercedes-benz.com"
-             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NjYxNGZkNzctMjVmZi00MTU4LThhNWYtOGUwMTFiODJlMWU4%40thread.v2/0?context=%7b%22Tid%22%3a%229652d7c2-1ccf-4940-8151-4a92bd474ed0%22%2c%22Oid%22%3a%22efb1321e-4b62-4eb3-9d3f-88bee0686fc1%22%7d"
+             contact="sujit.karne@mercedes-benz.com"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_OGYxZjQ4NzItNjc1OC00YjEyLWI2NjYtNThjNDBmMGI0MTk4%40thread.v2/0?context=%7b%22Tid%22%3a%229652d7c2-1ccf-4940-8151-4a92bd474ed0%22%2c%22Oid%22%3a%221cad1acb-7d7b-4e88-bc6b-875078a66bdf%22%7d"
              additionalLinks={
                 [
                     {title: 'BPDM Matrix Chat', url: 'https://chat.eclipse.org/#/room/#tractusx-bpdm:matrix.eclipse.org'},


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request adjusts the teams meeting link and details for BPDM - Open Meeting.
Every Wednesday from 10:00 am to 10:30 am
<img width="918" height="237" alt="image" src="https://github.com/user-attachments/assets/d41a4cda-0ca1-4db8-8e35-ab7250ba7891" />

Contributes to https://github.com/eclipse-tractusx/bpdm/issues/1436

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
