### PR TITLE
Hotfix/kit library: Added "View KIT" button on the KIT 3D logo library

### DIFF
--- a/src/components/2.0/Kit3DLogoLibrary/kit-3d-logo-library.jsx
+++ b/src/components/2.0/Kit3DLogoLibrary/kit-3d-logo-library.jsx
@@ -234,6 +234,20 @@ export default function Kit3DLogoLibrary() {
                   </>
                 )}
                 <KitLogoLicense logoLicencse={kit.logoLicencse} licenses={licenses} />
+                {kit.route && (
+                  <a
+                    href={kit.route}
+                    className={styles.viewKitButton}
+                    title={`View ${kit.name}`}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                      <polyline points="15 3 21 3 21 9" />
+                      <line x1="10" y1="14" x2="21" y2="3" />
+                    </svg>
+                    View KIT
+                  </a>
+                )}
                 </div>
               </div>
             </Grid>

--- a/src/components/2.0/Kit3DLogoLibrary/kit-3d-logo-library.module.scss
+++ b/src/components/2.0/Kit3DLogoLibrary/kit-3d-logo-library.module.scss
@@ -464,6 +464,36 @@
   }
 }
 
+// View KIT Link Button
+.viewKitButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+  padding: 8px 16px;
+  background: var(--ifm-color-primary);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  cursor: pointer;
+
+  &:hover {
+    background: white;
+    color: black;
+    text-decoration: none;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  svg {
+    flex-shrink: 0;
+  }
+}
+
 // Info Section
 .info {
   max-width: 900px;


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

I have added a button to go to the kit in the 3D logo library.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
