### PR TITLE
Update OSS How-To Xray Tutorial to fix image and caption formatting issues

### DIFF
--- a/docs/oss/howto-xray.md
+++ b/docs/oss/howto-xray.md
@@ -392,7 +392,7 @@ This work and all embedded screenshot images are licensed under the [CC-BY-4.0](
 - SPDX-License-Identifier: CC-BY-4.0
 - SPDX-FileCopyrightText: 2025, 2026 Contributors to the Eclipse Foundation
 - Source URL: [https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/)
-- Source URL: [https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs/oss/howto-xray](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs/oss/howto-xray)
+- Source URL: [https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs/oss/howto-xray.md](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs/oss/howto-xray.md)
 - Images: [https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs/images](https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/tree/main/docs/images)
 
 ## AUTHORS


### PR DESCRIPTION
This is a minor fix for https://eclipse-tractusx.github.io/docs/oss/howto-xray/ to correct formatting issues with some inconsistent alignments for images and their captions/subtitles that were not previously visible in the code editor and only really showed in the Docusaurus rendering of the page. 

This was now hopefully corrected with improved leading blank lines, paragraphs and emphasis tags, thus avoiding the need to use an additional Docusaurus image component for inline styles, additional HTML figure tags or other additional CSS files.

Some other minor formattings like bolding of some keywords were also corrected, and the introduction slightly better reworded regarding the free Jira subscription for open source projects.  