### PR TITLE
docs(banner): add new content to info banner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -253,7 +253,7 @@ const config = {
       },
       announcementBar: {
         id: `announcementBar-v25.09`,
-        content: `🎉️ <b><a href="/blog-changelog/release-25-09">Eclipse Tractus-X 25.09</a> is out!</b> 🥳️`,
+        content: `🎉️ New <b><a href="/docs/oss/release-process">Eclipse Tractus-X Release Documentation</a></b> and new <b><a href="/community/open-meetings">Open Meetings Calendar</a></b> 🥳️`,
       },
       navbar: {
         title: 'Eclipse Tractus-X',


### PR DESCRIPTION
## Description

This pull request updates the announcement bar content in the `docusaurus.config.js` file to highlight new documentation and community resources.

<img width="1906" height="110" alt="image" src="https://github.com/user-attachments/assets/dda493f7-37cd-49b7-a770-2348b2af0702" />

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
