### PR TITLE
docs(release-planning): add release planning information for 26.03

### DIFF
--- a/blog/2025-10-15-release-planning-R26.03.md
+++ b/blog/2025-10-15-release-planning-R26.03.md
@@ -1,0 +1,142 @@
+---
+title: Release Planning for Release 26.03
+description: Eclipse Tractus-X Community Update - Release Planning for Release 26.03
+slug: release-planning-R26.03
+date: 2025-10-15T19:00
+hide_table_of_contents: false
+authors:
+  - stephan_bauer
+  - theresa_hilger
+---
+
+[![Eclipse Tractus-X Open Planning Banner](/img/Tractus-X_openplanning.png)](/img/Tractus-X_openplanning.png)
+
+Hello, Eclipse Tractus-X Community!
+
+Collaboration drives the success of Eclipse Tractus-X, and we are excited to invite you to the Release Planning sessions for **R26.03**! These sessions are your chance to shape the roadmap,
+align with the community, and ensure a well-structured release.
+
+Rooms for Discussion and Planning:
+- [Release Management](https://matrix.to/#/#tractusx-release-planning:matrix.eclipse.org)
+- [Test Management](https://matrix.to/#/#tractusx-test-management:matrix.eclipse.org)
+
+Key Information:
+
+- Dates and Times: Listed for each session below.
+- Resources: Visit our [open meetings page](/community/open-meetings#one-time-meetings) for all session links and additional documentation.
+- Preparation Materials: Ensure readiness by reviewing the provided templates, guidelines, and your own features.
+
+We look forward to seeing you there and working together to make **R26.03** a success!
+
+<!--truncate-->
+
+## Alignment Day for R26.03
+
+The Alignment Day focuses on addressing open questions and unresolved dependencies from features planned for Release 26.03. This means we are highly
+dependent on your questions. We want to align and get a better understanding about the related features. This meeting is a possibility to connect.
+
+:::tip
+
+Even if you don't have questions, it could be interesting anyway.
+
+:::
+
+- Date: 30.10.2025
+- Time: 09:05 - 10:45
+- Main Teams Link: [Join the session](https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZWUzMmU2ODktMTU0OS00MjM5LTk0MDYtM2UxYmI5OTE1ZDE5%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22c4f4cd17-5452-4057-9b00-42444990d814%22%7d)
+
+### Agenda {#agenda-1}
+
+:::info
+The agenda itself is dependent on the labeled features.
+:::
+
+- 09:05 - 09:20: Welcome and overview of Open Discussion features
+- 09:20 - 10:30: Group discussions and breakout sessions as needed
+- 10:30 - 10:45: (Optional) closing and documentation of decisions
+
+### Key Focus Areas
+
+- Only features labeled `open question` will be considered for the agenda.
+- The label must be added at least 3 days prior to the event.
+- This is not a planning or refinement session — it’s a space to align on open questions and clarify remaining uncertainties.
+- Feature owners should be ready to describe their needs or concerns.
+- Component developers can use this session to clarify what is expected from them.
+
+## Open Planning for R26.03
+
+The Open Planning session finalizes the roadmap for **R26.03**, prioritizing features and aligning all participants on deliverables for the release.
+
+- Date: 13.11.2025
+- Time: 09:05 - 12:15
+- Teams Link: [Join the session](https://teams.microsoft.com/l/meetup-join/19%3ameeting_MjM4YTAwYWItMWU0Ny00NzU5LWFlZmYtYWRkZGQyMWRlMTM2%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22c4f4cd17-5452-4057-9b00-42444990d814%22%7d)
+
+Who Should Attend:
+
+- Contributors and Committers from the open-source community
+- Expert Group and Committee members
+- Feature requesters and stakeholders
+
+:::note
+Your participation is crucial to ensure the success of the release planning. Expert Groups, Committees, the open-source community (contributor and committer), feature requesters are encouraged to attend and actively engage in the discussions.
+:::
+
+### Agenda
+
+Here’s the plan for the day:
+
+- 09:05 - 09:20: Open Planning - Vision & Introduction
+- 09:20 - 12:00: Joint Open Planning (all teams)
+- 12:00 - 12:15: Feedback Retro / Open Planning Wrap-up / Summary & Next Steps
+
+#### Joint Open Planning
+
+:::note
+The planning sessions will be driven by our [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26/views/43?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R26.03%22+status%3ABacklog), which organizes
+features based on their `Topic/Product` field. The current agenda is only an example and will be updated with the actual features that are planned for **R26.03**.
+:::
+
+| Time          | Topics                                | [Features](https://github.com/orgs/eclipse-tractusx/projects/26/views/43) |
+|---------------|---------------------------------------|---------------------------------------------------------------------------|
+| 09:05 – 09:20 | Open Planning - Vision & Introduction | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+| 09:20 – 09:25 | PCF                                   | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+| 09:25 – 09:35 | Circularity                           | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+| 09:35 – 10:10 | Dataspace Connectivity                | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+| 10:10 – 10:30 | BPDM                                  | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+| 10:30 – 10:50 | Portal                                | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+| 10:50 – 11:05 | SSI                                   | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+| 11:05 – 11:15 | Traceability                          | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+| 11:15 – 11:25 | DCM                                   | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+| 11:25 – 11:30 | OSIM                                  | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+| 11:30 – 11:35 | PURIS                                 | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+| 11:35 – 11:50 | Industry Core                         | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+| 11:50 – 11:55 | Digital Twin                          | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+| 11:55 – 12:00 | Testmanagement                        | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+| 12:00 – 12:15 | Miscellaneous and Closing             | [Link](https://github.com/orgs/eclipse-tractusx/projects/26/views/43)     |
+
+:::warning[Please note]
+- The agenda provides a rough time structure to help guide the session. The timings are not fixed and can be adjusted depending on the flow of the discussion.
+- Use the agenda as orientation, but we may deviate if needed based on progress.
+:::
+
+### Prerequisites for features to be considered in Open Planning
+
+For a feature to be included in the Open Planning, the following conditions must be met:
+
+- Status must be `Backlog – Committers and Expert Groups can set this status after the feature is fully refined.
+- All categories in the feature template must be filled – Do not delete any sections from the template.
+- Milestone is NOT set – This will be assigned during the Open Planning session.
+- Contributor and Committer must be assigned.
+- Topic/Product must be set.
+
+During the session, if there is a common alignment among the participants, the feature milestone can be set to 26.03, meaning it will be developed in the upcoming release.
+
+### Important Notes and Hints
+
+- Keep the board clean – there are still features with older milestones that have not yet been completed.
+- Do not delete any sections from the feature template, except for KITs.
+- For KITs, only the Contributor, Committer, and Description fields need to be filled.
+
+For any questions or further information, feel free to reach out via our [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) or join us in the Tractus-X [Matrix channel](https://matrix.to/#/#automotive.tractusx:matrix.eclipse.org).
+
+We look forward to your participation and collaboration! 🚀

--- a/community/open-meetings.mdx
+++ b/community/open-meetings.mdx
@@ -21,11 +21,11 @@ All the times are shown in:
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MDFiNDJjMmQtNjFkYi00ODdjLTk2NDgtZGMwNTRmYzg3NzM0%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
              additionalLinks={
-                [
-                    {title: 'Taskboard', url: 'https://github.com/orgs/eclipse-tractusx/projects/61/views/1'},
-                    {title: 'Meeting minutes', url: '/community/meeting-minutes/tags/community'},
-                    {title: 'Timelines', url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/35'},
-                ]
+               [
+                 {title: 'Taskboard', url: 'https://github.com/orgs/eclipse-tractusx/projects/61/views/1'},
+                 {title: 'Meeting minutes', url: '/community/meeting-minutes/tags/community'},
+                 {title: 'Timelines', url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/35'},
+               ]
              }
 />
 
@@ -42,10 +42,10 @@ All the times are shown in:
              contact="stephan.bauer@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZjlmNTc5MjMtN2Y2YS00YjliLTg3NTItNWE1MmMzMWUzNmYw%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
              additionalLinks={
-                [
-                    {title: 'Taskboard', url: 'https://github.com/orgs/eclipse-tractusx/projects/61/views/6'},
-                    {title: 'Timelines', url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/35'},
-                ]
+               [
+                 {title: 'Taskboard', url: 'https://github.com/orgs/eclipse-tractusx/projects/61/views/6'},
+                 {title: 'Timelines', url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/35'},
+               ]
              }
 />
 
@@ -57,15 +57,27 @@ All the times are shown in:
              contact="mathias.moser@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MGJlYzgzMjktNWE4OS00NjcwLWIyOGYtZDgzYmMzODRiMTgy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d"
              additionalLinks={
-                [
-                    {title: 'Industry Core Hub Matrix Chat', url: 'https://matrix.to/#/#tractusx-industry-core-hub:matrix.eclipse.org'},
-                    {title: 'industry-core-hub Repository', url: 'https://github.com/eclipse-tractusx/industry-core-hub'},
-                    {title: 'tractusx-sdk Repository', url: 'https://github.com/eclipse-tractusx/tractusx-sdk'},
-                    {title: 'Planning Board Project', url: 'https://github.com/orgs/eclipse-tractusx/projects/83'},
-                    {title: 'Backend & TX-SDK Weekly - Monday 10:00 am to 10:30 am', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODU0ZDk3MjUtNjkzMS00MzQzLWFmZGYtY2Q3YWEzZmVjNmMx%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
-                    {title: 'Frontend Weekly - Tuesday 02:00 pm to 02:30 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODUyNWQxMzAtMWE0ZC00Mjc2LTgzYzAtNTc0ZGFiZDllNmQy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'},
-                    {title: 'Architecture Weekly - Thursday 01:00 pm to 02:00 pm', url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_YzYyMDUyZjMtMmFlMy00ODMyLWFlZDQtNjMwYWZhOTc3YTVh%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'}
-                ]
+               [
+                 {
+                   title: 'Industry Core Hub Matrix Chat',
+                   url: 'https://matrix.to/#/#tractusx-industry-core-hub:matrix.eclipse.org'
+                 },
+                 {title: 'industry-core-hub Repository', url: 'https://github.com/eclipse-tractusx/industry-core-hub'},
+                 {title: 'tractusx-sdk Repository', url: 'https://github.com/eclipse-tractusx/tractusx-sdk'},
+                 {title: 'Planning Board Project', url: 'https://github.com/orgs/eclipse-tractusx/projects/83'},
+                 {
+                   title: 'Backend & TX-SDK Weekly - Monday 10:00 am to 10:30 am',
+                   url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODU0ZDk3MjUtNjkzMS00MzQzLWFmZGYtY2Q3YWEzZmVjNmMx%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'
+                 },
+                 {
+                   title: 'Frontend Weekly - Tuesday 02:00 pm to 02:30 pm',
+                   url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODUyNWQxMzAtMWE0ZC00Mjc2LTgzYzAtNTc0ZGFiZDllNmQy%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'
+                 },
+                 {
+                   title: 'Architecture Weekly - Thursday 01:00 pm to 02:00 pm',
+                   url: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_YzYyMDUyZjMtMmFlMy00ODMyLWFlZDQtNjMwYWZhOTc3YTVh%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d'
+                 }
+               ]
              }
 />
 
@@ -82,11 +94,17 @@ All the times are shown in:
              contact="mathias.moser@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_NTIxMmIyMmItYTk0NC00YjMxLWFiNDAtOTRlOWM1ZDUxYWRm%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%2279a55f91-092d-4603-8fa9-c88b54ff2fe9%22%7d"
              additionalLinks={
-                [
-                    {title: 'Identity Hub Matrix Chat', url: 'https://matrix.eecc.de/#/room/#tractusx-identity-hub:matrix.eclipse.org'},
-                    {title: 'tractusx-identityhub Repository', url: 'https://github.com/eclipse-tractusx/tractusx-identityhub'},
-                    {title: 'Planning Board', url: 'https://github.com/orgs/eclipse-tractusx/projects/87/views/1'},
-                ]
+               [
+                 {
+                   title: 'Identity Hub Matrix Chat',
+                   url: 'https://matrix.eecc.de/#/room/#tractusx-identity-hub:matrix.eclipse.org'
+                 },
+                 {
+                   title: 'tractusx-identityhub Repository',
+                   url: 'https://github.com/eclipse-tractusx/tractusx-identityhub'
+                 },
+                 {title: 'Planning Board', url: 'https://github.com/orgs/eclipse-tractusx/projects/87/views/1'},
+               ]
              }
 />
 
@@ -96,10 +114,13 @@ All the times are shown in:
              contact="saad.rafiq@cofinity-x.com"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_YmIyYjgwOTQtZjI1Ny00YmM0LTlmOWQtODRjZWFmZWM1Y2E3%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d"
              additionalLinks={
-                [
-                    {title: 'Portal Matrix Chat', url: 'https://chat.eclipse.org/#/room/#tractusx-portal:matrix.eclipse.org'},
-                    {title: 'Feature Board', url: 'https://github.com/orgs/eclipse-tractusx/projects/50/views/25'},
-                ]
+               [
+                 {
+                   title: 'Portal Matrix Chat',
+                   url: 'https://chat.eclipse.org/#/room/#tractusx-portal:matrix.eclipse.org'
+                 },
+                 {title: 'Feature Board', url: 'https://github.com/orgs/eclipse-tractusx/projects/50/views/25'},
+               ]
              }
 />
 
@@ -109,10 +130,13 @@ All the times are shown in:
              contact="mgarcia@lksnext.com"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19:meeting_ODMzMzMxY2MtMGI4ZC00MjJkLThjZjYtMzk3ZjBjMmEzYjZj@thread.v2/0?context=%7B%22Tid%22:%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22,%22Oid%22:%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7D"
              additionalLinks={
-                [
-                    {title: 'Umbrella Repository', url: 'https://github.com/eclipse-tractusx/tractus-x-umbrella'},
-                    {title: 'Umbrella Matrix Chat', url: 'https://chat.eclipse.org/#/room/#tractusx-umbrella-chart:matrix.eclipse.org'},
-                ]
+               [
+                 {title: 'Umbrella Repository', url: 'https://github.com/eclipse-tractusx/tractus-x-umbrella'},
+                 {
+                   title: 'Umbrella Matrix Chat',
+                   url: 'https://chat.eclipse.org/#/room/#tractusx-umbrella-chart:matrix.eclipse.org'
+                 },
+               ]
              }
 />
 
@@ -122,9 +146,9 @@ All the times are shown in:
              contact="sujit.karne@mercedes-benz.com"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_OGYxZjQ4NzItNjc1OC00YjEyLWI2NjYtNThjNDBmMGI0MTk4%40thread.v2/0?context=%7b%22Tid%22%3a%229652d7c2-1ccf-4940-8151-4a92bd474ed0%22%2c%22Oid%22%3a%221cad1acb-7d7b-4e88-bc6b-875078a66bdf%22%7d"
              additionalLinks={
-                [
-                    {title: 'BPDM Matrix Chat', url: 'https://chat.eclipse.org/#/room/#tractusx-bpdm:matrix.eclipse.org'},
-                ]
+               [
+                 {title: 'BPDM Matrix Chat', url: 'https://chat.eclipse.org/#/room/#tractusx-bpdm:matrix.eclipse.org'},
+               ]
              }
 />
 
@@ -134,42 +158,66 @@ All the times are shown in:
              contact="johann.schuetz@catena-x.net"
              sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2I5MjM1NzUtZmFmZS00MTI2LTgyMmEtOGZiMDMxNmRlYTA4%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22bf6c04e8-bde4-4ca1-ac15-0f85f440ab48%22%7d"
              additionalLinks={
-                [
-                    {title: 'SLDT Semantic Models Repository', url: 'https://github.com/eclipse-tractusx/sldt-semantic-models'},
-                    {title: 'SLDT Ontology Models Repository', url: 'https://github.com/eclipse-tractusx/sldt-ontology-model'}
-                ]
+               [
+                 {
+                   title: 'SLDT Semantic Models Repository',
+                   url: 'https://github.com/eclipse-tractusx/sldt-semantic-models'
+                 },
+                 {
+                   title: 'SLDT Ontology Models Repository',
+                   url: 'https://github.com/eclipse-tractusx/sldt-ontology-model'
+                 }
+               ]
              }
 />
 
 ## One-time meetings
 
-<MeetingInfo title="Alignment Day for R25.12"
-             schedule="Thursday, 31. July 2025 from 09:05 AM to 12:00 AM"
-             description="Based on a predefined agenda (depending on the features on the board with label Open Question), individual dependencies are discussed and also documented directly on the feature.."
+<MeetingInfo title="Alignment Day for R26.03"
+             schedule="Thursday, 30. October 2025 from 09:05 AM to 10:45 AM"
+             description="Based on a predefined agenda (depending on the features on the board with label Open Question), individual dependencies are discussed and also documented directly on the feature."
              contact="stephan.bauer@catena-x.net"
-             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ODg5N2NlY2QtNzc2My00ZGJkLWIxNzMtNTFmZGQwZTc2NzU2%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22c4f4cd17-5452-4057-9b00-42444990d814%22%7d"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZWUzMmU2ODktMTU0OS00MjM5LTk0MDYtM2UxYmI5OTE1ZDE5%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22c4f4cd17-5452-4057-9b00-42444990d814%22%7d"
              additionalLinks={
-                 [
-                     {title: "Release Planning Board - Open Question", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/40?filterQuery=-label%3Ametadata+label%3APrep-R25.12+label%3A%22open+question%22"},
-                     {title: "Timeline", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A%2225.12%22"},
-                     {title: "News Blog", url: "/blog/release-planning-R25.12"},
-                     {title: "Release Planning Matrix Chat", url: "https://matrix.to/#/#tractusx-release-planning:matrix.eclipse.org"}
-                 ]
+               [
+                 {
+                   title: "Release Planning Board - Open Question",
+                   url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/43?filterQuery=-label%3Ametadata+label%3APrep-R26.03+label%3A%22open+question%22"
+                 },
+                 {
+                   title: "Timeline",
+                   url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A26.03"
+                 },
+                 {title: "News Blog", url: "/blog/release-planning-R26.03"},
+                 {
+                   title: "Release Planning Matrix Chat",
+                   url: "https://matrix.to/#/#tractusx-release-planning:matrix.eclipse.org"
+                 }
+               ]
              }
 />
 
-<MeetingInfo title="Open Planning for R25.12"
-             schedule="Thursday, 14. August 2025 from 09:05 AM to 02:30 PM"
+<MeetingInfo title="Open Planning for R26.03"
+             schedule="Thursday, 13. November 2025 from 09:05 AM to 12:15 PM"
              description="The goal for this meeting is planning of the intended work content for the next release - which contains also preparation of future release content, refactoring, general architectural work, tool & process improvements, and feature planning for the next Tractus-X release."
              contact="stephan.bauer@catena-x.net"
-             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_Y2YwYjBlYWQtY2JmNy00YjkxLWFjNTktZTJiM2ZlYmIzNGQ1%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22c4f4cd17-5452-4057-9b00-42444990d814%22%7d"
+             sessionLink="https://teams.microsoft.com/l/meetup-join/19%3ameeting_MjM4YTAwYWItMWU0Ny00NzU5LWFlZmYtYWRkZGQyMWRlMTM2%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22c4f4cd17-5452-4057-9b00-42444990d814%22%7d"
              additionalLinks={
-                 [
-                     {title: "Release Planning Board - Topic/Product", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R25.12%22+status%3ABacklog"},
-                     {title: "Timeline", url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A%2225.12%22"},
-                     {title: "News Blog", url: "/blog/release-planning-R25.12"},
-                     {title: "Detailed Agenda", url: "/blog/release-planning-R25.12#agenda-1"},
-                     {title: "Release Planning Matrix Chat", url: "https://matrix.to/#/#tractusx-release-planning:matrix.eclipse.org"}
-                 ]
+               [
+                 {
+                   title: "Release Planning Board - Topic/Product",
+                   url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R26.03%22+status%3ABacklog"
+                 },
+                 {
+                   title: "Timeline",
+                   url: "https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A26.03"
+                 },
+                 {title: "News Blog", url: "/blog/release-planning-R26.03"},
+                 {title: "Detailed Agenda", url: "/blog/release-planning-R26.03#agenda-1"},
+                 {
+                   title: "Release Planning Matrix Chat",
+                   url: "https://matrix.to/#/#tractusx-release-planning:matrix.eclipse.org"
+                 }
+               ]
              }
 />

--- a/utils/newsTitles.js
+++ b/utils/newsTitles.js
@@ -1,12 +1,22 @@
 export const newsTitles = [
-    {
-        date: "04.12.2025",
-        title: "Fifth Eclipse Tractus-X Community Days",
-        blogLink: "/blog/community-days-12-2025"
-    },
-    {
-        date: "01.07.2025",
-        title: "Tractus-X Community Update - Release Planning for Release 25.12",
-        blogLink: "/blog/release-planning-R25.12"
-    },
+  {
+    date: "30.10.2025",
+    title: "Tractus-X Community Update - Alignment Day for Release 26.03",
+    blogLink: "/blog/release-planning-R26.03"
+  },
+  {
+    date: "13.11.2025",
+    title: "Tractus-X Community Update - Open Planning for Release 26.03",
+    blogLink: "/blog/release-planning-R26.03"
+  },
+  {
+    date: "04.12.2025",
+    title: "Fifth Eclipse Tractus-X Community Days",
+    blogLink: "/blog/community-days-12-2025"
+  },
+  {
+    date: "01.07.2025",
+    title: "Tractus-X Community Update - Release Planning for Release 25.12",
+    blogLink: "/blog/release-planning-R25.12"
+  },
 ]


### PR DESCRIPTION
## Description

This pull request introduces updates for the upcoming Eclipse Tractus-X Release 26.03, including a new blog post, meeting schedule updates, and improved formatting for meeting links.

---

<img width="1902" height="1109" alt="image" src="https://github.com/user-attachments/assets/71b80509-7c3f-407a-97ac-06b612b3da7c" />

---

<img width="1904" height="1042" alt="image" src="https://github.com/user-attachments/assets/00a401bf-dc2c-490c-bfed-26734e94c7d8" />

---

<img width="1907" height="1040" alt="image" src="https://github.com/user-attachments/assets/7ef913af-bf1a-4d71-a6da-f6629fc7a13f" />

---

<img width="1904" height="1040" alt="image" src="https://github.com/user-attachments/assets/cd79bd3e-c473-4e54-a29b-b02b7753be89" />

---

<img width="1908" height="1041" alt="image" src="https://github.com/user-attachments/assets/a887db99-1fd5-4997-bcd8-98499fa238d1" />

---

<img width="1907" height="1014" alt="image" src="https://github.com/user-attachments/assets/8d86c042-264a-4851-8870-e9b6683d1e44" />

---

<img width="1906" height="1115" alt="image" src="https://github.com/user-attachments/assets/24e079b7-f06f-40a7-9b6a-d1439b4ee9e1" />


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
