### PR TITLE
docs(office-hour-meeting minutes): create new meeting minutes for cw41

### DIFF
--- a/blog-meeting-minutes/2025-10-10-community-hour.md
+++ b/blog-meeting-minutes/2025-10-10-community-hour.md
@@ -41,7 +41,7 @@ tags: [community, meeting-minutes]
 
 - **Theresa** nominated as committer (focus: release management).
 - Election closing next Thursday; committers asked to vote.
-- Andriis PMC election pending next PMC Monday meeting.
+- Andrii's PMC election pending next PMC Monday meeting.
 
 ### Community Days
 


### PR DESCRIPTION
## Description

This pull request adds the meeting minutes for the Community Office Hour held on October 10, 2025. The minutes cover key updates on the upcoming release, documentation changes, governance decisions, moderation planning, committer elections, event planning, security reminders, and technical discussions regarding the Postgres image source.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
