### PR TITLE
chore(docs): update meeting details and add release planning 26.06

### DIFF
--- a/blog/2026-01-26-release-planning-R26.06.md
+++ b/blog/2026-01-26-release-planning-R26.06.md
@@ -2,7 +2,7 @@
 title: Release Planning for Release 26.06
 description: Eclipse Tractus-X Community Update - Release Planning for Release 26.06
 slug: release-planning-R26.06
-date: 2026-03-10T09:00
+date: 2026-01-26T11:30
 hide_table_of_contents: false
 authors:
   - stephan_bauer
@@ -24,6 +24,7 @@ Key Information:
 - Dates and Times: Listed for each session below.
 - Resources: Visit our [open meetings page](/community/open-meetings#one-time-meetings) for all session links and additional documentation.
 - Preparation Materials: Ensure readiness by reviewing the provided templates, guidelines, and your own features.
+- Overall process description: [Release Planning Process](/docs/oss/release-process)
 
 We look forward to seeing you there and working together to make **R26.06** a success!
 
@@ -39,19 +40,19 @@ Even if you don't have questions, it could be interesting anyway.
 
 :::
 
-- Date: 25.03.2026
-- Time: 09:05 - 10:45
+- Date: 12.02.2026
+- Time: 09:05 - 10:00
 - Main Teams Link: See the Open Meetings page (One-time meetings) for the join link and local-time conversion: [Open Meetings](/community/open-meetings#one-time-meetings)
 
-### Agenda {#agenda-1}
+### Agenda
 
 :::info
 The agenda itself is dependent on the labeled features.
 :::
 
-- 09:05 - 09:20: Welcome and overview of Open Discussion features
-- 09:20 - 10:30: Group discussions and breakout sessions as needed
-- 10:30 - 10:45: (Optional) closing and documentation of decisions
+- 09:05 - 09:15: Welcome and overview of Open Discussion features
+- 09:15 - 09:55: Group discussions and breakout sessions as needed
+- 09:55 - 10:00: (Optional) closing and documentation of decisions
 
 ### Key Focus Areas
 
@@ -65,14 +66,14 @@ The agenda itself is dependent on the labeled features.
 
 The Open Planning session finalizes the roadmap for **R26.06**, prioritizing features and aligning all participants on deliverables for the release.
 
-- Date: 08.04.2026
-- Time: 09:05 - 12:15
+- Date: 26.02.2026
+- Time: 09:05 - 12:15 (end time can vary based on discussion and features)
 - Teams Link: See the Open Meetings page (One-time meetings) for the join link and local-time conversion: [Open Meetings](/community/open-meetings#one-time-meetings)
 
 Who Should Attend:
 
 - Contributors and Committers from the open-source community
-- Expert Group and Committee members
+- Experts
 - Feature requesters and stakeholders
 
 :::note
@@ -94,12 +95,12 @@ The planning sessions will be driven by our Release Planning Board and filtered 
 :::
 
 |          Time | Topics                                | Features |
-|--------------:|---------------------------------------|----------:|
-| 09:05 – 09:20 | Open Planning - Vision & Introduction |           |
-| 09:20 – 10:00 | Product & Platform Topics             |           |
-| 10:00 – 10:30 | Sustainability & Use Cases            |           |
-| 10:30 – 11:15 | Engineering                           |           |
-| 11:15 – 12:00 | Test Management / Misc               |           |
+|--------------:|---------------------------------------|---------:|
+| 09:05 – 09:20 | Open Planning - Vision & Introduction |          |
+| 09:20 – 10:00 | Product & Platform Topics             |          |
+| 10:00 – 10:30 | Sustainability & Use Cases            |          |
+| 10:30 – 11:15 | Engineering                           |          |
+| 11:15 – 12:00 | Test Management / Misc                |          |
 
 ### Prerequisites for features to be considered in Open Planning
 

--- a/data/meetings.js
+++ b/data/meetings.js
@@ -317,7 +317,7 @@ export const meetings = [
     category: MEETING_CATEGORIES.ONE_TIME,
     description: 'Address open questions and unresolved dependencies for features planned for Release 26.06. This session focuses on alignment and clarifying blockers before open planning.',
     contact: 'stephan.bauer@catena-x.net',
-    sessionLink: null, // Add Teams link when available
+    sessionLink: 'https://teams.microsoft.com/meet/32237268178214?p=89tbu5bGzNdCVPpfhn', // Add Teams link when available
     additionalLinks: [
       { title: 'Release Planning Board - Open Question', url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/43?filterQuery=-label%3Ametadata+label%3APrep-R26.06+label%3A%22open+question%22' },
       { title: 'Timeline', url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A26.06' },
@@ -326,9 +326,9 @@ export const meetings = [
     ],
     recurrence: {
       frequency: 'once',
-      startDate: '2026-03-25',
+      startDate: '2026-02-12',
       startTime: '09:05',
-      endTime: '10:45',
+      endTime: '10:00',
     },
   },
   {
@@ -337,7 +337,7 @@ export const meetings = [
     category: MEETING_CATEGORIES.ONE_TIME,
     description: 'Finalize roadmap, prioritize features and align participants on deliverables for Release 26.06.',
     contact: 'stephan.bauer@catena-x.net',
-    sessionLink: null, // Add Teams link when available
+    sessionLink: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_NTliYzcyM2YtODMwNC00NzdiLThlNTEtNGI2MzNhYzAyMDRi%40thread.v2/0?context=%7b%22Tid%22%3a%221ad22c6d-2f08-4f05-a0ba-e17f6ce88380%22%2c%22Oid%22%3a%22a8b7a5ee-66ff-4695-afa2-08f893d8aaf6%22%7d', // Add Teams link when available
     additionalLinks: [
       { title: 'Release Planning Board - Topic/Product', url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R26.06%22+status%3ABacklog' },
       { title: 'Timeline', url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A26.06' },
@@ -347,7 +347,7 @@ export const meetings = [
     ],
     recurrence: {
       frequency: 'once',
-      startDate: '2026-04-08',
+      startDate: '2026-02-26',
       startTime: '09:05',
       endTime: '12:15',
     },


### PR DESCRIPTION
## Description

This pull request updates the meeting schedule and documentation for the upcoming Eclipse Tractus-X Release 26.06. It introduces new meeting entries for the release planning process, updates existing meetings to reflect the new release cycle, and adds a detailed blog post outlining the planning events and requirements for participation.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
