### PR TITLE
feat: expand timezone options in MeetingCalendar component

### DIFF
--- a/src/components/OpenMeetings/MeetingCalendar.jsx
+++ b/src/components/OpenMeetings/MeetingCalendar.jsx
@@ -40,12 +40,19 @@ const localizer = dateFnsLocalizer({
 
 // Common timezones
 const TIMEZONES = [
-  { value: 'Europe/Berlin', label: 'Berlin (CET/CEST)' },
-  { value: 'UTC', label: 'UTC' },
-  { value: 'America/New_York', label: 'New York (EST/EDT)' },
-  { value: 'America/Los_Angeles', label: 'Los Angeles (PST/PDT)' },
-  { value: 'Asia/Tokyo', label: 'Tokyo (JST)' },
-  { value: 'Asia/Shanghai', label: 'Shanghai (CST)' },
+  { value: 'Europe/Berlin', label: '(CET/CEST) Berlin / Madrid / Paris' },
+  { value: 'Europe/Bucharest', label: '(EET/EEST) Eastern Europe' },
+  { value: 'Africa/Johannesburg', label: '(SAST) South Africa' },
+  { value: 'UTC', label: '(UTC/GMT) London / Lisbon' },
+  { value: 'America/New_York', label: '(EST/EDT) New York / Toronto' },
+  { value: 'America/Los_Angeles', label: '(PST/PDT) Los Angeles / Vancouver' },
+  { value: 'America/Mexico_City', label: '(CST/CDT) Mexico City' },
+  { value: 'America/Sao_Paulo', label: '(BRT/BRST) São Paulo' },
+  { value: 'America/Argentina/Buenos_Aires', label: '(ART) Buenos Aires' },
+  { value: 'Asia/Kolkata', label: '(IST) India' },
+  { value: 'Asia/Tokyo', label: '(JST) Tokyo' },
+  { value: 'Asia/Seoul', label: '(KST) Seoul' },
+  { value: 'Asia/Shanghai', label: '(CST) Shanghai' },
 ];
 
 export default function MeetingCalendar({ onTimezoneChange }) {


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

Added more timezones for our meeting calendar

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
