### PR TITLE
Bugfix/download: optimization by elimination of download response time for KIT logos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Generated files
 .docusaurus
 .cache-loader
+/static/generated/
 
 # Misc
 .DS_Store

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -43,7 +43,7 @@ npm/npmjs/-/baseline-browser-mapping/2.10.24, Apache-2.0, approved, #26300
 npm/npmjs/-/batch/0.6.1, MIT, approved, clearlydefined
 npm/npmjs/-/big.js/5.2.2, MIT, approved, clearlydefined
 npm/npmjs/-/binary-extensions/2.3.0, MIT, approved, #13867
-npm/npmjs/-/body-parser/1.20.4, MIT, approved, clearlydefined
+npm/npmjs/-/body-parser/1.20.4, MIT, approved, #27898
 npm/npmjs/-/bonjour-service/1.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/boolbase/1.0.0, ISC, approved, #24861
 npm/npmjs/-/boxen/6.2.1, MIT, approved, clearlydefined
@@ -454,7 +454,7 @@ npm/npmjs/-/json-schema-traverse/0.4.1, MIT, approved, clearlydefined
 npm/npmjs/-/json-schema-traverse/1.0.0, MIT, approved, #24851
 npm/npmjs/-/json2mq/0.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/json5/2.2.3, MIT, approved, #15226
-npm/npmjs/-/jsonfile/6.2.0, MIT, approved, clearlydefined
+npm/npmjs/-/jsonfile/6.2.0, MIT, approved, #27883
 npm/npmjs/-/katex/0.16.45, Apache-2.0 AND MIT AND OFL-1.1 AND LicenseRef-Public-Domain, approved, #8549
 npm/npmjs/-/keyv/4.5.4, MIT, approved, #4674
 npm/npmjs/-/khroma/2.1.0, MIT, approved, clearlydefined
@@ -482,7 +482,7 @@ npm/npmjs/-/lightningcss/1.32.0, MPL-2.0, approved, clearlydefined
 npm/npmjs/-/lilconfig/3.1.3, MIT AND ISC, approved, #18956
 npm/npmjs/-/lines-and-columns/1.2.4, MIT, approved, clearlydefined
 npm/npmjs/-/linkify-it/4.0.1, MIT, approved, clearlydefined
-npm/npmjs/-/loader-runner/4.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/loader-runner/4.3.1, MIT, approved, #27891
 npm/npmjs/-/loader-utils/2.0.4, MIT, approved, #4986
 npm/npmjs/-/local-pkg/1.1.2, MIT, approved, #20362
 npm/npmjs/-/locate-path/7.2.0, MIT, approved, clearlydefined

--- a/documentation/kit-3d-logo-library.mdx
+++ b/documentation/kit-3d-logo-library.mdx
@@ -1,6 +1,7 @@
 ---
 title: KIT 3D Logo Library
 hide_table_of_contents: true
