### PR TITLE
docs(release-planning): add Open Planning session details for Release 27.03

### DIFF
--- a/blog/2026-11-05-release-planning-R27.03.md
+++ b/blog/2026-11-05-release-planning-R27.03.md
@@ -1,0 +1,100 @@
+---
+title: Release Planning for Release 27.03
+description: Eclipse Tractus-X Community Update - Release Planning for Release 27.03
+slug: release-planning-R27.03
+date: 2026-08-11T10:30
+hide_table_of_contents: false
+authors:
+  - stephan_bauer
+  - theresa_hilger
+---
+
+[![Eclipse Tractus-X Open Planning Banner](/img/Tractus-X_openplanning.png)](/img/Tractus-X_openplanning.png)
+
+Hello, Eclipse Tractus-X Community!
+
+Collaboration drives the success of Eclipse Tractus-X, and we are excited to invite you to the **Release Planning session for R27.03**!
+This session is your chance to shape the roadmap, align with the community, and ensure a well-structured release.
+
+- **Matrix chat -> [Release Management](https://matrix.to/#/#tractusx-release-planning:matrix.eclipse.org)**
+- **Matrix chat -> [Test Management](https://matrix.to/#/#tractusx-test-management:matrix.eclipse.org)**
+
+**Key Information:**
+
+- 📅 **Dates and Times**: Listed for each session below.
+- 📂 **Resources**: Visit our [**open meetings page**](/community/open-meetings) for all session links and additional documentation.
+- 🔗 **Preparation Materials**: Ensure readiness by reviewing the provided templates, guidelines, and your own features.
+
+We look forward to seeing you there and working together to make R27.03 a success!
+
+<!--truncate-->
+
+## Open Planning for R27.03
+
+The Open Planning session finalizes the roadmap for R27.03, prioritizing features and aligning all participants on deliverables
+for the release.
+
+- **Date:** 11.11.2026
+- **Time:** 09:05 - 10:30
+- **Teams Link:** [Join the session](https://teams.microsoft.com/meet/390787570757205?p=0jCKpPTyrjvhJYFmNz)
+
+**Who Should Attend**:
+
+- Contributors and Committers from the open-source community
+- Expert Group and Committee members
+- Feature requesters and stakeholders
+
+:::note
+Your participation is crucial to ensure the success of the release planning. Expert Groups, Committees, the open-source community
+(contributor and committer), feature requesters are encouraged to attend and actively engage in the discussions.
+:::
+
+### Agenda
+
+Here's the plan for the day:
+
+- **09:05 - 09:20**: Open Planning - Vision & Introduction
+- **09:20 - 10:15**: Joint Open Planning (all teams)
+- **10:15 - 10:30**: Feedback Retro / Open Planning Wrap-up / Summary & Next Steps
+
+#### Joint Open Planning
+
+:::note
+The planning sessions will be driven by our [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26), which organizes features based on their **Topic/Product** field. The current agenda is only an example and will be updated with the actual features that are planned for R27.03.
+:::
+
+| Time          | Topics | Features |
+|---------------|--------|----------|
+| 09:20 - 10:15 | TBD    |          |
+
+:::warning[**Please note:**]
+
+- The agenda provides a **rough time structure** to help guide the session. The **timings are not fixed** and can be adjusted
+- depending on the flow of the discussion.
+- Use the agenda as **orientation**, but we may deviate if needed based on progress.
+
+:::
+
+### Prerequisites for features to be considered in Open Planning
+
+For a feature to be included in the Open Planning, the following conditions must be met:
+
+- **Status must be 'Backlog'** - Committers and Expert Groups can set this status after the feature is fully refined.
+- **All categories in the feature template must be filled** - Do not delete any sections from the template.
+- **Milestone is NOT set** - This will be assigned during the Open Planning session.
+- **Contributor and Committer must be assigned**.
+- **`Topic/Product` must be set**.
+
+During the session, if there is a common alignment among the participants, the feature milestone can be set to **27.03**, meaning
+it will be developed in the upcoming release.
+
+### Important Notes and Hints
+
+- Keep the board clean - there are still features with older milestones that have not yet been completed.
+- Do not delete any sections from the feature template, except for KITs.
+- For KITs, only the Contributor, Committer, and Description fields need to be filled.
+
+For any questions or further information, feel free to reach out via our [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev)
+or join us in the Tractus-X [Matrix channel](https://matrix.to/#/#automotive.tractusx:matrix.eclipse.org).
+
+We look forward to your participation and collaboration! 🚀

--- a/data/meetings.js
+++ b/data/meetings.js
@@ -471,4 +471,33 @@ export const meetings = [
       endTime: '10:30',
     },
   },
+  {
+    id: 'open-planning-r27-03',
+    title: 'Open Planning for R27.03',
+    icon: 'event_note',
+    category: MEETING_CATEGORIES.ONE_TIME,
+    priority: MEETING_PRIORITIES.FEATURED,
+    description: 'Finalize roadmap, prioritize features and align participants on deliverables for Release 27.03.',
+    contact: [CONTACTS.STEPHAN_BAUER, CONTACTS.THERESA_HILGER],
+    sessionLink: 'https://teams.microsoft.com/meet/390787570757205?p=0jCKpPTyrjvhJYFmNz',
+    matrixChatUrl: 'https://chat.eclipse.org/#/room/#tractusx-release-planning:matrix.eclipse.org',
+    additionalLinks: [
+      {
+        title: 'Release Planning Board - Topic/Product',
+        url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/28?filterQuery=-status%3ADone+has%3Atopic%2Fproduct+label%3A%22Prep-R27.03%22+status%3ABacklog'
+      },
+      {
+        title: 'Timeline',
+        url: 'https://github.com/orgs/eclipse-tractusx/projects/26/views/35?filterQuery=label%3Ametadata+milestone%3A27.03'
+      },
+      {title: 'News Blog', url: '/blog/release-planning-R27.03'},
+      {title: 'Detailed Agenda', url: '/blog/release-planning-R27.03#agenda-1'},
+    ],
+    recurrence: {
+      frequency: 'once',
+      startDate: '2026-11-11',
+      startTime: '09:05',
+      endTime: '10:30',
+    },
+  },
 ];


### PR DESCRIPTION
## Description

This pull request adds information and promotion for the upcoming "Open Planning for R27.03" release planning session for Eclipse Tractus-X. The main changes are the creation of a new blog post with all relevant details and the addition of the event to the meetings data, ensuring it appears in the site's event listings and calendars.

**Event announcement and documentation:**

* Added a new blog post (`blog/2026-11-05-release-planning-R27.03.md`) that announces the R27.03 release planning session, including agenda, participation details, prerequisites for feature consideration, and resource links.

**Event listing and integration:**

* Added the "Open Planning for R27.03" session to the `meetings.js` data file, with full metadata (title, description, date/time, organizers, links to resources and agenda, and recurrence information) to ensure the event is featured and discoverable on the site.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
