### PR TITLE
docs: add meeting minutes for 2025-10-31

### DIFF
--- a/blog-meeting-minutes/2025-10-31-community-hour.md
+++ b/blog-meeting-minutes/2025-10-31-community-hour.md
@@ -1,0 +1,30 @@
+---
+slug: community-office-hour-2025-10-31
+title: Community Office Hour 2025-10-31
+authors:
+  - tom-rm-meyer-ISST
+tags: [community, meeting-minutes]
+---
+
+## Office Hour meeting minutes
+
+## Update Infrastructure/Test Management
+
+- Deployment phase for 25.12 is ongoing. None has deployed yet, please start.
+- DTR has an update ongoing, but the PR is open. New version expected on next week
+
+## Update Release Management
+
+- Release Check issues must be created next week to confirm who joins or opts out of the test phase; reminders have been sent to previous participants.
+- Current reminder for 26.03 open planning: https://eclipse-tractusx.github.io/community/open-meetings#Open%20Planning%20for%20R26.03
+
+## Update Security
+
+- Please patch high and critical security vulneratiblities before e2e test.
+
+## Update Community/Open Planning
+
+- Community Days: registration open; a lot of other data spaces have been invited.
+- Container images: [@mgarciaLKS](https://github.com/mgarciaLKS) raised a TRG update for postgres with an example linked [eclipse-tractusx/eclipse-tractusx.github.io#1367](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/pull/1367), committers aligned on 18.x
+- What's the last date to provide the semantic model? Should be in line with the Final KIT PR (25.12 = 2025-11-17)
+- What needs a ticket for release and how to release a kit? If you release a KIT, you need a release ticket: [PURIS example](https://github.com/eclipse-tractusx/sig-release/issues/1494) - If you release something unfinished or not released in standards, add a disclaimer.


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Community Office Hour meeting minutes for 2025-10-31.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