+hide_title: true
 ---
 
 {/********************************************************************************* 
@@ -24,6 +25,8 @@ hide_table_of_contents: true
  }
 
 import Kit3DLogoLibrary from '@site/src/components/2.0/Kit3DLogoLibrary/kit-3d-logo-library';
+
+# KIT 3D Logo Library <span className="badge badge--warning" style={{verticalAlign: 'middle', fontSize: '0.6rem', marginLeft: '8px'}}>BETA</span>
 
 Browse and download 3D isometric logos for all Eclipse Tractus-X kits.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -306,6 +306,11 @@ const config = {
                 label: 'KIT Master Data',
                 className: 'kit-nav-item'
               },
+              {
+                to: '/documentation/kit-3d-logo-library',
+                label: 'KIT Assets',
+                className: 'kit-nav-item'
+              },
               // Dynamically generated from kitsData
               ...generateKitNavItems(),
             ],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "npm run pre-build:kit-master-data && docusaurus start",
+    "start": "npm run pre-build:kit-master-data && npm run pre-render:kit-logos && docusaurus start",
     "build": "npm run pre-build:kit-master-data && npm run pre-render:kit-logos && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "npm run pre-build:kit-master-data && docusaurus start",
-    "build": "npm run pre-build:kit-master-data && docusaurus build",
+    "build": "npm run pre-build:kit-master-data && npm run pre-render:kit-logos && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
@@ -15,6 +15,7 @@
     "lint-doc": "markdownlint-cli2-config .markdownlint.yaml \"docs/**/*.md\" \"#node_modules\"",
     "lint-kits": "markdownlint-cli2-config .markdownlint.yaml \"docs-kits/kits/**/*.md\" \"#node_modules\"",
     "generate:nav-items": "node utils/generateKitNavItems.js",
+    "pre-render:kit-logos": "node utils/prerenderKitLogos.js",
     "pre-build:kit-master-data": "npm run validate:kits:silent && npm run generate:nav-items",
     "validate:kits": "node utils/validate-kits-data.js",
     "validate:kits:silent": "node utils/validate-kits-data.js --silent",

--- a/sidebarsDocumentation.js
+++ b/sidebarsDocumentation.js
@@ -57,6 +57,7 @@ const sidebars = {
         {
             type: 'category',
             label: 'KIT Assets',
+            collapsed: false,
             link: {
                 type: 'doc',
                 id: 'kit-3d-logo-library'

--- a/src/components/2.0/Kit3DLogo/Kit3DLogo.jsx
+++ b/src/components/2.0/Kit3DLogo/Kit3DLogo.jsx
@@ -38,11 +38,24 @@ import styles from './Kit3DLogo.module.scss';
  */
 const Kit3DLogo = ({ kitId, className = '', showDownload = false }) => {
   const containerRef = React.useRef(null);
-  const [showModal, setShowModal] = React.useState(false);
+  const optionsPanelRef = React.useRef(null);
+  const [showOptions, setShowOptions] = React.useState(false);
   const [downloadFormat, setDownloadFormat] = React.useState('svg');
   const [downloadSize, setDownloadSize] = React.useState('large');
   // Progress tracking: { active, progress (0-100), status, error }
   const [dl, setDl] = React.useState({ active: false, progress: 0, status: '', error: null });
+
+  // Close the options panel when clicking outside
+  React.useEffect(() => {
+    if (!showOptions) return;
+    const onMouseDown = (e) => {
+      if (optionsPanelRef.current && !optionsPanelRef.current.contains(e.target)) {
+        if (!dl.active) setShowOptions(false);
+      }
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    return () => document.removeEventListener('mousedown', onMouseDown);
+  }, [showOptions, dl.active]);
   
   // Find the kit data from all categories
   const kitData = useMemo(() => {
@@ -219,7 +232,7 @@ const Kit3DLogo = ({ kitId, className = '', showDownload = false }) => {
       }
 
       setDl({ active: false, progress: 100, status: 'Done!', error: null });
-      setTimeout(() => setShowModal(false), 600);
+      setTimeout(() => setShowOptions(false), 600);
     } catch (error) {
       console.error('Download error:', error);
       setDl({ active: false, progress: 0, status: '', error: error.message });
@@ -228,21 +241,21 @@ const Kit3DLogo = ({ kitId, className = '', showDownload = false }) => {
 
   /** Quick download: SVG at large size. */
   const handleQuickDownload = () => {
-    setShowModal(true);
-    setTimeout(() => handleDownload('svg', 'large'), 50);
+    handleDownload('svg', 'large');
   };
 
   return (
     <div className={`${styles.logo3dWrapper} ${className}`}>
       {showDownload && (
-        <>
+        <div ref={optionsPanelRef}>
           {/* Download trigger button */}
           <div className={styles.downloadButtons}>
             <button
               className={`${styles.downloadButton} ${styles.downloadButtonMain}`}
               onClick={handleQuickDownload}
-              title="Download as SVG (original size)"
+              title="Download as SVG (large)"
               aria-label="Download logo"
+              disabled={dl.active}
             >
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
@@ -252,106 +265,90 @@ const Kit3DLogo = ({ kitId, className = '', showDownload = false }) => {
             </button>
             <button
               className={`${styles.downloadButton} ${styles.downloadButtonDropdown}`}
-              onClick={() => { setDl({ active: false, progress: 0, status: '', error: null }); setShowModal(true); }}
+              onClick={() => { setDl({ active: false, progress: 0, status: '', error: null }); setShowOptions(v => !v); }}
               title="Download options"
               aria-label="Show download options"
-            > 
+            >
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                 <polyline points="6 9 12 15 18 9" />
               </svg>
             </button>
           </div>
 
-          {/* Download modal overlay */}
-          {showModal && (
-            // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-            <div className={styles.modalOverlay} onMouseDown={() => { if (!dl.active) setShowModal(false); }}>
-              {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-              <div className={styles.modalContent} onMouseDown={e => e.stopPropagation()}>
-                {/* Header */}
-                <div className={styles.modalHeader}>
-                  <h4>Download Logo</h4>
-                  {!dl.active && (
-                    <button
-                      className={styles.closeButton}
-                      onClick={() => setShowModal(false)}
-                      aria-label="Close"
-                    >
-                      ×
-                    </button>
-                  )}
-                </div>
-
-                {/* Progress section — shown while downloading */}
-                {dl.active && (
-                  <div className={styles.progressSection}>
-                    <div className={styles.progressBarTrack}>
-                      <div
-                        className={styles.progressBarFill}
-                        style={{ width: `${dl.progress}%` }}
-                      />
-                    </div>
-                    <div className={styles.progressInfo}>
-                      <span className={styles.progressStatus}>{dl.status}</span>
-                      <span className={styles.progressPct}>{dl.progress}%</span>
-                    </div>
-                  </div>
-                )}
-
-                {/* Error message */}
-                {dl.error && (
-                  <div className={styles.errorMessage}>
-                    <span>Download failed: {dl.error}</span>
-                    <button
-                      className={styles.retryButton}
-                      onClick={() => handleDownload(downloadFormat, downloadSize)}
-                    >
-                      Retry
-                    </button>
-                  </div>
-                )}
-
-                {/* Options — hidden while downloading */}
+          {/* Inline options dropdown panel */}
+          {showOptions && (
+            <div className={styles.downloadOptions}>
+              <div className={styles.optionsHeader}>
+                <h4>Download Logo</h4>
                 {!dl.active && (
-                  <>
-                    <div className={styles.optionGroup}>
-                      <label>Format:</label>
-                      <select
-                        value={downloadFormat}
-                        onChange={(e) => setDownloadFormat(e.target.value)}
-                      >
-                        <option value="svg">SVG</option>
-                        <option value="png">PNG</option>
-                      </select>
-                    </div>
-
-                    <div className={styles.optionGroup}>
-                      <label>Size:</label>
-                      <select
-                        value={downloadSize}
-                        onChange={(e) => setDownloadSize(e.target.value)}
-                      >
-                        <option value="small">Small (300×280)</option>
-                        <option value="medium">Medium (600×560)</option>
-                        <option value="large">Large (1200×1120)</option>
-                        <option value="xlarge">Full (2400×2240)</option>
-                      </select>
-                    </div>
-
-                    <div className={styles.downloadActions}>
-                      <button
-                        className={styles.downloadActionButton}
-                        onClick={() => handleDownload(downloadFormat, downloadSize)}
-                      >
-                        Download {downloadFormat.toUpperCase()}
-                      </button>
-                    </div>
-                  </>
+                  <button
+                    className={styles.closeButton}
+                    onClick={() => setShowOptions(false)}
+                    aria-label="Close"
+                  >
+                    ×
+                  </button>
                 )}
               </div>
+
+              {/* Progress bar — shown while downloading */}
+              {dl.active && (
+                <div className={styles.progressSection}>
+                  <div className={styles.progressBarTrack}>
+                    <div className={styles.progressBarFill} style={{ width: `${dl.progress}%` }} />
+                  </div>
+                  <div className={styles.progressInfo}>
+                    <span className={styles.progressStatus}>{dl.status}</span>
+                    <span className={styles.progressPct}>{dl.progress}%</span>
+                  </div>
+                </div>
+              )}
+
+              {/* Error message */}
+              {dl.error && (
+                <div className={styles.errorMessage}>
+                  <span>Download failed: {dl.error}</span>
+                  <button
+                    className={styles.retryButton}
+                    onClick={() => handleDownload(downloadFormat, downloadSize)}
+                  >
+                    Retry
+                  </button>
+                </div>
+              )}
+
+              {/* Options */}
+              {!dl.active && (
+                <>
+                  <div className={styles.optionGroup}>
+                    <label>Format:</label>
+                    <select value={downloadFormat} onChange={(e) => setDownloadFormat(e.target.value)}>
+                      <option value="svg">SVG</option>
+                      <option value="png">PNG</option>
+                    </select>
+                  </div>
+                  <div className={styles.optionGroup}>
+                    <label>Size:</label>
+                    <select value={downloadSize} onChange={(e) => setDownloadSize(e.target.value)}>
+                      <option value="small">Small (300×280)</option>
+                      <option value="medium">Medium (600×560)</option>
+                      <option value="large">Large (1200×1120)</option>
+                      <option value="xlarge">Full (2400×2240)</option>
+                    </select>
+                  </div>
+                  <div className={styles.downloadActions}>
+                    <button
+                      className={styles.downloadActionButton}
+                      onClick={() => handleDownload(downloadFormat, downloadSize)}
+                    >
+                      Download {downloadFormat.toUpperCase()}
+                    </button>
+                  </div>
+                </>
+              )}
             </div>
           )}
-        </>
+        </div>
       )}
       <div ref={containerRef} className={styles.logo3dContainer}>
         <div className={styles.logo3dInner}>

--- a/src/components/2.0/Kit3DLogo/Kit3DLogo.jsx
+++ b/src/components/2.0/Kit3DLogo/Kit3DLogo.jsx
@@ -38,14 +38,11 @@ import styles from './Kit3DLogo.module.scss';
  */
 const Kit3DLogo = ({ kitId, className = '', showDownload = false }) => {
   const containerRef = React.useRef(null);
-  const [showDownloadOptions, setShowDownloadOptions] = React.useState(false);
-  const [isDownloading, setIsDownloading] = React.useState(false);
-  const [downloadingFrom, setDownloadingFrom] = React.useState(null); // 'main' or 'dropdown'
+  const [showModal, setShowModal] = React.useState(false);
   const [downloadFormat, setDownloadFormat] = React.useState('svg');
-  const [downloadSettings, setDownloadSettings] = React.useState({
-    scale: 4,
-    size: 'xlarge'
-  });
+  const [downloadSize, setDownloadSize] = React.useState('large');
+  // Progress tracking: { active, progress (0-100), status, error }
+  const [dl, setDl] = React.useState({ active: false, progress: 0, status: '', error: null });
   
   // Find the kit data from all categories
   const kitData = useMemo(() => {
@@ -58,7 +55,6 @@ const Kit3DLogo = ({ kitId, className = '', showDownload = false }) => {
       ...(Object.values(kitsData.industryKits || {}).flat())
     ];
     
-    return allKits.find(kit => kit.id === kitId);
     return allKits.find(kit => kit.id === kitId);
   }, [kitId]);
 
@@ -136,331 +132,222 @@ const Kit3DLogo = ({ kitId, className = '', showDownload = false }) => {
 
   const Logo = kitData.logo;
 
-  // Size multipliers based on selected size
-  const sizeMultipliers = {
-    small: 0.5,
-    original: 1,
-    large: 2,
-    xlarge: 3,
-    xxlarge: 4,
-    ultra: 6
+  // Size presets: label → [width, height]
+  const sizePresets = {
+    small:  [300, 280],
+    medium: [600, 560],
+    large:  [1200, 1120],
+    xlarge: [2400, 2240],
   };
 
-  // Handle download with current settings
-  const handleDownload = async () => {
-    if (downloadingFrom === 'dropdown') {
-      // Download from dropdown with custom settings
-      if (downloadFormat === 'svg') {
-        await handleDownloadSVGCustom();
+  /** Trigger a file download from a Blob. */
+  const downloadBlob = (blob, filename) => {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.download = filename;
+    link.href = url;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    setTimeout(() => URL.revokeObjectURL(url), 500);
+  };
+
+  /** Allow React to process state updates between heavy sync steps. */
+  const yieldToUI = () => new Promise(resolve => { setTimeout(resolve, 0); });
+
+  /** Main download handler — fetches pre-rendered SVG, optionally rasterises to PNG. */
+  const handleDownload = async (format, size) => {
+    const onProgress = async (pct, msg) => {
+      setDl({ active: true, progress: pct, status: msg, error: null });
+      await yieldToUI();
+    };
+
+    setDl({ active: true, progress: 0, status: 'Starting...', error: null });
+    await yieldToUI();
+
+    try {
+      await onProgress(10, 'Fetching pre-rendered logo...');
+
+      const response = await fetch(`/generated/kit-logos/${kitId}.svg`);
+      if (!response.ok) throw new Error(`Logo not found (${response.status})`);
+
+      const svgText = await response.text();
+      const [outW, outH] = sizePresets[size] || sizePresets.large;
+
+      if (format === 'svg') {
+        // Patch the SVG width/height to the requested size
+        await onProgress(80, 'Preparing SVG...');
+        const resized = svgText
+          .replace(/width="\d+"/, `width="${outW}"`)
+          .replace(/height="\d+"/, `height="${outH}"`);
+
+        await onProgress(95, 'Downloading...');
+        const svgBlob = new Blob([resized], { type: 'image/svg+xml;charset=utf-8' });
+        downloadBlob(svgBlob, `${kitId}-3d-logo-${outW}x${outH}.svg`);
       } else {
-        await handleDownloadPNGCustom();
+        // Rasterise SVG → PNG at the requested size via canvas
+        await onProgress(30, 'Rasterising to PNG...');
+
+        const svgBlob = new Blob([svgText], { type: 'image/svg+xml;charset=utf-8' });
+        const imgUrl = URL.createObjectURL(svgBlob);
+        const img = await new Promise((resolve, reject) => {
+          const image = new Image();
+          image.onload = () => resolve(image);
+          image.onerror = () => reject(new Error('Failed to rasterise SVG'));
+          image.src = imgUrl;
+        });
+
+        await onProgress(60, 'Drawing to canvas...');
+
+        const canvas = document.createElement('canvas');
+        canvas.width = outW;
+        canvas.height = outH;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0, outW, outH);
+        URL.revokeObjectURL(imgUrl);
+
+        await onProgress(80, 'Encoding PNG...');
+        const pngBlob = await new Promise((resolve, reject) => {
+          canvas.toBlob(b => {
+            if (b) resolve(b);
+            else reject(new Error('Failed to create PNG'));
+          }, 'image/png', 1.0);
+        });
+
+        await onProgress(95, 'Downloading...');
+        downloadBlob(pngBlob, `${kitId}-3d-logo-${outW}x${outH}.png`);
       }
-    } else {
-      // Main button: always download SVG at original size and quality
-      await handleDownloadSVGOriginal();
+
+      setDl({ active: false, progress: 100, status: 'Done!', error: null });
+      setTimeout(() => setShowModal(false), 600);
+    } catch (error) {
+      console.error('Download error:', error);
+      setDl({ active: false, progress: 0, status: '', error: error.message });
     }
   };
 
-  // Handle SVG download at original size (for main button)
-  const handleDownloadSVGOriginal = async () => {
-    if (!containerRef.current) return;
-    setIsDownloading(true);
-    setDownloadingFrom('main');
-
-    try {
-      const html2canvas = (await import('html2canvas')).default;
-      
-      const canvas = await html2canvas(containerRef.current, {
-        backgroundColor: null,
-        scale: 2, // Fixed quality
-        logging: false,
-        useCORS: true,
-        allowTaint: true,
-      });
-
-      const blob = await new Promise((resolve) => {
-        canvas.toBlob(resolve, 'image/png', 1.0);
-      });
-
-      const reader = new FileReader();
-      const dataURL = await new Promise((resolve) => {
-        reader.onloadend = () => resolve(reader.result);
-        reader.readAsDataURL(blob);
-      });
-      
-      const width = canvas.width;
-      const height = canvas.height;
-      
-      const svgContent = [
-        '<?xml version="1.0" encoding="UTF-8" standalone="no"?>',
-        `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">`,
-        `  <image x="0" y="0" width="${width}" height="${height}" href="${dataURL}"/>`,
-        '</svg>'
-      ].join('\n');
-
-      const svgBlob = new Blob([svgContent], { type: 'image/svg+xml;charset=utf-8' });
-      const url = URL.createObjectURL(svgBlob);
-      const link = document.createElement('a');
-      link.download = `${kitId}-3d-logo.svg`;
-      link.href = url;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      
-      setTimeout(() => {
-        URL.revokeObjectURL(url);
-        setIsDownloading(false);
-        setDownloadingFrom(null);
-      }, 500);
-    } catch (error) {
-      console.error('Error downloading SVG:', error);
-      alert('Failed to download SVG: ' + error.message);
-      setIsDownloading(false);
-      setDownloadingFrom(null);
-    }
-  };
-
-  // Handle PNG download functionality with custom settings
-  const handleDownloadPNGCustom = async () => {
-    if (!containerRef.current) return;
-    setIsDownloading(true);
-    setDownloadingFrom('dropdown');
-
-    try {
-      const html2canvas = (await import('html2canvas')).default;
-      
-      const canvas = await html2canvas(containerRef.current, {
-        backgroundColor: null,
-        scale: downloadSettings.scale * sizeMultipliers[downloadSettings.size],
-        logging: false,
-      });
-
-      const blob = await new Promise((resolve, reject) => {
-        canvas.toBlob((blob) => {
-          if (blob) {
-            resolve(blob);
-          } else {
-            reject(new Error('Failed to create blob from canvas'));
-          }
-        }, 'image/png', 1.0);
-      });
-
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.download = `${kitId}-3d-logo-${downloadSettings.size}-${downloadSettings.scale}x.png`;
-      link.href = url;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      
-      setTimeout(() => {
-        
-        setTimeout(() => {
-          URL.revokeObjectURL(url);
-          setIsDownloading(false);
-          setDownloadingFrom(null);
-        }, 500);
-      }, 500);
-    } catch (error) {
-      console.error('Error downloading PNG:', error);
-      alert('Failed to download PNG: ' + error.message);
-      setIsDownloading(false);
-      setDownloadingFrom(null);
-    }
-  };
-
-  // Handle SVG download functionality with custom settings
-  const handleDownloadSVGCustom = async () => {
-    if (!containerRef.current) return;
-
-    try {
-      const html2canvas = (await import('html2canvas')).default;
-      
-      const canvas = await html2canvas(containerRef.current, {
-        backgroundColor: null,
-        scale: downloadSettings.scale * sizeMultipliers[downloadSettings.size],
-        logging: false,
-        useCORS: true,
-        allowTaint: true,
-      });
-
-      const blob = await new Promise((resolve) => {
-        canvas.toBlob(resolve, 'image/png', 1.0);
-      });
-
-      const reader = new FileReader();
-      const dataURL = await new Promise((resolve) => {
-        reader.onloadend = () => resolve(reader.result);
-        reader.readAsDataURL(blob);
-      });
-      
-      const width = canvas.width;
-      const height = canvas.height;
-      
-      const svgContent = [
-        '<?xml version="1.0" encoding="UTF-8" standalone="no"?>',
-        `<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">`,
-        `  <image x="0" y="0" width="${width}" height="${height}" href="${dataURL}"/>`,
-        '</svg>'
-      ].join('\n');
-
-      const svgBlob = new Blob([svgContent], { type: 'image/svg+xml;charset=utf-8' });
-      const url = URL.createObjectURL(svgBlob);
-      const link = document.createElement('a');
-      link.download = `${kitId}-3d-logo-${downloadSettings.size}-${downloadSettings.scale}x.svg`;
-      link.href = url;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      
-      setTimeout(() => {
-        URL.revokeObjectURL(url);
-        setIsDownloading(false);
-        setDownloadingFrom(null);
-      }, 500);
-    } catch (error) {
-      console.error('Error downloading SVG:', error);
-      alert('Failed to download SVG: ' + error.message);
-      setIsDownloading(false);
-      setDownloadingFrom(null);
-    }
+  /** Quick download: SVG at large size. */
+  const handleQuickDownload = () => {
+    setShowModal(true);
+    setTimeout(() => handleDownload('svg', 'large'), 50);
   };
 
   return (
     <div className={`${styles.logo3dWrapper} ${className}`}>
       {showDownload && (
         <>
+          {/* Download trigger button */}
           <div className={styles.downloadButtons}>
-            {/* Main download button */}
-            <button 
+            <button
               className={`${styles.downloadButton} ${styles.downloadButtonMain}`}
-              onClick={() => {
-                setDownloadingFrom('main');
-                setIsDownloading(true);
-                // Use setTimeout to allow React to re-render and show spinner before starting download
-                setTimeout(async () => {
-                  await handleDownloadSVGOriginal();
-                }, 50);
-              }}
+              onClick={handleQuickDownload}
               title="Download as SVG (original size)"
               aria-label="Download logo"
-              disabled={isDownloading}
             >
-              {isDownloading && downloadingFrom === 'main' ? (
-                <svg className={styles.spinner} width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                  <circle cx="12" cy="12" r="10" strokeOpacity="0.25"/>
-                  <path d="M12 2a10 10 0 0 1 10 10" strokeLinecap="round"/>
-                </svg>
-              ) : (
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-                  <polyline points="7 10 12 15 17 10" />
-                  <line x1="12" y1="15" x2="12" y2="3" />
-                </svg>
-              )}
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <polyline points="7 10 12 15 17 10" />
+                <line x1="12" y1="15" x2="12" y2="3" />
+              </svg>
             </button>
-            
-            {/* Dropdown arrow button */}
-            <button 
+            <button
               className={`${styles.downloadButton} ${styles.downloadButtonDropdown}`}
-              onClick={() => setShowDownloadOptions(!showDownloadOptions)}
+              onClick={() => { setDl({ active: false, progress: 0, status: '', error: null }); setShowModal(true); }}
               title="Download options"
               aria-label="Show download options"
-              disabled={isDownloading}
-            >
+            > 
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                 <polyline points="6 9 12 15 18 9" />
               </svg>
             </button>
           </div>
-          
-          {showDownloadOptions && (
-            <div className={styles.downloadOptions}>
-              <div className={styles.optionsHeader}>
-                <h4>Download Options</h4>
-                <button 
-                  className={styles.closeButton}
-                  onClick={() => setShowDownloadOptions(false)}
-                  aria-label="Close options"
-                >
-                  ×
-                </button>
-              </div>
-              
-              <div className={styles.optionGroup}>
-                <label>Format:</label>
-                <select 
-                  value={downloadFormat} 
-                  onChange={(e) => setDownloadFormat(e.target.value)}
-                >
-                  <option value="svg">SVG</option>
-                  <option value="png">PNG</option>
-                </select>
-              </div>
-              
-              <div className={styles.optionGroup}>
-                <label>Size:</label>
-                <select 
-                  value={downloadSettings.size} 
-                  onChange={(e) => setDownloadSettings({...downloadSettings, size: e.target.value})}
-                >
-                  <option value="small">Small (150x140)</option>
-                  <option value="original">Original (300x280)</option>
-                  <option value="large">Large (600x560)</option>
-                  <option value="xlarge">X-Large (900x840)</option>
-                  <option value="xxlarge">2X-Large (1200x1120)</option>
-                  <option value="ultra">Ultra (1800x1680)</option>
-                </select>
-              </div>
-              
-              <div className={styles.optionGroup}>
-                <label>Quality:</label>
-                <select 
-                  value={downloadSettings.scale} 
-                  onChange={(e) => setDownloadSettings({...downloadSettings, scale: Number(e.target.value)})}
-                >
-                  <option value="2">Standard (2x)</option>
-                  <option value="3">High (3x)</option>
-                  <option value="4">Ultra (4x)</option>
-                  <option value="5">Maximum (5x)</option>
-                  <option value="6">Extreme (6x)</option>
-                  <option value="8">Print Quality (8x)</option>
-                </select>
-              </div>
-              
-              <div className={styles.downloadActions}>
-                <button 
-                  className={styles.downloadActionButton}
-                  onClick={() => {
-                    setDownloadingFrom('dropdown');
-                    setIsDownloading(true);
-                    // Use setTimeout to allow React to re-render and show spinner before starting download
-                    setTimeout(async () => {
-                      try {
-                        if (downloadFormat === 'svg') {
-                          await handleDownloadSVGCustom();
-                        } else {
-                          await handleDownloadPNGCustom();
-                        }
-                      } finally {
-                        setShowDownloadOptions(false);
-                      }
-                    }, 50);
-                  }}
-                  disabled={isDownloading}
-                >
-                  {isDownloading && downloadingFrom === 'dropdown' ? (
-                    <>
-                      <svg className={styles.spinnerInline} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                        <circle cx="12" cy="12" r="10" strokeOpacity="0.25"/>
-                        <path d="M12 2a10 10 0 0 1 10 10" strokeLinecap="round"/>
-                      </svg>
-                      Downloading...
-                    </>
-                  ) : (
-                    `Download ${downloadFormat.toUpperCase()}`
+
+          {/* Download modal overlay */}
+          {showModal && (
+            // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+            <div className={styles.modalOverlay} onMouseDown={() => { if (!dl.active) setShowModal(false); }}>
+              {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+              <div className={styles.modalContent} onMouseDown={e => e.stopPropagation()}>
+                {/* Header */}
+                <div className={styles.modalHeader}>
+                  <h4>Download Logo</h4>
+                  {!dl.active && (
+                    <button
+                      className={styles.closeButton}
+                      onClick={() => setShowModal(false)}
+                      aria-label="Close"
+                    >
+                      ×
+                    </button>
                   )}
-                </button>
+                </div>
+
+                {/* Progress section — shown while downloading */}
+                {dl.active && (
+                  <div className={styles.progressSection}>
+                    <div className={styles.progressBarTrack}>
+                      <div
+                        className={styles.progressBarFill}
+                        style={{ width: `${dl.progress}%` }}
+                      />
+                    </div>
+                    <div className={styles.progressInfo}>
+                      <span className={styles.progressStatus}>{dl.status}</span>
+                      <span className={styles.progressPct}>{dl.progress}%</span>
+                    </div>
+                  </div>
+                )}
+
+                {/* Error message */}
+                {dl.error && (
+                  <div className={styles.errorMessage}>
+                    <span>Download failed: {dl.error}</span>
+                    <button
+                      className={styles.retryButton}
+                      onClick={() => handleDownload(downloadFormat, downloadSize)}
+                    >
+                      Retry
+                    </button>
+                  </div>
+                )}
+
+                {/* Options — hidden while downloading */}
+                {!dl.active && (
+                  <>
+                    <div className={styles.optionGroup}>
+                      <label>Format:</label>
+                      <select
+                        value={downloadFormat}
+                        onChange={(e) => setDownloadFormat(e.target.value)}
+                      >
+                        <option value="svg">SVG</option>
+                        <option value="png">PNG</option>
+                      </select>
+                    </div>
+
+                    <div className={styles.optionGroup}>
+                      <label>Size:</label>
+                      <select
+                        value={downloadSize}
+                        onChange={(e) => setDownloadSize(e.target.value)}
+                      >
+                        <option value="small">Small (300×280)</option>
+                        <option value="medium">Medium (600×560)</option>
+                        <option value="large">Large (1200×1120)</option>
+                        <option value="xlarge">Full (2400×2240)</option>
+                      </select>
+                    </div>
+
+                    <div className={styles.downloadActions}>
+                      <button
+                        className={styles.downloadActionButton}
+                        onClick={() => handleDownload(downloadFormat, downloadSize)}
+                      >
+                        Download {downloadFormat.toUpperCase()}
+                      </button>
+                    </div>
+                  </>
+                )}
               </div>
             </div>
           )}

--- a/src/components/2.0/Kit3DLogo/Kit3DLogo.module.scss
+++ b/src/components/2.0/Kit3DLogo/Kit3DLogo.module.scss
@@ -271,59 +271,6 @@
   }
 }
 
-/* ─── Download Modal ─────────────────────────────────────────────────── */
-
-/* Full-screen overlay */
-.modalOverlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.55);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 9999;
-  animation: fadeIn 0.15s ease;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
-/* Modal card */
-.modalContent {
-  background: var(--ifm-background-surface-color);
-  border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 16px;
-  padding: 24px;
-  width: 360px;
-  max-width: 90vw;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.25);
-  animation: slideUp 0.2s ease;
-}
-
-@keyframes slideUp {
-  from { opacity: 0; transform: translateY(12px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
-.modalHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 20px;
-
-  h4 {
-    margin: 0;
-    font-size: 18px;
-    font-weight: 600;
-    color: var(--ifm-font-color-base);
-  }
-}
-
 /* ─── Progress bar ───────────────────────────────────────────────────── */
 
 .progressSection {

--- a/src/components/2.0/Kit3DLogo/Kit3DLogo.module.scss
+++ b/src/components/2.0/Kit3DLogo/Kit3DLogo.module.scss
@@ -271,6 +271,138 @@
   }
 }
 
+/* ─── Download Modal ─────────────────────────────────────────────────── */
+
+/* Full-screen overlay */
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  animation: fadeIn 0.15s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Modal card */
+.modalContent {
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 16px;
+  padding: 24px;
+  width: 360px;
+  max-width: 90vw;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.25);
+  animation: slideUp 0.2s ease;
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.modalHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+
+  h4 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--ifm-font-color-base);
+  }
+}
+
+/* ─── Progress bar ───────────────────────────────────────────────────── */
+
+.progressSection {
+  margin-bottom: 20px;
+}
+
+.progressBarTrack {
+  width: 100%;
+  height: 8px;
+  border-radius: 4px;
+  background: var(--ifm-color-emphasis-200);
+  overflow: hidden;
+}
+
+.progressBarFill {
+  height: 100%;
+  border-radius: 4px;
+  background: var(--ifm-color-primary);
+  transition: width 0.3s ease;
+}
+
+.progressInfo {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.progressStatus {
+  font-size: 13px;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.progressPct {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  min-width: 36px;
+  text-align: right;
+}
+
+/* ─── Error state ────────────────────────────────────────────────────── */
+
+.errorMessage {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  border-radius: 8px;
+  background: rgba(220, 38, 38, 0.1);
+  border: 1px solid rgba(220, 38, 38, 0.3);
+  color: var(--ifm-color-danger-darkest);
+  font-size: 13px;
+
+  [data-theme='dark'] & {
+    background: rgba(248, 113, 113, 0.1);
+    border-color: rgba(248, 113, 113, 0.3);
+    color: var(--ifm-color-danger-lightest);
+  }
+}
+
+.retryButton {
+  flex-shrink: 0;
+  padding: 6px 14px;
+  border: none;
+  border-radius: 6px;
+  background: var(--ifm-color-primary);
+  color: white;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--ifm-color-primary-dark);
+  }
+}
+
 /* 3D Logo Stack Container */
 .logo3dContainer {
   position: relative;

--- a/utils/prerenderKitLogos.js
+++ b/utils/prerenderKitLogos.js
@@ -1,0 +1,444 @@
+#!/usr/bin/env node
+
+/*********************************************************************************
+ * Eclipse Tractus-X - eclipse-tractusx.github.io
+ *
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+/**
+ * Pre-renders all Kit 3D logos as SVG files at build time.
+ *
+ * This replicates the CSS 3D isometric effect (rotateX(55deg) rotateZ(45deg))
+ * using pure SVG with computed 2D projection math.
+ *
+ * Output: static/generated/kit-logos/{kitId}.svg (git-ignored, generated per build)
+ *
+ * Usage: node utils/prerenderKitLogos.js
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Constants matching the CSS (Kit3DLogo.module.scss)
+// ──────────────────────────────────────────────────────────────────────────────
+const CONTAINER_W = 300;
+const CONTAINER_H = 280;
+const INNER_SIZE = 180;
+const BORDER_RADIUS = 24;
+const INNER_OFFSET_Y = 30; // translateY(30px) on .logo3dInner
+
+// 3D rotation angles (degrees → radians)
+const RX_DEG = 55;
+const RZ_DEG = 45;
+const RX = (RX_DEG * Math.PI) / 180;
+const RZ = (RZ_DEG * Math.PI) / 180;
+const cosRX = Math.cos(RX);
+const sinRX = Math.sin(RX);
+const cosRZ = Math.cos(RZ);
+const sinRZ = Math.sin(RZ);
+
+// Layer definitions: { zOffset, opacity, type }
+// type: 'fill' = gradient-filled, 'border' = stroke only
+const LAYERS = [
+  { zOffset: -14.5, opacity: 0.4, type: 'border' },  // layer5
+  { zOffset: 0,     opacity: 0.4, type: 'fill' },     // layer4
+  { zOffset: 14.5,  opacity: 0.4, type: 'border' },   // layer4b
+  { zOffset: 29,    opacity: 0.6, type: 'fill' },     // layer3
+  { zOffset: 43.5,  opacity: 0.6, type: 'border' },   // layer3b
+  { zOffset: 58,    opacity: 0.8, type: 'fill' },     // layer2
+  { zOffset: 72.5,  opacity: 0.8, type: 'border' },   // layer2b
+  { zOffset: 87,    opacity: 1,   type: 'fill' },     // layer1 (top)
+];
+
+const BORDER_WIDTH = 2;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 3D → 2D projection (orthographic with CSS transform order)
+//
+// CSS: transform: rotateX(55deg) rotateZ(45deg) translateZ(offset)
+// Applied right-to-left: first rotateZ, then rotateX.
+//
+// For a point (px, py) on a flat layer at translateZ = offset:
+//   After rotateZ(45°):  x1 = px·cosRZ − py·sinRZ,  y1 = px·sinRZ + py·cosRZ,  z1 = offset
+//   After rotateX(55°):  x2 = x1,  y2 = y1·cosRX − z1·sinRX
+//
+// Screen coords: (x2, y2)
+// ──────────────────────────────────────────────────────────────────────────────
+
+function project(px, py, zOffset) {
+  const x1 = px * cosRZ - py * sinRZ;
+  const y1 = px * sinRZ + py * cosRZ;
+  const x2 = x1;
+  const y2 = y1 * cosRX - zOffset * sinRX;
+  return { x: x2, y: y2 };
+}
+
+/**
+ * Generate points along a rounded rectangle (in local coords centered at origin).
+ * Returns array of {x, y} points that approximate the rounded rect including arcs.
+ */
+function roundedRectPoints(w, h, r, segments = 16) {
+  const hw = w / 2;
+  const hh = h / 2;
+  const points = [];
+
+  // Clamp radius
+  const cr = Math.min(r, hw, hh);
+
+  // Go clockwise from top-left corner
+  // Top-left arc: center at (-hw+cr, -hh+cr), from 180° to 270°
+  for (let i = 0; i <= segments; i++) {
+    const angle = Math.PI + (i / segments) * (Math.PI / 2);
+    points.push({
+      x: -hw + cr + cr * Math.cos(angle),
+      y: -hh + cr + cr * Math.sin(angle),
+    });
+  }
+  // Top-right arc: center at (hw-cr, -hh+cr), from 270° to 360°
+  for (let i = 0; i <= segments; i++) {
+    const angle = (3 * Math.PI) / 2 + (i / segments) * (Math.PI / 2);
+    points.push({
+      x: hw - cr + cr * Math.cos(angle),
+      y: -hh + cr + cr * Math.sin(angle),
+    });
+  }
+  // Bottom-right arc: center at (hw-cr, hh-cr), from 0° to 90°
+  for (let i = 0; i <= segments; i++) {
+    const angle = (i / segments) * (Math.PI / 2);
+    points.push({
+      x: hw - cr + cr * Math.cos(angle),
+      y: hh - cr + cr * Math.sin(angle),
+    });
+  }
+  // Bottom-left arc: center at (-hw+cr, hh-cr), from 90° to 180°
+  for (let i = 0; i <= segments; i++) {
+    const angle = Math.PI / 2 + (i / segments) * (Math.PI / 2);
+    points.push({
+      x: -hw + cr + cr * Math.cos(angle),
+      y: hh - cr + cr * Math.sin(angle),
+    });
+  }
+
+  return points;
+}
+
+/**
+ * Project a set of 2D points through the 3D transform and return
+ * an SVG polygon/path points string.
+ */
+function projectPolygon(localPoints, zOffset, cx, cy) {
+  return localPoints
+    .map((pt) => {
+      const p = project(pt.x, pt.y, zOffset);
+      return `${(p.x + cx).toFixed(2)},${(p.y + cy).toFixed(2)}`;
+    })
+    .join(' ');
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Parse kitsData.js
+// ──────────────────────────────────────────────────────────────────────────────
+
+function parseKitsData() {
+  const kitsDataPath = path.join(__dirname, '../data/kitsData.js');
+  const content = fs.readFileSync(kitsDataPath, 'utf8');
+
+  const kits = [];
+
+  // Map import variable names to SVG file paths
+  const importMap = {};
+  const importRegex = /import\s+(\w+)\s+from\s+["']@site\/([^"']+)["']/g;
+  let m;
+  while ((m = importRegex.exec(content)) !== null) {
+    importMap[m[1]] = m[2];
+  }
+
+  // Split into individual kit blocks by finding each { id: '...' } object.
+  // We locate each "id:" and extract the surrounding block.
+  const idRegex = /id:\s*['"]([^'"]+)['"]/g;
+  const idPositions = [];
+  while ((m = idRegex.exec(content)) !== null) {
+    idPositions.push({ id: m[1], pos: m.index });
+  }
+
+  for (let i = 0; i < idPositions.length; i++) {
+    const start = idPositions[i].pos;
+    const end = i + 1 < idPositions.length ? idPositions[i + 1].pos : content.length;
+    const block = content.substring(start, end);
+    const kitId = idPositions[i].id;
+
+    // Skip template/placeholder entries
+    if (kitId.includes('<') || kitId.includes('>')) continue;
+
+    // Extract fields from this block
+    const nameMatch = block.match(/name:\s*['"]([^'"]+)['"]/);
+    const logoMatch = block.match(/logo:\s*(\w+)\s*,/);
+    const heightMatch = block.match(/logoHeight:\s*(\d+)/);
+    const widthMatch = block.match(/logoWidth:\s*(\d+)/);
+    const gradientMatch = block.match(/gradient:\s*['"]([^'"]+)['"]/);
+    const primaryMatch = block.match(/primary:\s*['"]([^'"]+)['"]/);
+
+    if (!nameMatch || !logoMatch || !heightMatch || !widthMatch || !gradientMatch || !primaryMatch) {
+      continue; // Incomplete entry (e.g. template placeholder or industry category)
+    }
+
+    const logoVar = logoMatch[1];
+    const svgRelPath = importMap[logoVar];
+    if (!svgRelPath) {
+      console.warn(`  ⚠  No SVG import found for "${logoVar}" (kit: ${kitId}), skipping`);
+      continue;
+    }
+
+    kits.push({
+      id: kitId,
+      name: nameMatch[1],
+      logoSvgPath: path.join(__dirname, '..', svgRelPath),
+      logoHeight: Number.parseInt(heightMatch[1], 10),
+      logoWidth: Number.parseInt(widthMatch[1], 10),
+      gradient: gradientMatch[1],
+      primaryColor: primaryMatch[1],
+    });
+  }
+
+  return kits;
+}
+
+/**
+ * Extract two hex colours from a CSS gradient string.
+ * Supports both hex (#RRGGBB) and rgba() formats.
+ */
+function parseGradientColors(gradient) {
+  // Try hex format
+  const hexMatches = gradient.match(/#[0-9A-Fa-f]{6}/g);
+  if (hexMatches && hexMatches.length >= 2) {
+    return [hexMatches[0], hexMatches[1]];
+  }
+  // Try rgba
+  const rgbaMatches = gradient.match(/rgba?\(([^)]+)\)/g);
+  if (rgbaMatches && rgbaMatches.length >= 2) {
+    return rgbaMatches.map((rgba) => {
+      const parts = rgba.match(/(\d+)/g);
+      if (!parts || parts.length < 3) return '#888888';
+      const [r, g, b] = parts.map(Number);
+      return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
+    });
+  }
+  return ['#888888', '#444444'];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SVG construction
+// ──────────────────────────────────────────────────────────────────────────────
+
+function buildLogoSvg(kit) {
+  const [color1, color2] = parseGradientColors(kit.gradient);
+  const primary = kit.primaryColor;
+
+  // Centre of the inner container in the output viewport
+  const cx = CONTAINER_W / 2;
+  const cy = CONTAINER_H / 2 + INNER_OFFSET_Y;
+
+  // Rounded rect points for a 180×180 layer (centred at origin)
+  const rectPts = roundedRectPoints(INNER_SIZE, INNER_SIZE, BORDER_RADIUS, 16);
+
+  let defs = '';
+  let layers = '';
+
+  LAYERS.forEach((layer, idx) => {
+    const points = projectPolygon(rectPts, layer.zOffset, cx, cy);
+    const gradId = `grad_${idx}`;
+
+    if (layer.type === 'fill') {
+      // Gradient definition (each layer gets its own because the y-shift differs)
+      const gs = project(-INNER_SIZE / 2, INNER_SIZE / 2, layer.zOffset);
+      const ge = project(INNER_SIZE / 2, -INNER_SIZE / 2, layer.zOffset);
+      defs += `<linearGradient id="${gradId}" gradientUnits="userSpaceOnUse"
+        x1="${(gs.x + cx).toFixed(2)}" y1="${(gs.y + cy).toFixed(2)}"
+        x2="${(ge.x + cx).toFixed(2)}" y2="${(ge.y + cy).toFixed(2)}">
+        <stop offset="0%" stop-color="${color1}"/>
+        <stop offset="100%" stop-color="${color2}"/>
+      </linearGradient>\n`;
+
+      layers += `<polygon points="${points}"
+        fill="url(#${gradId})" opacity="${layer.opacity}"/>\n`;
+    } else {
+      // Border-only layer
+      layers += `<polygon points="${points}"
+        fill="none" stroke="${primary}" stroke-width="${BORDER_WIDTH}"
+        opacity="${layer.opacity}"/>\n`;
+    }
+  });
+
+  // ── Logo on top layer ──────────────────────────────────────────────────
+  // Read the raw SVG and embed it, transformed to sit on the top layer.
+  let logoContent = '';
+  try {
+    const svgRaw = fs.readFileSync(kit.logoSvgPath, 'utf8');
+    // Extract viewBox or width/height from the raw SVG
+    const vbMatch = svgRaw.match(/viewBox=["']([^"']+)["']/);
+    const wMatch = svgRaw.match(/width=["'](\d+(?:\.\d+)?)/);
+    const hMatch = svgRaw.match(/height=["'](\d+(?:\.\d+)?)/);
+
+    let svgW, svgH;
+    if (vbMatch) {
+      const parts = vbMatch[1].split(/[\s,]+/).map(Number);
+      svgW = parts[2] || 100;
+      svgH = parts[3] || 100;
+    } else {
+      svgW = wMatch ? Number.parseFloat(wMatch[1]) : 100;
+      svgH = hMatch ? Number.parseFloat(hMatch[1]) : 100;
+    }
+
+    // Logo size: same logic as the React component
+    const avgSize = (kit.logoWidth + kit.logoHeight) / 2;
+    const logoSizePercent = (avgSize / 80) * 45;
+    const logoW = (INNER_SIZE * logoSizePercent) / 100;
+    const logoH = (INNER_SIZE * logoSizePercent) / 100;
+
+    // Position the logo centred on the top layer.
+    // In layer-local coords (centred at origin): the logo occupies
+    // [-logoW/2, -logoH/2] to [logoW/2, logoH/2]
+    //
+    // We need to project the four corners of the logo bounding box through
+    // the 3D transform, then use an SVG affine transform to map the logo SVG
+    // into that projected quadrilateral.
+    //
+    // For an orthographic projection the affine transform is the same for all
+    // points at the same z. We compute the affine matrix directly:
+    //
+    //   | cosRZ   -sinRZ |   then   | 1       0      |
+    //   | sinRZ    cosRZ |          | 0     cosRX     |
+    //
+    // Combined: a = cosRZ, b = sinRZ*cosRX, c = -sinRZ, d = cosRZ*cosRX
+    const a = cosRZ;
+    const b = sinRZ * cosRX;
+    const c = -sinRZ;
+    const d = cosRZ * cosRX;
+
+    const topZ = 87; // top layer zOffset
+    const yShift = -topZ * sinRX;
+
+    // We want to map the SVG viewbox [0, 0, svgW, svgH] onto the projected
+    // rectangle centred at (cx, cy + yShift).
+    //
+    // Scale from SVG coords to layer-local coords:
+    const sx = logoW / svgW;
+    const sy = logoH / svgH;
+
+    // The full transform: translate to centre, apply projection matrix, scale from SVG coords
+    // SVG point (u, v) → layer local (u*sx - logoW/2, v*sy - logoH/2) → projected
+    //
+    // In SVG matrix(a, b, c, d, e, f) format:
+    //   x' = a*u + c*v + e
+    //   y' = b*u + d*v + f
+    //
+    // Combined steps:
+    //   local_x = u * sx - logoW/2
+    //   local_y = v * sy - logoH/2
+    //   proj_x = a * local_x + c * local_y + cx
+    //   proj_y = b * local_x + d * local_y + cy + yShift
+    //
+    //   proj_x = (a*sx)*u + (c*sy)*v + (-a*logoW/2 - c*logoH/2 + cx)
+    //   proj_y = (b*sx)*u + (d*sy)*v + (-b*logoW/2 - d*logoH/2 + cy + yShift)
+
+    const ma = a * sx;
+    const mb = b * sx;
+    const mc = c * sy;
+    const md = d * sy;
+    const me = -a * (logoW / 2) - c * (logoH / 2) + cx;
+    const mf = -b * (logoW / 2) - d * (logoH / 2) + cy + yShift;
+
+    // Extract inner SVG content (everything inside the <svg ...>...</svg> tag)
+    const innerMatch = svgRaw.match(/<svg[^>]*>([\s\S]*)<\/svg>/i);
+    const innerSvg = innerMatch ? innerMatch[1] : '';
+
+    const cleanInner = innerSvg;
+
+    logoContent = `<g transform="matrix(${ma.toFixed(6)}, ${mb.toFixed(6)}, ${mc.toFixed(6)}, ${md.toFixed(6)}, ${me.toFixed(2)}, ${mf.toFixed(2)})"
+      opacity="1">
+      ${cleanInner}
+    </g>`;
+  } catch (err) {
+    console.warn(`  ⚠  Could not read logo SVG for ${kit.id}: ${err.message}`);
+  }
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${CONTAINER_W}" height="${CONTAINER_H}"
+    viewBox="0 0 ${CONTAINER_W} ${CONTAINER_H}">
+  <defs>${defs}</defs>
+  ${layers}
+  ${logoContent}
+</svg>`;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Main
+// ──────────────────────────────────────────────────────────────────────────────
+
+function renderKit(kit, outDir) {
+  const outPath = path.join(outDir, `${kit.id}.svg`);
+  try {
+    const svg = buildLogoSvg(kit);
+    fs.writeFileSync(outPath, svg, 'utf8');
+    const sizeKB = (Buffer.byteLength(svg, 'utf8') / 1024).toFixed(1);
+    console.log(`  ✅ ${kit.id.padEnd(30)} ${sizeKB} KB`);
+    return true;
+  } catch (err) {
+    console.error(`  ❌ ${kit.id}: ${err.message}`);
+    return false;
+  }
+}
+
+async function main() {
+  console.log('═'.repeat(60));
+  console.log('Pre-rendering Kit 3D logos as SVG...\n');
+
+  const kits = parseKitsData();
+  if (kits.length === 0) {
+    console.error('❌ No kits found in kitsData.js');
+    process.exit(1);
+  }
+
+  console.log(`Found ${kits.length} kits.\n`);
+
+  const outDir = path.join(__dirname, '../static/generated/kit-logos');
+  fs.mkdirSync(outDir, { recursive: true });
+
+  let rendered = 0;
+  let failed = 0;
+
+  for (const kit of kits) {
+    if (renderKit(kit, outDir)) rendered++;
+    else failed++;
+  }
+
+  const totalSizeMB = fs
+    .readdirSync(outDir)
+    .filter((f) => f.endsWith('.svg'))
+    .reduce((sum, f) => sum + fs.statSync(path.join(outDir, f)).size, 0) / (1024 * 1024);
+
+  console.log(`\n${'═'.repeat(60)}`);
+  console.log(`Pre-render complete: ${rendered} rendered, ${failed} failed`);
+  console.log(`Total size: ${totalSizeMB.toFixed(2)} MB in ${outDir}`);
+  console.log('═'.repeat(60));
+
+  if (failed > 0) process.exit(1);
+}
+
+main();


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

There was a big problem when we wanted to download kits:

<img width="527" height="544" alt="image" src="https://github.com/user-attachments/assets/1c1a865c-64b0-45a1-9227-c2658ec718df" />

When we tried to download the "browser" blocked, because it was generating the SVG in a canvas with the "power" of your computer processing. After 2 minutes it worked to download.

There for I needed to find a solution to fix this. What I have done is to "pre-process" the kit logos with the CSS component before and store them into a simple svg file (only in the "compiled/image" version of the website), so not even storing it in the repo itself to save space.

Therefore I just offer now this options to download, just resizing the SVG (can be done by some attributes in the XML from the SVG), and then if a PNG is needed it can still be downloaded, but converting a SVG to a PNG is a straight forward operation which takes not capacity from your browser or computer.

<img width="587" height="817" alt="image" src="https://github.com/user-attachments/assets/8602db81-3da8-4b30-b7d4-0e5eb41211fa" />


Therefore when we compile the website there is now a "pre-rendering" step which I added:

<img width="845" height="611" alt="image" src="https://github.com/user-attachments/assets/8c89cc1d-7033-45fd-abc9-36f2745972f6" />

It should be straight forward.

Also I have made more visible the KIT 3d LOGO library now people can see it:

This pull request introduces a new "KIT 3D Logo Library" feature, making 3D isometric logos for Eclipse Tractus-X kits available for browsing and download. It adds a new documentation page, navigation links, and a major refactor of the logo download component to support pre-rendered SVG/PNG downloads at multiple sizes with a new modal UI and progress feedback.

**New Feature: KIT 3D Logo Library**

* Added a new documentation page `kit-3d-logo-library.mdx` for browsing and downloading 3D isometric kit logos, marked as BETA and integrated into the sidebar and navigation. [[1]](diffhunk://#diff-16394c8d1ea319bf1fe3de6554c9a7073b6da3734ca7ec01a2b20f7e10a4d9d2R4) [[2]](diffhunk://#diff-16394c8d1ea319bf1fe3de6554c9a7073b6da3734ca7ec01a2b20f7e10a4d9d2R29-R30) [[3]](diffhunk://#diff-a038096cbdea434999e1dce5ab497212f1fe18204dde1a027ce3bdd663261a2aR309-R313) [[4]](diffhunk://#diff-7fa7db656b371779b2d8abee2b7e28bdeac5b8b9f20eea72e0b57862fa6a4ab6R60)

**Build & Pre-rendering Improvements**

* Updated the build process in `package.json` to pre-render kit logos before the Docusaurus build, and added a new script `pre-render:kit-logos` for this purpose. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L8-R8) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R18)

**Logo Download Component Refactor**

* Refactored `Kit3DLogo.jsx` to fetch pre-rendered SVGs for downloads instead of rendering on the client, supporting both SVG and PNG formats at multiple preset sizes, with a new modal UI for download options, progress tracking, and error handling. The component now provides a smoother and more robust download experience. [[1]](diffhunk://#diff-32076b69f26249a5705e48576dfc8f18ccd7b607246bf49efffd9154faf6a70aL41-R45) [[2]](diffhunk://#diff-32076b69f26249a5705e48576dfc8f18ccd7b607246bf49efffd9154faf6a70aL139-R316) [[3]](diffhunk://#diff-32076b69f26249a5705e48576dfc8f18ccd7b607246bf49efffd9154faf6a70aL404-L463)

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
