### PR TITLE
docs(pcf-exchange-kit): add new api version to KIT and API-HUB

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -44,6 +44,7 @@ openApiSpecs:
 - "https://raw.githubusercontent.com/eclipse-tractusx/eclipse-tractusx.github.io/main/openApi/industry-core/kit_industry-core-unique-id-push-openAPI_2-1-0.yaml"
 
 # PCF KIT
+- "https://raw.githubusercontent.com/eclipse-tractusx/eclipse-tractusx.github.io/main/openApi/pcf/kit_pcf-openAPI_1-1-2.yaml"
 - "https://raw.githubusercontent.com/eclipse-tractusx/eclipse-tractusx.github.io/main/openApi/pcf/kit_pcf-openAPI_1-1-1.yaml"
 
 # MaaS KIT

--- a/docs-kits/kits/product-carbon-footprint-exchange-kit/software-development-view.md
+++ b/docs-kits/kits/product-carbon-footprint-exchange-kit/software-development-view.md
@@ -73,7 +73,7 @@ The sequence diagram provided below presents an example of a PCF update flow. An
 - When responding an PCF exchange request, the "requestID" is mandatory in the PUT call.
 - When sharing a PCF update, the "requestID" is NOT allowed in the PUT call.
 - The EDC asset used to receive a PCF is NOT looked up through AAS, but identified by type ("data.pcf.exchangeEndpoint").
