### PR TITLE
chore(docs): add details for the first international Eclipse Tractus-X hackathon

### DIFF
--- a/data/meetings.js
+++ b/data/meetings.js
@@ -352,4 +352,25 @@ export const meetings = [
       endTime: '12:15',
     },
   },
+  {
+    id: 'first-international-hackathon',
+    title: 'First International Eclipse Tractus-X Hackathon 🇪🇸',
+    category: MEETING_CATEGORIES.ONE_TIME,
+    description: 'Join us for the first international open source hackathon of Eclipse Tractus-X in Bilbao, Spain! This is a hands-on technical event focused on developing the Tractus-X Identity Hub Wallet and Industry Core Hub Add-Ons. Bring your laptop and motivation to code!',
+    contact: 'mgarcia@lksnext.com',
+    sessionLink: 'https://forms.office.com/e/LkYbasfXJA',
+    additionalLinks: [
+      { title: 'News Blog', url: '/blog/first-international-hackathon' },
+      { title: 'Identity Hub Repository', url: 'https://github.com/eclipse-tractusx/tractusx-identityhub' },
+      { title: 'Umbrella Repository', url: 'https://github.com/eclipse-tractusx/tractus-x-umbrella' },
+      { title: 'Industry Core Hub Repository', url: 'https://github.com/eclipse-tractusx/industry-core-hub' },
+      { title: 'Tractus-X Mailing List', url: 'https://accounts.eclipse.org/mailing-list/tractusx-dev' },
+    ],
+    recurrence: {
+      frequency: 'once',
+      startDate: '2026-02-17',
+      startTime: '09:00',
+      endTime: '17:00',
+    },
+  },
 ];


### PR DESCRIPTION
## Description

This pull request adds a new event to the `meetings` data, specifically the "First International Eclipse Tractus-X Hackathon" in Bilbao, Spain. This event is categorized as a one-time meeting and includes relevant details such as description, contact information, session registration link, and several additional resource links.

<img width="1617" height="558" alt="image" src="https://github.com/user-attachments/assets/2674d630-1f31-4ba2-a8e8-2db2324fe204" />

<img width="601" height="600" alt="image" src="https://github.com/user-attachments/assets/d8a1ca12-a4fa-4de1-8d9e-38fd3bc98467" />


<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
