### PR TITLE
fix: Adjust the frequency of occurrences for Portal Open Meetings

### DIFF
--- a/data/meetings.js
+++ b/data/meetings.js
@@ -171,7 +171,7 @@ export const meetings = [
     ],
     recurrence: {
       frequency: 'weekly',
-      interval: 1,
+      interval: 4,
       daysOfWeek: ['tuesday'],
       startTime: '10:30',
       endTime: '11:00',


### PR DESCRIPTION
## Description

Adjust the frequency of occurrences for Portal Open Meetings, from every week to once 1 month.

## Pre-review checks

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
