### PR TITLE
[TRG 7.07 + 10.02] feat: added that the eclipse foundation contributors need to be included in KITs notice.

### DIFF
--- a/docs/release/trg-10/trg-10-02.mdx
+++ b/docs/release/trg-10/trg-10-02.mdx
@@ -11,6 +11,7 @@ import MenuBookIcon from '@mui/icons-material/MenuBook';
 |------------|--------------|----------------------------------------|
 | Draft      | 12-Apr-2024  | Initial contribution                   |
 | Active     | 20-Nov-2025  | Splitted 09.01 Draft into 10.01, 10.02, 10.03 adding the new KIT 2.0 Content Structure |
+| Active     | 11-Dec-2025  | Added copyright notice eclipse foudation contributors enforcement |
 
 ## Why
 

--- a/docs/release/trg-10/trg-10-02.mdx
+++ b/docs/release/trg-10/trg-10-02.mdx
@@ -28,6 +28,51 @@ For the KIT Content this two TRGs must be followed:
 - [TRG 7.07 - Legal notice for non-code](/docs/release/trg-7/trg-7-07) - Image and media licensing requirements
 - [TRG 7.08 - Legal notice for KIT documentation (CC-BY-4.0)](/docs/release/trg-7/trg-7-08) - Documentation licensing
 
+## Copyright Notice
+
+Mandatory for every KIT, it **MUST** be included in every file (not just on the adoption view!).
+KIT documentation works under the CC-BY-4.0 license. Therefore you need to add the "notice" part to make transparent which companies worked on this KIT.
+It **MUST** always include the `- SPDX-FileCopyrightText: 2025 Contributors to the Eclipse Foundation` copyright statement.
+
+Example:
+
+```md
+## NOTICE
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2025 <Your Company FullName>
+- SPDX-FileCopyrightText: 2023, 2025 ZF Friedrichshafen AG
+- SPDX-FileCopyrightText: 2023, 2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2023, 2025 SAP SE
+- SPDX-FileCopyrightText: 2023, 2025 Volkswagen AG
+- SPDX-FileCopyrightText: 2023, 2025 Robert Bosch GmbH
+- SPDX-FileCopyrightText: 2023, 2025 Mercedes Benz Group
+- SPDX-FileCopyrightText: 2023, 2025 BASF SE
+- SPDX-FileCopyrightText: 2023, 2025 Schaeffler AG
+- SPDX-FileCopyrightText: 2023, 2025 Contributors to the Eclipse Foundation
+- Source URL: [Source Code](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/)
+```
+
+In case its a new KIT the year can be referenced like that:
+
+Example:
+
+```md
+## NOTICE
+
+This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2025 <Your Company FullName>
+- SPDX-FileCopyrightText: 2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+- SPDX-FileCopyrightText: 2025 Contributors to the Eclipse Foundation
+- Source URL: [Source Code](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/)
+```
+
+For more information consult [TRG 7.07 - Legal notice for non-code](/docs/release/trg-7/trg-7-07) - Image and media licensing requirements
+
 ## General Requirements
 
 - A KIT must have a <code>changelog.md</code> following semantic versioning + the release date of Tractus-X - see [TRG 1.03 - CHANGELOG.md](/docs/release/trg-1/trg-1-03)

--- a/docs/release/trg-7/trg-7-06.md
+++ b/docs/release/trg-7/trg-7-06.md
@@ -7,7 +7,8 @@ title: TRG 7.06 - Legal notice for end user content
 | Active | 27-Jun-2025 | Remove documentation section               |
 | Active | 25-Apr-2024 | Updates for CC-BY-4.0 license              |
 | Active | 04-Dec-2023 | Update Shared UI Components / NPM library  |
-| Active | 13-Apr-2023 | New                                        |
+| Active | 13-Apr-2023 | New REUSE.toml                             |
+| Active | 11-Dec-2025 | Added copyright notice eclipse foudation contributors enforcement |
 
 ## Why
 