-- The Open API specification defining all mandatory PCF Exchange endpoints and the data structures transferred through those can be found [here](./resources/development-view/catena-x-pcf-endpoint-1_1_1.yaml)
+- The Open API specification defining all mandatory PCF Exchange endpoints and the data structures transferred through those can be found [here](https://eclipse-tractusx.github.io/api-hub/eclipse-tractusx.github.io/kit-pcf-openAPI-1.1.2/swagger-ui/)
 
 ##### Payload for Requesting PCF Sub Model
 

--- a/openApi/pcf/kit_pcf-openAPI_1-1-2.yaml
+++ b/openApi/pcf/kit_pcf-openAPI_1-1-2.yaml
@@ -1,0 +1,768 @@
+openapi: "3.1.0"
+info:
+  title: "PCF Data Exchange API"
+  version: 1.1.2
+paths:
+  /footprintExchange/{requestId}:
+    put:
+      tags:
+        - "EDC PCF Data Exchange"
+      summary: "PCF Response / Update"
+      operationId: "putPcfWithPathId"
+      parameters:
+        - name: "requestId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+        - name: message
+          in: query
+          required: false
+          description: URL encoded, max 250 chars
+          example: No%20offset%20included%2C%20please%21
+          schema:
+            type: string
+        - name: "update"
+          description: "Whether this is an update to an existing request. If 'false' this is a response to an open request."
+          in: "query"
+          required: false
+          schema:
+            default: false
+            type: "boolean"
+        - name: edc-bpn
+          description: The caller's Catena-X BusinessPartnerNumber, automatically set by the EDC
+          example: BPNL0000005AMPL3
+          in: header
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+        required: true
+        description: "PCF data that matches the <a href=\"https://github.com/eclipse-tractusx/sldt-semantic-models/blob/main/io.catenax.pcf/7.0.0/gen/Pcf-schema.json\">Catena-X aspect model urn:samm:io.catenax.pcf:7.0.0#Pcf</a>"
+      responses:
+        "200":
+          description: "OK"
+        "400":
+          description: "Bad Request"
+    get:
+      tags:
+        - "EDC PCF Data Exchange"
+      summary: "PCF Request"
+      description: "Request footprint. At least one manufacturerPartId or customerPartId must be provided."
+      operationId: "requestPcf"
+      parameters:
+        - name: "requestId"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+          description: "The id of the footprint request"
+        - name: edc-bpn
+          description: The caller's Catena-X BusinessPartnerNumber, automatically set by the EDC
+          example: BPNL0000005AMPL3
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: "manufacturerPartId"
+          in: "query"
+          required: false
+          schema:
+            type: "string"
+        - name: "customerPartId"
+          in: "query"
+          required: false
+          schema:
+            type: "string"
+        - name: message
+          in: query
+          required: false
+          description: URL encoded, max 250 chars
+          example: No%20offset%20included%2C%20please%21
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "OK"
+        "404":
+          description: "Not Found"
+  /productIds/{productId}:
+    get:
+      tags:
+      - "Deprecated API"
+      deprecated: true
+      operationId: get_pcf
+      parameters:
+        - name: edc-bpn
+          description: The caller's Catena-X BusinessPartnerNumber, automatically set by the EDC
+          example: BPNL0000005AMPL3
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: productId
+          description: ID of the product/material the PCF is requested for
+          example: urn:id:8534x67
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: requestId
+          description: ID identifying the call (will be referenced in corresponding PCF response)
+          example: 2daa49aa-ee16-4df3-bca3-69ddead40419
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: message
+          in: query
+          required: false
+          description: URL encoded, max 250 chars
+          example: No%20offset%20included%2C%20please%21
+          schema:
+            type: string
+      responses:
+        '202':
+          description: PCF was accepted. PCF will be sent later via to POST endpoint.
+    put:
+      tags:
+      - "Deprecated API"
+      deprecated: true
+      operationId: set_pcf
+      parameters:
+        - name: edc-bpn
+          description: The caller's Catena-X BusinessPartnerNumber
+          example: BPNL0000005AMPL3
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: productId
+          description: ID of the product/material the PCF referring to
+          example: urn:id:8534x67
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: requestId
+          description: ID identifying the request call (same as within original PCF request), if the PUT is responing to a call. Can be dismissed in a PCF update call.
+          example: 2daa49aa-ee16-4df3-bca3-69ddead40419
+          in: query
+          required: false
+          schema:
+            type: string
+      requestBody:
+        description: The requested PCF in WBCSD format
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProductFootprintResponse'
+      responses:
+        '200':
+          description: ''
+components:
+  schemas:
+    ProductFootprintResponse:
+      description: A Product (Carbon) Footprint represents the carbon footprint of a product with values as specified in the Catena-X PCF Rulebook in accordance with the WBCSD (World Business Council for Sustainable Development) Pathfinder framework and the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD/ PACT initiative.
+      type: object
+      properties:
+        id:
+          description: 'Mandatory: The product footprint identifier as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#id
+          $ref: '#/components/schemas/UuidV4Trait'
+        specVersion:
+          description: 'Mandatory: Version of the product footprint data specification as defined in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#specVersion
+          $ref: '#/components/schemas/Text'
+        partialFullPcf:
+          description: 'Mandatory: Indicator for partial or full PCF (Product Carbon Footprint) declaration as specified in the Catena-X PCF Rulebook (Version 3.0.0).'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#partialFullPcf
+          $ref: '#/components/schemas/PartialFullPcfCharacteristic'
+        precedingPfIds:
+          description: 'Optional: Set of preceding PCF (Product Carbon Footprint) identifiers without duplicates as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the WBCSD (World Business Council for Sustainable Development) Pathfinder framework and the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD/ PACT initiative. Declared as "optional" in WBCSD, needs to be covered by application.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#precedingPfIds
+          $ref: '#/components/schemas/PrecedingPfIdsCharacteristic'
+        version:
+          description: 'Mandatory: Version of the product (carbon) footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example set to "0" per default.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#version
+          $ref: '#/components/schemas/ProductFootprintVersion'
+        created:
+          description: 'Mandatory: Timestamp of the creation of the Product (Carbon) Footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#created
+          $ref: '#/components/schemas/Timestamp'
+        extWBCSD_pfStatus:
+          description: 'Mandatory: Status indicator of a product (carbon) footprint as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example set to "Active" per default.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#status
+          $ref: '#/components/schemas/PfStatusCharacteristic'
+        validityPeriodStart:
+          description: 'Optional: Start of interval during which the product (carbon) footprint is declared as valid as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. If specified, the validity period start must be equal to or greater than the reference period end.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#validityPeriodStart
+          $ref: '#/components/schemas/Timestamp'
+        validityPeriodEnd:
+          description: 'Optional: End of interval during which the product (carbon) footprint is declared as valid as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#validityPeriodEnd
+          $ref: '#/components/schemas/Timestamp'
+        comment:
+          description: 'Optional: Additional information and instructions related to the calculation of the product (carbon) footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#comment
+          $ref: '#/components/schemas/Text'
+        companyName:
+          description: 'Mandatory: Name of the product (carbon) footprint data owner as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#companyName
+          $ref: '#/components/schemas/NonEmptyStringTrait'
+        companyIds:
+          description: "Mandatory: Non-empty set of Uniform Resource Names (URN). Each value is supposed to uniquely identify the product (carbon) footprint data owner as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. For Catena-X Industry Core compliance the set of URNs must contain at least the Business Partner Number Legal Entity (BPNL) in the specified format urn:bpn:id:BPNL[a-zA-Z0-9]{12}.\_"
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#companyIds
+          $ref: '#/components/schemas/IdsTrait'
+        productDescription:
+          description: 'Optional: Free-form description of the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#productDescription
+          $ref: '#/components/schemas/Text'
+        productIds:
+          description: 'Mandatory: Non-empty set of product identifiers. Each value is supposed to uniquely identify the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X productId corresponds with Industry Core manufacturerPartId.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#productIds
+          $ref: '#/components/schemas/IdsTrait'
+        extWBCSD_productCodeCpc:
+          description: 'Mandatory: UN (United Nations) Product Classification Code (CPC - Central Classification Code) of a given product as specified the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, which will probably be declared as "optional" in a later WBCSD specification version. In Catena-X for example specified with default value "011-99000".'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#productCategoryCpc
+          $ref: '#/components/schemas/Text'
+        productName:
+          description: "Mandatory: Non-empty trade name of a product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X productNameCompany corresponds with Industry Core nameAtManufacturer.\_"
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#productNameCompany
+          $ref: '#/components/schemas/NonEmptyStringTrait'
+        pcf:
+          description: A PCF (Product Carbon Footprint) represents the carbon footprint of a product and related data as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#pcf
+          $ref: '#/components/schemas/CarbonFootprint'
+        pcfLegalStatement:
+          description: 'Optional: Option for legal statement/ disclaimer as specified in the Catena-X PCF Rulebook (Version 3.0.0).'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#pcfLegalStatement
+          $ref: '#/components/schemas/Text'
+      required:
+        - id
+        - specVersion
+        - partialFullPcf
+        - version
+        - created
+        - extWBCSD_pfStatus
+        - companyName
+        - companyIds
+        - productIds
+        - extWBCSD_productCodeCpc
+        - productName
+        - pcf
+    UuidV4Trait:
+      type: string
+      x-samm-aspect-model-urn: urn:samm:io.catenax.shared.uuid:2.0.0#UuidV4Trait
+      description: The provided regular expression ensures that the UUID is composed of five groups of characters separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens), optionally prefixed by "urn:uuid:" to make it an IRI.
+      pattern: (^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)
+    Text:
+      type: string
+      x-samm-aspect-model-urn: urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#Text
+      description: Describes a Property which contains plain text. This is intended exclusively for human readable strings, not for identifiers, measurement values, etc.
+    PartialFullPcfCharacteristic:
+      type: string
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#PartialFullPcfCharacteristic
+      description: Characteristic for defining an indicator for partial or full PCF (Product Carbon Footprint) declaration as specified in the Catena-X PCF Rulebook (Version 3.0.0).
+      enum:
+        - Cradle-to-gate
+        - Cradle-to-grave
+    PrecedingPfId:
+      description: Entity for defining a preceding PCF (Product Carbon Footprint) identifier entity as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#PrecedingPfId
+      type: object
+      properties:
+        id:
+          description: 'Mandatory: The product footprint identifier as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#id
+          $ref: '#/components/schemas/UuidV4Trait'
+      required:
+        - id
+    PrecedingPfIdsCharacteristic:
+      description: Characteristic for defining a non-empty set of product (carbon) footprint identifiers as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the WBCSD (World Business Council for Sustainable Development) Pathfinder framework and the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD/ PACT initiative.
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#PrecedingPfIdsCharacteristic
+      type: array
+      items:
+        $ref: '#/components/schemas/PrecedingPfId'
+    ProductFootprintVersion:
+      type: number
+      minimum: 0
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#ProductFootprintVersion
+      description: Characteristic for defining a product footprint version as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+    Timestamp:
+      type: string
+      pattern: '-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?|(24:00:00(\.0+)?))(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?'
+      x-samm-aspect-model-urn: urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#Timestamp
+      description: Describes a Property which contains the date and time with an optional timezone.
+    PfStatusCharacteristic:
+      type: string
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#PfStatusCharacteristic
+      description: Characteristic for defining a status indicator of a product (carbon) footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Enumeration with possible "Active" and "Deprecated".
+      enum:
+        - Active
+        - Deprecated
+    NonEmptyStringTrait:
+      type: string
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#NonEmptyStringTrait
+      description: Constraint for ensuring that a string has at least one character.
+      minLength: 1
+    IdsTrait:
+      description: Constraint for defining a non-empty set of URIs (Uniform Resource Identifieres).
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#IdsTrait
+      type: array
+      items:
+        type: string
+        format: uri
+      minItems: 1
+    DeclaredUnitCharacteristic:
+      type: string
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#DeclaredUnitCharacteristic
+      description: Unit of analysis of the product with accepted values as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. For countable products/ components/ materials, Catena-X for example adds the unit "piece" to the value list specified by WBCSD.
+      enum:
+        - liter
+        - kilogram
+        - cubic meter
+        - kilowatt hour
+        - megajoule
+        - ton kilometer
+        - square meter
+        - piece
+    StrictlyPositiveDecimalTrait:
+      type: number
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#StrictlyPositiveDecimalTrait
+      description: Constraint for defining a positive, non-zero decimal.
+      minimum: 0
+      exclusiveMinimum: true
+    PositiveDecimalWeightTrait:
+      type: number
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#PositiveDecimalWeightTrait
+      description: Constraint for defining a decimal equal to or greater than zero.
+      minimum: 0
+      exclusiveMinimum: false
+    ExemptedEmissionsPercentTrait:
+      type: number
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#ExemptedEmissionsPercentTrait
+      description: Characteristic for defining the percentage of emissions excluded from a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      maximum: 5
+      exclusiveMaximum: false
+      minimum: 0
+      exclusiveMinimum: false
+    GeographyCountrySubdivisionTrait:
+      type: string
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#GeographyCountrySubdivisionTrait
+      description: Constraint for defining a geography country subdivision in compliance to ISO 3166-2 as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      pattern: ([A-Z]{2}-[A-Z0-9]{1,3}|)
+    GeographyCountryTrait:
+      type: string
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#GeographyCountryTrait
+      description: Constraint for defining a geography country conform to ISO 3166CC as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      pattern: ([A-Z]{2})
+    GeographyRegionOrSubregionCharacteristic:
+      type: string
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#GeographyRegionOrSubregionCharacteristic
+      description: Characteristic for defining a list of valid geographic regions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example "Global" has been added to the value list.
+      enum:
+        - Africa
+        - Americas
+        - Asia
+        - Europe
+        - Oceania
+        - Australia and New Zealand
+        - Central Asia
+        - Eastern Asia
+        - Eastern Europe
+        - Latin America and the Caribbean
+        - Melanesia
+        - Micronesia
+        - Northern Africa
+        - Northern America
+        - Northern Europe
+        - Polynesia
+        - South-eastern Asia
+        - Southern Asia
+        - Southern Europe
+        - Sub-Saharan Africa
+        - Western Asia
+        - Western Europe
+        - Global
+        - Several
+    CrossSectoralStandardsUsedEnumerationCharacteristic:
+      type: string
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#CrossSectoralStandardsUsedEnumerationCharacteristic
+      description: Characteristic for defining the enumeration of valid accounting standards used for product carbon footprint calculation as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      enum:
+        - ISO Standard 14067
+        - ISO Standard 14044
+        - Pathfinder v1
+        - Pathfinder v2
+        - PAS 2050
+        - ISO Standard 14040
+        - ISO Standard 14041
+        - ISO Standard 14042
+        - ISO Standard 14043
+        - PEF
+        - Other
+        - GHG Protocol Product Standard
+    CrossSectoralStandard:
+      description: Entity for defining an accounting standard used for product carbon footprint calculation as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#CrossSectoralStandard
+      type: object
+      properties:
+        crossSectoralStandard:
+          description: 'Mandatory: Discloses a cross-sectoral standard applied for calculating or allocating GHG (Greenhouse Gas) emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#crossSectoralStandard
+          $ref: '#/components/schemas/CrossSectoralStandardsUsedEnumerationCharacteristic'
+      required:
+        - crossSectoralStandard
+    CrossSectoralStandardSet:
+      description: Characteristic for defining the list of valid accounting standards used for product carbon footprint calculation as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#CrossSectoralStandardSet
+      type: array
+      items:
+        $ref: '#/components/schemas/CrossSectoralStandard'
+    ProductOrSectorSpecificRuleOperator:
+      type: string
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#ProductOrSectorSpecificRuleOperator
+      description: Enumeration of PCR (Product Category Rule) operators as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension for example in Catena-X.
+      enum:
+        - PEF
+        - EPD International
+        - Other
+    RuleName:
+      description: Name of a rule applied by a specified operator as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#RuleName
+      type: object
+      properties:
+        ruleName:
+          description: Name of a rule applied by a specific operator as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#ruleName
+          $ref: '#/components/schemas/NonEmptyStringTrait'
+      required:
+        - ruleName
+    RuleNamesTrait:
+      description: Constraint for defining a non-empty set of rule names as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#RuleNamesTrait
+      type: array
+      items:
+        $ref: '#/components/schemas/RuleName'
+      uniqueItems: true
+      minItems: 1
+    ProductOrSectorSpecificRule:
+      description: Entity for defining a product or sector specific rule of a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#ProductOrSectorSpecificRule
+      type: object
+      properties:
+        extWBCSD_operator:
+          description: 'Mandatory: Operator of PCR (Product Category Rule)/ PSR (Product Specific Rule) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example must always be "Other".'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#operator
+          $ref: '#/components/schemas/ProductOrSectorSpecificRuleOperator'
+        productOrSectorSpecificRules:
+          description: 'Mandatory: Product-specific or sector-specific set of rules used for calculating or allocating GHG (Greenhouse Gas) emissions applied from the specified operator as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#ruleNames
+          $ref: '#/components/schemas/RuleNamesTrait'
+        extWBCSD_otherOperatorName:
+          description: 'Optional: Other operator of PCR (Product Category Rule)/ PSR (Product Specific Rule) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example specified by a default value.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#otherOperatorName
+          $ref: '#/components/schemas/NonEmptyStringTrait'
+      required:
+        - extWBCSD_operator
+        - productOrSectorSpecificRules
+    ProductOrSectorSpecificRuleSet:
+      description: Characteristic for defining the set of product or sector specific rules of a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#ProductOrSectorSpecificRuleSet
+      type: array
+      items:
+        $ref: '#/components/schemas/ProductOrSectorSpecificRule'
+      uniqueItems: true
+    CharacterizationFactorsCharacteristic:
+      type: string
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#CharacterizationFactorsCharacteristic
+      description: Characteristic for defining the characterization factors of a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example specified by a default value.
+      enum:
+        - AR5
+        - AR6
+    AllocationWasteIncinerationCharacteristic:
+      type: string
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#AllocationWasteIncinerationCharacteristic
+      description: Characteristic for defining the allocation approach used for waste incineration as specified by the TFS (Together For Sustainability) initiative.
+      enum:
+        - cut-off
+        - reverse cut-off
+        - system expansion
+    PercentTrait:
+      type: number
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#PercentTrait
+      description: Constraint for a decimal number in the range of and including 0 and 100.
+      maximum: 100
+      exclusiveMaximum: false
+      minimum: 0
+      exclusiveMinimum: false
+    EmissionFactorDS:
+      description: Entity for defining an emission factor data source used to calculate a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#EmissionFactorDS
+      type: object
+      properties:
+        secondaryEmissionFactorSource:
+          description: 'Mandatory: Emission factor data source used to calculate a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#emissionFactorDS
+          $ref: '#/components/schemas/Text'
+      required:
+        - secondaryEmissionFactorSource
+    EmissionFactorDSSet:
+      description: Characteristic for defining a set of emission factor sources used for calculating a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#EmissionFactorDSSet
+      type: array
+      items:
+        $ref: '#/components/schemas/EmissionFactorDS'
+      uniqueItems: true
+    DqiNumberTrait:
+      type: number
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#DqiNumberTrait
+      description: Constraint for defining a decimal between 1 and 3 including.
+      maximum: 3
+      exclusiveMaximum: false
+      minimum: 1
+      exclusiveMinimum: false
+    DataQualityIndicators:
+      description: Characteristic for defining the quantitative data quality indicators of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#DataQualityIndicators
+      type: object
+      properties:
+        coveragePercent:
+          description: 'Mandatory starting 2025: Percentage of PCF (Product Carbon Footprint) included in the data quality assessment based on the >5% emissions threshold as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example set to "100" per default.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#coveragePercent
+          $ref: '#/components/schemas/PercentTrait'
+        technologicalDQR:
+          description: 'Optional: Technological representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#technologicalDQR
+          $ref: '#/components/schemas/DqiNumberTrait'
+        temporalDQR:
+          description: 'Optional: Temporal representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#temporalDQR
+          $ref: '#/components/schemas/DqiNumberTrait'
+        geographicalDQR:
+          description: 'Optional: Geographical representativeness of the sources used for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#geographicalDQR
+          $ref: '#/components/schemas/DqiNumberTrait'
+        completenessDQR:
+          description: 'Optional: Completeness of the data collected for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#completenessDQR
+          $ref: '#/components/schemas/DqiNumberTrait'
+        reliabilityDQR:
+          description: 'Optional: Reliability of the data collected for PCF (Product Carbon Footprint) calculation based on weighted average of all inputs representing >5% of PCF emissions. Specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#reliabilityDQR
+          $ref: '#/components/schemas/DqiNumberTrait'
+    Boolean:
+      type: boolean
+      x-samm-aspect-model-urn: urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#Boolean
+      description: Represents a boolean value (i.e. a "flag").
+    PositiveEmissionsTrait:
+      type: number
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#PositiveEmissionsTrait
+      description: 'Only positive emission values (>0) are valid '
+      minimum: 0
+      exclusiveMinimum: false
+    PositiveOrNegativeEmission:
+      type: number
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#PositiveOrNegativeEmission
+      description: Characteristic for defining (positive or negative) emissions in context of a PCF (Product Carbon Footprint) as specified by the WBCSD (World Business Council for Sustainable Development) Pathfinder initiative.
+    NegativeEmissionsTrait:
+      type: number
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#NegativeEmissionsTrait
+      description: Only negative emission values (<=0) are valid.
+      maximum: 0
+      exclusiveMaximum: false
+    PcfEntity:
+      description: Entity for defining a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#PcfEntity
+      type: object
+      properties:
+        declaredUnit:
+          description: 'Mandatory: Unit of analysis of a product in context of the PCF (product carbon footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. In Catena-X for example list of valid units includes "piece".'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#declaredUnit
+          $ref: '#/components/schemas/DeclaredUnitCharacteristic'
+        unitaryProductAmount:
+          description: 'Mandatory: Amount of units contained within a product in context of the PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#unitaryProductAmount
+          $ref: '#/components/schemas/StrictlyPositiveDecimalTrait'
+        productMassPerDeclaredUnit:
+          description: 'Mandatory: Mass of a product per declared unit (net, unpackaged) in context of the PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0).'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#productMassPerDeclaredUnit
+          $ref: '#/components/schemas/PositiveDecimalWeightTrait'
+        exemptedEmissionsPercent:
+          description: |-
+            Mandatory: Applied cut-off percentage of emissions excluded from PCF (Product Carbon Footprint).
+            For accordance with Catena-X PCF Rulebook (Version 3.0.0) <3%.
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#exemptedEmissionsPercent
+          $ref: '#/components/schemas/ExemptedEmissionsPercentTrait'
+        exemptedEmissionsDescription:
+          description: 'Optional: Rationale behind exclusion of specific PCF (Product Carbon Footprint) emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#exemptedEmissionsDescription
+          $ref: '#/components/schemas/Text'
+        boundaryProcessesDescription:
+          description: 'Optional: Processes attributable to each lifecycle stage as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#boundaryProcessesDescription
+          $ref: '#/components/schemas/Text'
+        geographyCountrySubdivision:
+          description: 'Optional: Subdivision of a country which must be an ISO 3166-2 subdivision code as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#geographyCountrySubdivision
+          $ref: '#/components/schemas/GeographyCountrySubdivisionTrait'
+        geographyCountry:
+          description: 'Optional: Two letter country code that must conform to data type ISO 3166CC as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#geographyCountry
+          $ref: '#/components/schemas/GeographyCountryTrait'
+        geographyRegionOrSubregion:
+          description: 'Mandatory: Region according to list as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#geographyRegionOrSubregion
+          $ref: '#/components/schemas/GeographyRegionOrSubregionCharacteristic'
+        referencePeriodStart:
+          description: 'Mandatory: Start of time boundary for which a PCF (Product Carbon Footprint) value is considered to be representative as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#referencePeriodStart
+          $ref: '#/components/schemas/Timestamp'
+        referencePeriodEnd:
+          description: 'Mandatory: End of time boundary for which a PCF (Product Carbon Footprint) value is considered to be representative as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#referencePeriodEnd
+          $ref: '#/components/schemas/Timestamp'
+        crossSectoralStandardsUsed:
+          description: 'Mandatory: Discloses the cross-sectoral standards applied for calculating or allocating GHG (Greenhouse Gas) emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#crossSectoralStandardsUsed
+          $ref: '#/components/schemas/CrossSectoralStandardSet'
+        productOrSectorSpecificRules:
+          description: 'Mandatory: Product or sector specific rules applied for calculating or allocating GHG (Greenhouse Gas) emissions, e.g. PCRs (Product Category Rules), including operators or publishers and according rule names as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#productOrSectorSpecificRules
+          $ref: '#/components/schemas/ProductOrSectorSpecificRuleSet'
+        extWBCSD_characterizationFactors:
+          description: 'Mandatory: IPCC (Intergovernmental Panel on Climate Change) version of the GWP (Global Warming Potential) characterization factors used for calculating the PCF (Product Carbon Footprint) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example specified by default with value \"AR6\". Default value can be overwritten.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#characterizationFactors
+          $ref: '#/components/schemas/CharacterizationFactorsCharacteristic'
+        extWBCSD_allocationRulesDescription:
+          description: 'Optional: Allocation rules used and underlying reasoning in context of a product carbon footprint as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension, in Catena-X for example specified by default with value "In accordance with Catena-X PCF Rulebook (Version 3.0.0)".'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#allocationRulesDescription
+          $ref: '#/components/schemas/Text'
+        extTFS_allocationWasteIncineration:
+          description: 'Mandatory: Allocation approach used for waste incineration with energy recovery as specified by the TFS (Together For Sustainability) initiative. In Catena-X for example must be specified by value "cut-off".'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#allocationWasteIncineration
+          $ref: '#/components/schemas/AllocationWasteIncinerationCharacteristic'
+        primaryDataShare:
+          description: 'Mandatory starting 2025: Share of primary data in percent as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#primaryDataShare
+          $ref: '#/components/schemas/PercentTrait'
+        secondaryEmissionFactorSources:
+          description: 'Mandatory: Emission factors used for the PCF (Product Carbon Footprint) calculation as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#secondaryEmissionFactorSources
+          $ref: '#/components/schemas/EmissionFactorDSSet'
+        dataQualityRating:
+          description: 'Mandatory starting 2025: Quantitative data quality indicators of a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#dqi
+          $ref: '#/components/schemas/DataQualityIndicators'
+        extWBCSD_packagingEmissionsIncluded:
+          description: |-
+            Mandatory: The Catena-X PCF Rulebook requires to include packaging from a system boundary perspective. "FALSE" is only possible due to the application of the cut-off rule.
+            Flag indicating whether packaging emissions are included in a PCF (Product Carbon Footprint) as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension.
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#packagingEmissionsIncluded
+          $ref: '#/components/schemas/Boolean'
+        pcfExcludingBiogenic:
+          description: 'Mandatory: Product carbon footprint of a product excluding biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#pcfExcludingBiogenic
+          $ref: '#/components/schemas/PositiveEmissionsTrait'
+        pcfIncludingBiogenic:
+          description: 'Mandatory starting 2025: Product carbon footprint of a product including biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Optional value in current specification version but will be mandatory in future version.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#pcfIncludingBiogenic
+          $ref: '#/components/schemas/PositiveOrNegativeEmission'
+        fossilGhgEmissions:
+          description: 'Mandatory starting 2025: Emissions from combustion of fossil sources as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Identical to "pcfExcludingBiogenic", will be removed in later version.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#fossilGhgEmissions
+          $ref: '#/components/schemas/PositiveEmissionsTrait'
+        biogenicCarbonEmissionsOtherThanCO2:
+          description: 'Mandatory starting 2025: GWP (Global Warming Potential) of biogenic CO2e-emissions in production phase which contain only GHG (Greenhouse Gas) emissions other than CO2 - excludes biogenic CO2. For specification see Catena-X PCF Rulebook (Version 3.0.0).'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#biogenicCarbonEmissionsOtherThanCO2
+          $ref: '#/components/schemas/PositiveEmissionsTrait'
+        biogenicCarbonWithdrawal:
+          description: 'Mandatory starting 2025: Biogenic carbon content in the product converted to CO2e as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#biogenicCarbonWithdrawal
+          $ref: '#/components/schemas/NegativeEmissionsTrait'
+        dlucGhgEmissions:
+          description: 'Mandatory starting 2025: Direct land use change CO2e emissions in context of a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#dlucGhgEmissions
+          $ref: '#/components/schemas/PositiveEmissionsTrait'
+        extTFS_luGhgEmissions:
+          description: 'Mandatory starting 2025: Land use CO2 emissions in context of a product carbon footprint as specified by the TFS (Together For Sustainability) initiative. TFS specific extension.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#luGhgEmissions
+          $ref: '#/components/schemas/PositiveOrNegativeEmission'
+        aircraftGhgEmissions:
+          description: 'Mandatory starting 2025: GHG (Greenhouse Gas) emissions resulting from aircraft engine usage for the transport of the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#aircraftGhgEmissions
+          $ref: '#/components/schemas/PositiveEmissionsTrait'
+        extWBCSD_packagingGhgEmissions:
+          description: 'Optional: Emissions resulting from the packaging of the product as specified in the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. WBCSD specific extension. In Catena-X not relevant to be reported separately.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#packagingGhgEmissions
+          $ref: '#/components/schemas/PositiveEmissionsTrait'
+        distributionStagePcfExcludingBiogenic:
+          description: 'Optional: Product carbon footprint for the distribution stage of a product excluding biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0).'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#distributionStagePcfExcludingBiogenic
+          $ref: '#/components/schemas/PositiveEmissionsTrait'
+        distributionStagePcfIncludingBiogenic:
+          description: 'Optional: Product carbon footprint for the distribution stage of a product including biogenic emissions as specified in the Catena-X PCF Rulebook (Version 3.0.0).'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#distributionStagePcfIncludingBiogenic
+          $ref: '#/components/schemas/PositiveOrNegativeEmission'
+        distributionStageFossilGhgEmissions:
+          description: 'Optional: Emissions from the combustion of fossil sources in the distribution stage as specified in the Catena-X PCF Rulebook (Version 3.0.0).'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#distributionStageFossilGhgEmissions
+          $ref: '#/components/schemas/PositiveEmissionsTrait'
+        distributionStageBiogenicCarbonEmissionsOtherThanCO2:
+          description: 'Optional: GWP (Global Warming Potential) of biogenic CO2e-emissions in distribution phase which contain only GHG (Greenhouse Gas) emissions other than CO2 ? excludes biogenic CO2. For specification see Catena-X PCF Rulebook (Version 3.0.0).'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#distributionStageBiogenicCarbonEmissionsOtherThanCO2
+          $ref: '#/components/schemas/PositiveEmissionsTrait'
+        distributionStageBiogenicCarbonWithdrawal:
+          description: 'Optional: GWP (Global Warming Potential) of biogenic CO2-withdrawal in distribution stage (biogenic CO2 contained in the product) as specified in the Catena-X PCF Rulebook (Version 3.0.0).'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#distributionStageBiogenicCarbonWithdrawal
+          $ref: '#/components/schemas/NegativeEmissionsTrait'
+        extTFS_distributionStageDlucGhgEmissions:
+          description: 'Optional: Direct land use change CO2 emissions during distribution stage in context of a product carbon footprint as specified by the TFS (Together For Sustainability) initiative. TFS specific extension.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#distributionStageDlucGhgEmissions
+          $ref: '#/components/schemas/PositiveEmissionsTrait'
+        extTFS_distributionStageLuGhgEmissions:
+          description: 'Optional: Land use CO2 emissions in context of a product carbon footprint as specified by the TFS (Together For Sustainability) initiative. TFS specific extension.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#distributionStageLuGhgEmissions
+          $ref: '#/components/schemas/PositiveOrNegativeEmission'
+        carbonContentTotal:
+          description: 'Mandatory starting 2025: Total carbon content per declared unit in context of a product carbon footprint as specified in the Catena-X PCF Rulebook (Version 3.0.0).'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#carbonContentTotal
+          $ref: '#/components/schemas/PositiveEmissionsTrait'
+        extWBCSD_fossilCarbonContent:
+          description: 'Mandatory starting 2025: Fossil carbon amount embodied in a product as specified in the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Must be calculated with kgC (kilogram Carbon) / declaredUnit equal to or greater zero; WBCSD specific extension, in Catena-X specified by a calculated value.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#fossilCarbonContent
+          $ref: '#/components/schemas/PositiveEmissionsTrait'
+        carbonContentBiogenic:
+          description: 'Mandatory starting 2025: Biogenic carbon amount embodied in a product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.1.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative. Must be calculated with kgC (kilogram Carbon) / declaredUnit equal to or greater zero.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#biogenicCarbonContent
+          $ref: '#/components/schemas/PositiveEmissionsTrait'
+        distributionStageAircraftGhgEmissions:
+          description: 'Optional: GHG (Greenhouse Gas) emissions for the distribution stage resulting from aircraft engine usage for the transport of the product as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.'
+          x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#distributionStageAircraftGhgEmissions
+          $ref: '#/components/schemas/PositiveEmissionsTrait'
+      required:
+        - declaredUnit
+        - unitaryProductAmount
+        - productMassPerDeclaredUnit
+        - exemptedEmissionsPercent
+        - geographyRegionOrSubregion
+        - referencePeriodStart
+        - referencePeriodEnd
+        - crossSectoralStandardsUsed
+        - productOrSectorSpecificRules
+        - extWBCSD_characterizationFactors
+        - extTFS_allocationWasteIncineration
+        - secondaryEmissionFactorSources
+        - extWBCSD_packagingEmissionsIncluded
+        - pcfExcludingBiogenic
+    CarbonFootprint:
+      description: Characteristic for defining a PCF (Product Carbon Footprint) as specified in the Catena-X PCF Rulebook (Version 3.0.0) in accordance with the technical specifications for PCF Data Exchange (Version 2.0.0) from the WBCSD (World Business Council for Sustainable Development)/ PACT initiative.
+      x-samm-aspect-model-urn: urn:samm:io.catenax.pcf:7.0.0#CarbonFootprint
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/PcfEntity'


### PR DESCRIPTION
## Description

This PR add the new API version 1.1.2 to the KIT itself and also to the API Hub. The related yaml file was taken (as discussed) from this [source](https://github.com/catenax-eV/product-standardization-prod/blob/8ac803075b78db3f3a74b0c0d9b8edb3f93d3d3e/standards/CX-0136-UseCasePCF/assets/catena-x-pcf-endpoint-1_1_2.yaml) -> closed repository, since it was developed there.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
