### PR TITLE
Fix/cross industry use cases: updated naming from use cases to cross industry use cases to match architecture

### DIFF
--- a/utils/generateKitNavItems.js
+++ b/utils/generateKitNavItems.js
@@ -218,7 +218,7 @@ function generateKitNavItems() {
     });
     items.push({
       to: '/Kits/cross-industry',
-      label: 'USE CASES',
+      label: 'CROSS-INDUSTRY USE CASES',
       className: 'kit-category-header'
     });
     

--- a/utils/generated/kitNavItems.js
+++ b/utils/generated/kitNavItems.js
@@ -311,7 +311,7 @@ function generateKitNavItems() {
     });
     items.push({
       to: '/Kits/cross-industry',
-      label: 'USE CASES',
+      label: 'CROSS-INDUSTRY USE CASES',
       className: 'kit-category-header'
     });
     


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Initial contribution done by copilot.

This pull request makes a minor update to the navigation items by clarifying the label for the cross-industry kits section.

* Changed the label for the `/Kits/cross-industry` navigation item from `'USE CASES'` to `'CROSS-INDUSTRY USE CASES'` in `generateKitNavItems.js` to improve clarity.
## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
