### PR TITLE
docs(office-hour): add office hour agenda

### DIFF
--- a/blog-meeting-minutes/2025-09-26-community-hour.md
+++ b/blog-meeting-minutes/2025-09-26-community-hour.md
@@ -1,0 +1,59 @@
+---
+slug: community-office-hour-2025-09-26
+title: Community Office Hour 2025-09-26
+authors:
+    - phil91
+    - stephan_bauer
+tags: [community, meeting-minutes]
+---
+
+## Office Hour meeting minutes
+
+### Infrastructure Test Management
+
+- **GNI X-Ray Test Sessions**:  
+    2 sessions held; no active registrations.  
+    Keep status _in progress_ for potential October session.
+- **External Product Test Phase**:  
+    Release Candidate 3 published by Lars & team; some issues remain.  
+    Next evaluation meeting on Tuesday.  
+    Confirmed: Catena-X **does not** provide dedicated dev environments — teams are responsible for their own.
+
+### Release Management
+
+- Release postponed; target Tuesday/Wednesday.
+- **Preparation**:
+    - Change logs ready for review (Teresa prepared initial version).
+    - Need contributions for _Known Issues_ and _product-specific notes_ (e.g. BPDM, Connector).
+- **Screenshots in Release Notes**: Discuss post-release.
+- **Changelog Improvement Idea**: Block-format inspired by _Docusaurus_ for better presentation.
+
+### Security
+
+- Reminder: Check the security tab regularly.
+- Deprecation of "Digital Product as Repository of Surveillance" planned next week.
+- Plan to migrate VP visualization to _Industry Core_.
+
+### Community & Events
+
+- **Catena-X Community Days** (End of December): Registration open.
+    - New field to list products you contributed to.
+    - Multiple select option fixed.
+    - Booking changes may require cancel/re-register.
+- Call for workshop leaders/presenters.
+- New “Community Events” room created for event promotion and discussions.
+
+### Committer Election
+
+- **Andrii** proposed as new committer — key contributions on EDC component, DSP/DCP TCK, release process improvements.
+
+### General Reminders
+
+- Moderation list update needed (René added).
+- No office hour next week due to public holiday in Germany.
+
+### GitHub Fork Access Clarification
+
+- Forks in _private accounts_ do **not** inherit original repo’s write access.  
+    Owner must explicitly grant rights.  
+    Public forks: read-only access by default.


### PR DESCRIPTION
## Description

This pull request adds the meeting minutes for the Community Office Hour held on September 26, 2025. The document covers updates and decisions across infrastructure test management, release planning, security, community events, committer election, and general reminders.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files