### PR TITLE
Adopt TRG 1-03 and 2-03 concerning already in use practices to fulfill the intention

### DIFF
--- a/docs/release/trg-1/trg-1-03.md
+++ b/docs/release/trg-1/trg-1-03.md
@@ -23,7 +23,7 @@ All notable changes of a new release in the product repositories **MUST** be doc
   Be aware, that this mechanism uses the title lines of PRs merged in the release period, so this requires some discipline in this regard.
   It is possible, to adapt the generated text to get rid of PR issues and to generally improve user experience.
 - Alternative: Document all releases with their changes in a `CHANGELOG.md` file at the root level in the repository.
-  A `CHANGELOG.md` file **SHOULD** follow the format as described in [Keep A Changelog](https://keepachangelog.com/en/1.1.0/).
+  A `CHANGELOG.md` file **MUST** follow the format as described in [Keep A Changelog](https://keepachangelog.com/en/1.1.0/).
 
 In addition, a link to the change documentation **MUST** be added to the [Eclipse Tractus-X Changelog](https://github.com/eclipse-tractusx/tractus-x-release/blob/main/CHANGELOG.md).
 
@@ -35,6 +35,7 @@ The versioning of the product releases **MUST** follow [semantic versioning](htt
   - Separate the changes into adequate categories (e.g., features, bugfixes, documentation, infrastructure, dependencies).
   - Use [conventional commits](https://www.conventionalcommits.org) to support the release notes mechanism in doing a pre-sorting of changes into categories.
   - Cleanup the list to provide a better user experience to adoptors of the version.
+- Use a workflow to automate the changelog creation (see example in [sig-release with release please](https://github.com/eclipse-tractusx/sig-release/blob/dcb0f77bdb1ff49274b314940f2ba86a53505476/.github/workflows/release-please.yaml))
 
 ### Example GitHub Release item
 
@@ -69,6 +70,9 @@ The versioning of the product releases **MUST** follow [semantic versioning](htt
 ### Other Changes
 * chore: Update k8s versions for deployment test by `a contributor` in `link to pr`
 * Any other PR that does not qualify to any of the above categories, e.g., infrastructure topics or config changes
+
+## Screenshots
+* Pictures from the running system and the features in this release.
 
 ## New Contributors
 * A list of people who did their first contribution in the corresponding release cycle

--- a/docs/release/trg-2/trg-2-03.md
+++ b/docs/release/trg-2/trg-2-03.md
@@ -22,6 +22,7 @@ All repositories **MUST** contain the following files and folders:
 /docs
 /charts
 README.md
+<<other mandatory files from TRG 7.01>>
 ```
 
 All repositories **MUST** contain files required due to legal needs as defined in [TRG 7.01](../trg-7/trg-7-01)
@@ -29,6 +30,7 @@ All repositories **MUST** contain files required due to legal needs as defined i
 Recommended but optional:
 
 ```shell
+AUTHORS.md
 INSTALL.md
 ```
 


### PR DESCRIPTION
## Description

### TRG 1-03

- Added the option to use the GitHub release notes mechanism for documenting the changes in a release as recommended alternative to a CHANGELOG.md file

### TRG 2-03

- Removed all references to legal documentation and added a clear reference to the corresponding TRG 7-01
  - Reason: The spec was already inconsistent, as changes had been applied to 7-01 but 2-03 had not been adopted
  - Solution: By only referencing the TRG and the requirements from there concerning files, the TRG is stable and inconsistencies between the two TRGs are prevented.
  
## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files

Closes #1412 
Closes #1413 
