### PR TITLE
Fix typo in prerequisites.md from 'atp' to 'apt'

### DIFF
--- a/docs/tutorials/e2e/prerequisites/prerequisites.md
+++ b/docs/tutorials/e2e/prerequisites/prerequisites.md
@@ -155,7 +155,7 @@ Within this section we briefly describe how to install the required tools on an 
 
 #### Install docker
 
-Ensure that you are up to date with your release (for Ubuntu we use atp, which needs to run with root privileges):
+Ensure that you are up to date with your release (for Ubuntu we use apt, which needs to run with root privileges):
 
 ```bash
 sudo apt update && sudo apt upgrade


### PR DESCRIPTION
## Description
This PR fixes a typo in the tutorial documentation:  
In the file `docs/tutorials/e2e/prerequisites/prerequisites.md`, the incorrect package manager name "atp" (a misspelling) is corrected to "apt" — the standard package management tool for Ubuntu systems.  

This change improves the accuracy of the documentation, avoiding confusion for users when following the tutorial to perform package management operations on Ubuntu.


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.  
  *Note: This PR only modifies documentation content and does not involve dependency changes, so this check is not applicable.*
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files  
  *Note: The modification only adjusts a single word, and the original file already contains the required copyright/license header.*