### PR TITLE
fix(open-meetings): change meeting recurrence frequency from bi-weekly to weekly

### DIFF
--- a/data/meetings.js
+++ b/data/meetings.js
@@ -150,7 +150,7 @@ export const meetings = [
     contact: 'lars.blaumeiser@cofinity-x.com',
     sessionLink: 'https://eclipse.zoom.us/j/87463482673?pwd=XwLhl6yazHg2Llaos4ojcCs2OPRaip.1',
     recurrence: {
-      frequency: 'bi-weekly',
+      frequency: 'weekly',
       interval: 2,
       daysOfWeek: ['tuesday'],
       startTime: '16:00',


### PR DESCRIPTION
## Description

This pull request makes a small update to the meeting schedule in `data/meetings.js`. The frequency for one of the meetings has been changed from bi-weekly to weekly.

<img width="1579" height="209" alt="image" src="https://github.com/user-attachments/assets/ec050c82-382d-4caf-9d38-8ff3506243dc" />

<img width="1643" height="720" alt="image" src="https://github.com/user-attachments/assets/65087a37-62c8-4f52-9f81-99d866866652" />


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
