### PR TITLE
doc: Update wrong link to source of pcf kit

### DIFF
--- a/docs-kits/kits/product-carbon-footprint-exchange-kit/adoption-view.md
+++ b/docs-kits/kits/product-carbon-footprint-exchange-kit/adoption-view.md
@@ -427,4 +427,4 @@ This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses
 - SPDX-FileCopyrightText: 2023,2024 CCT
 - SPDX-FileCopyrightText: 2023,2024 Gris Group
 - SPDX-FileCopyrightText: 2023,2024 Contributors to the Eclipse Foundation
-- [Source URL](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs-kits/kits/PCF%20Exchange%20Kit)
+- [Source URL](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs-kits/kits/product-carbon-footprint-exchange-kit)

--- a/docs-kits/kits/product-carbon-footprint-exchange-kit/software-development-view.md
+++ b/docs-kits/kits/product-carbon-footprint-exchange-kit/software-development-view.md
@@ -400,4 +400,4 @@ This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses
 - SPDX-FileCopyrightText: 2023, 2024 CCT
 - SPDX-FileCopyrightText: 2023, 2024 Gris Group
 - SPDX-FileCopyrightText: 2023, 2024 Contributors to the Eclipse Foundation
-- [Source URL](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs-kits/kits/PCF%20Exchange%20Kit)
+- [Source URL](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs-kits/kits/product-carbon-footprint-exchange-kit)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Update the link to the sources of the PCF kit

<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
