### PR TITLE
fix: update layout in TodaySection and regenerate kitNavItems with ne…

### DIFF
--- a/src/components/OpenMeetings/MeetingsHub.jsx
+++ b/src/components/OpenMeetings/MeetingsHub.jsx
@@ -932,7 +932,7 @@ function TodaySection({ timezone, onSelect, onDownload }) {
                   <Icon name={ev.icon} size={36} />
                 </div>
               )}
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8 }}>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'flex-start', marginBottom: 8 }}>
                 <span className={`${styles.badge} ${getCategoryBadgeClass(ev.category)}`}>
                   {CATEGORY_LABELS[ev.category]}
                 </span>

--- a/utils/generated/kitNavItems.js
+++ b/utils/generated/kitNavItems.js
@@ -20,7 +20,7 @@
 /**
  * AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
  * Generated from data/kitsData.js
- * Content hash: 2836d12da51791318797487399255ff7416f98096fa50568b52bc25974eb0e16
+ * Content hash: 98576d2873b527284fe54cb82f9c5f62498b465ea89e299cbb5b2bf53ff30109
  * 
  * To regenerate: npm run generate:nav-items
  * 
@@ -217,7 +217,7 @@ const kitsByCategory = {
       {
         "id": "maas",
         "name": "MANUFACTURING AS A SERVICE KIT",
-        "route": "/docs-kits/kits/manufacturing-as-a-service-kit/adoption-view",
+        "route": "/docs-kits/next/kits/manufacturing-as-a-service-kit/adoption-view",
         "deprecated": false
       },
       {


### PR DESCRIPTION
…w content hash

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

There was a small bug:

<img width="435" height="435" alt="image" src="https://github.com/user-attachments/assets/2867781a-a25d-448e-b4d8-3f4c2635ea92" />


But now it is fixed:
<img width="496" height="487" alt="image" src="https://github.com/user-attachments/assets/9cc350c8-8ae2-41fd-81a6-c1db8a8c08ee" />



<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
