### PR TITLE
chore: removed semantic models from development view

### DIFF
--- a/docs-kits/kit-template/sandbox/adoption-view/adoption-view.md
+++ b/docs-kits/kit-template/sandbox/adoption-view/adoption-view.md
@@ -68,6 +68,27 @@ KIT LOGO END
 
 > TODO: Describe the business value of this KIT and why it should be implemented
 
+## Semantic Models / Data Model
+
+<!-- Reference the relevant semantic models, APIs, or standards. -->
+
+> TODO: Link or describe the data model, when using big payloads or json-schemas use expandable sections like below:
+
+<details>
+  <summary>Semantic Model Example - click to expand</summary>
+
+Place here the description of your semantic model.
+
+```json
+{
+  "key": "value",
+  "object": {...},
+  "array": [...]
+}
+```
+
+</details>
+
 ## Standards
 
 <!-- Provide a list of standards this KIT. -->

--- a/docs-kits/kit-template/sandbox/development-view/development-view.md
+++ b/docs-kits/kit-template/sandbox/development-view/development-view.md
@@ -75,26 +75,6 @@ graph LR
 > As described in TRG 1.08: https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-08
 > Will be hosted in API HUB: https://eclipse-tractusx.github.io/api-hub/
 
-## Semantic Models / Data Model
-
-<!-- Reference the relevant semantic models, APIs, or standards. -->
-
-> TODO: Link or describe the data model, when using big payloads or json-schemas use expandable sections like below:
-
-<details>
-  <summary>Semantic Model Example - click to expand</summary>
-
-Place here the description of your semantic model.
-
-```json
-{
-  "key": "value",
-  "object": {...},
-  "array": [...]
-}
-```
-
-</details>
 
 ## Protocols
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This pull request updates the KIT documentation templates by moving the "Semantic Models / Data Model" section from the development view to the adoption view. This change helps clarify where information about data models should be documented.

**Documentation structure improvements:**

* Moved the "Semantic Models / Data Model" section (including the expandable semantic model example) from `development-view.md` to `adoption-view.md` to better organize information about data models in KIT documentation. [[1]](diffhunk://#diff-238186604ee78a5d2f056a99bae3bcebc79cc93cb65c41d9ec69db077339e281L78-L97) [[2]](diffhunk://#diff-0e98649aa155b7094c608e9a7429924cd8faeb4a6e4ed0a9686155ac03043cb3R71-R91)
<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
