### PR TITLE
docs(open-meetings): removes `validUntil` from meeting data office and committer hour

### DIFF
--- a/data/meetings.js
+++ b/data/meetings.js
@@ -47,7 +47,6 @@ export const meetings = [
       startTime: '10:05',
       endTime: '11:00',
       validFrom: '2025-01-01',
-      validUntil: '2025-12-31',
     },
   },
   {
@@ -77,7 +76,6 @@ export const meetings = [
       startTime: '14:05',
       endTime: '15:00',
       validFrom: '2025-01-01',
-      validUntil: '2025-12-31',
     },
   },
   {


### PR DESCRIPTION
## Description

This pull request includes a small change to the `data/meetings.js` file, specifically removing the `validUntil` property from two general meeting objects.

The office hour and the committer meeting shouldn't have an end ;) This means, they are valid as well for next year.

<img width="1146" height="619" alt="image" src="https://github.com/user-attachments/assets/c2092ffd-b472-4d77-96cd-5aa05ffe4b52" />

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
