### PR TITLE
docs(open-meetings): Change end time of meeting from 12:15 to 10:15

### DIFF
--- a/data/meetings.js
+++ b/data/meetings.js
@@ -349,7 +349,7 @@ export const meetings = [
       frequency: 'once',
       startDate: '2026-02-26',
       startTime: '09:05',
-      endTime: '12:15',
+      endTime: '10:15',
     },
   },
   {


### PR DESCRIPTION
## Description

This pull request makes a minor update to the meeting schedule data. The change corrects the end time for a scheduled meeting.

* Updated the `endTime` for a meeting in `data/meetings.js` from `12:15` to `10:15`.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
