### PR TITLE
docs(community-days): adapt day 2 agenda

### DIFF
--- a/blog/2026-03-23-sixth-community-days.md
+++ b/blog/2026-03-23-sixth-community-days.md
@@ -49,29 +49,25 @@ The final agenda will be published closer to the event. The structure below is a
 
 #### Day 1
 
-| Time | Session |
-|------|---------|
-| 09:00 – 09:30 | Registration & Welcome Coffee |
-| 09:30 – 10:00 | **Opening & Welcome** |
-| 10:00 – 10:45 | **Keynote: State of Eclipse Tractus-X** |
-| 10:45 – 11:00 | Coffee Break |
-| 11:00 – 12:30 | **Parallel Streams: Presentations · Workshops · Challenges** |
-| 12:30 – 13:30 | Lunch Break |
-| 13:30 – 15:30 | **Parallel Streams: Presentations · Workshops · Challenges** |
-| 15:30 – 16:00 | Coffee Break |
-| 16:00 – 17:00 | **Developer Panel & Open Discussion** |
-| 18:00 – open end | **Networking Evening Event** |
+| Time             | Session                                                      |
+|------------------|--------------------------------------------------------------|
+| 09:00 – 09:30    | Registration & Welcome Coffee                                |
+| 09:30 – 10:00    | **Opening & Welcome**                                        |
+| 10:00 – 10:45    | **Keynote: State of Eclipse Tractus-X**                      |
+| 10:45 – 11:00    | Coffee Break                                                 |
+| 11:00 – 12:30    | **Parallel Streams: Presentations · Workshops · Challenges** |
+| 12:30 – 13:30    | Lunch Break                                                  |
+| 13:30 – 15:30    | **Parallel Streams: Presentations · Workshops · Challenges** |
+| 15:30 – 16:00    | Coffee Break                                                 |
+| 16:00 – 17:00    | **Developer Panel & Open Discussion**                        |
+| 18:00 – open end | **Networking Evening Event**                                 |
 
 #### Day 2
 
-| Time | Session |
-|------|---------|
-| 09:00 – 09:30 | Welcome Back & Tech Talk |
-| 09:30 – 12:30 | **Continuation of Streams: Workshops · Challenges** |
-| 12:30 – 13:30 | Lunch Break |
-| 13:30 – 15:30 | **Advanced Sessions & Collaborative Working Groups** |
-| 15:30 – 16:00 | **Wrap-Up & Key Takeaways** |
-| 16:00 | Farewell |
+| Time          | Session                                             |
+|---------------|-----------------------------------------------------|
+| 09:00 – 09:30 | Welcome Back & Tech Talk                            |
+| 09:30 – 12:00 | **Continuation of Streams: Workshops · Challenges** |
 
 :::info
 We are actively looking for **speakers, workshop facilitators, and challenge leaders**! If you'd like to contribute a session, presentation, or use-case showcase — we'd love to hear from you. Please reach out via the [Tractus-X mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) or our [Matrix community channel](https://matrix.to/#/#tractusx-dev:matrix.eclipse.org).


### PR DESCRIPTION
## Description

This pull request makes minor formatting corrections to the agenda tables for Day 1 and Day 2 in the `blog/2026-03-23-sixth-community-days.md` file.

- Adjusted the Day 2 agenda by updating the session time for "Continuation of Streams: Workshops · Challenges" from 09:30–12:30 to 09:30–12:00 and removed several subsequent sessions, likely to reflect a more accurate or updated schedule.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