--- a/docs/release/trg-7/trg-7-06.md
+++ b/docs/release/trg-7/trg-7-06.md
@@ -7,8 +7,7 @@ title: TRG 7.06 - Legal notice for end user content
 | Active | 27-Jun-2025 | Remove documentation section               |
 | Active | 25-Apr-2024 | Updates for CC-BY-4.0 license              |
 | Active | 04-Dec-2023 | Update Shared UI Components / NPM library  |
-| Active | 13-Apr-2023 | New REUSE.toml                             |
-| Active | 11-Dec-2025 | Added copyright notice eclipse foudation contributors enforcement |
+| Active | 13-Apr-2023 | New                                        |
 
 ## Why
 

--- a/docs/release/trg-7/trg-7-07.md
+++ b/docs/release/trg-7/trg-7-07.md
@@ -62,7 +62,7 @@ For text files, like files in the markdown format, the attribution is done direc
 section. The attribution is shown with an example for a CC-BY-4.0 licensed markdown file. For other formats like
 slides, pdf, and others adapt the information in an adequate way.
 
-Add a `NOTICE` section (post or preamble) into your dedicated documentation file, with the following information:
+Add a `NOTICE` section (post or preamble) into your dedicated documentation file, with the following information **MUST** be included:
 
 ```text
 ## NOTICE

--- a/docs/release/trg-7/trg-7-07.md
+++ b/docs/release/trg-7/trg-7-07.md
@@ -70,6 +70,7 @@ This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses
 
 - SPDX-License-Identifier: CC-BY-4.0
 - SPDX-FileCopyrightText: 202x {Owner}
+- SPDX-FileCopyrightText: 202x Contributors to the Eclipse Foundation
 - Source URL: https://github.com/eclipse-tractusx/<myrepo>/<link_to_doc_or_doc_dir> (+)
 ```
 
@@ -86,6 +87,8 @@ Explanations in brackets, do not copy. PLEASE.
 ```
 
 :::
+
+The copyright for the Eclipse Foundation Contributors `202x Contributors to the Eclipse Foundation` (with the respective year(s)) **MUST** be included in all markdown NOTICE copyright. For more information consult [Eclipse Foundation Rulebook - Legal Documentation](https://www.eclipse.org/projects/handbook/#legaldoc)
 
 ### Self-created content
 

--- a/docs/release/trg-7/trg-7-07.md
+++ b/docs/release/trg-7/trg-7-07.md
@@ -4,7 +4,8 @@ title: TRG 7.07 - Legal notice for non-code (e.g. KITS, documentation, images, s
 
 | Status | Created     | Post-History                  |
 |--------|-------------|-------------------------------|
-| Active | 27-06-2025  | Integration of non-code rules |
+| Active | 11-Dec-2025 | Added copyright notice eclipse foudation contributors enforcement |
+| Active | 27-Jun-2025 | Integration of non-code rules |
 | Active | 25-Apr-2024 | Updates for CC-BY-4.0 license |
 | Active | 18-Jul-2023 | Update: improved description  |
 |        | 13-Apr-2023 | Initial version               |
@@ -85,7 +86,6 @@ Explanations in brackets, do not copy. PLEASE.
 - SPDX-FileCopyrightText: 2021 Owner2 (-> Owner2 created the content in 2021)
 - SPDX-FileCopyrightText: 2021 Contributors to the Eclipse Foundation
 ```
-
 :::
 
 The copyright for the Eclipse Foundation Contributors `202x Contributors to the Eclipse Foundation` (with the respective year(s)) **MUST** be included in all markdown NOTICE copyright. For more information consult [Eclipse Foundation Rulebook - Legal Documentation](https://www.eclipse.org/projects/handbook/#legaldoc)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

There were no clear indications that in the NOTICE sections the Eclipse Foundation contributions must be mentioned.

As mentioned here: https://eclipse-tractusx.github.io/documentation/kit-framework#copyright-notice

Up to discussion (To clarify with Committers and eclipse foundation @AngelikaWittek).

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
