### PR TITLE
Chore: Add missing Changelog for IC KIT

### DIFF
--- a/docs-kits/kits/industry-core-kit/changelog.mdx
+++ b/docs-kits/kits/industry-core-kit/changelog.mdx
@@ -9,6 +9,17 @@ sidebar_position: 0
 
 All notable changes to this KIT will be documented in this file.
 
+## [1.5.0] - 2025-11-07
+
+### Added
+
+- Mass Data handling
+- Cloud-to-Cloud Parquet File Transfer with EDC Cloud Extension
+
+### Changed
+
+- Updates AAS API version from 3.0 to 3.1
+
 ## [1.4.0] - 2025-03-17
 
 Compatible for **release 25.03**.


### PR DESCRIPTION
This PR adds a forgotten changelog from #1278.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
