### PR TITLE
docs: update BPDM open meeting information

### DIFF
--- a/data/meetings.js
+++ b/data/meetings.js
@@ -221,8 +221,8 @@ export const meetings = [
     title: 'BPDM - Open Meeting',
     category: MEETING_CATEGORIES.PRODUCT,
     description: 'Coordination of feature refinement and development for bpdm product.',
-    contact: 'sujit.karne@mercedes-benz.com',
-    sessionLink: 'https://teams.microsoft.com/l/meetup-join/19%3ameeting_OGYxZjQ4NzItNjc1OC00YjEyLWI2NjYtNThjNDBmMGI0MTk4%40thread.v2/0?context=%7b%22Tid%22%3a%229652d7c2-1ccf-4940-8151-4a92bd474ed0%22%2c%22Oid%22%3a%221cad1acb-7d7b-4e88-bc6b-875078a66bdf%22%7d',
+    contact: 'julian.stoll@mercedes-benz.com',
+    sessionLink: 'https://teams.microsoft.com/meet/39668829824816?p=V98MwqIBHMrXfu6GSd',
     additionalLinks: [
       { title: 'BPDM Matrix Chat', url: 'https://chat.eclipse.org/#/room/#tractusx-bpdm:matrix.eclipse.org' },
     ],
@@ -230,8 +230,8 @@ export const meetings = [
       frequency: 'weekly',
       interval: 1,
       daysOfWeek: ['wednesday'],
-      startTime: '10:00',
-      endTime: '10:30',
+      startTime: '09:00',
+      endTime: '09:30',
     },
   },
   {


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull requests updates the outdated BPDM Open Meeting information. Currently, I am hosting the meeting during in the given new time frame. The overall contact person though changed to our BPDM expert group lead.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
