### PR TITLE
feat: Update Construct-X logo URL in kitsData.js

### DIFF
--- a/data/kitsData.js
+++ b/data/kitsData.js
@@ -1326,7 +1326,7 @@ export const industries = [
         url: "https://construct-x.org",
         gradient: 'linear-gradient(135deg, #002865, #FF6B35, #FFB74D)',
         logo: {
-          src: 'https://construct-x.org/wp-content/uploads/2025/11/CX-BM-RGB.png',
+          src: 'https://www.construct-x.org/sites/default/files/2026-05/cx-bm-rgb_0.png',
           alt: 'Construct-X Logo',
           width: 70,
           height: 70


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

Very simple:

Contruct-X link for the logo has changed

And now it displays like this:
<img width="2095" height="595" alt="image" src="https://github.com/user-attachments/assets/cc2a4195-c80d-4335-a707-6561bc49a196" />

This PR updates to the latest link:

https://www.construct-x.org/sites/default/files/2026-05/cx-bm-rgb_0.png

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
