### PR TITLE
Update kick-off meeting for release 26.09

### DIFF
--- a/data/meetings.js
+++ b/data/meetings.js
@@ -409,8 +409,8 @@ export const meetings = [
     recurrence: {
       frequency: 'once',
       startDate: '2026-08-17',
-      startTime: '08:30',
-      endTime: '09:00',
+      startTime: '11:00',
+      endTime: '11:30',
     },
   },
   // New entries for R26.12 - Alignment Day and Open Planning


### PR DESCRIPTION
## Description

Updatefor
This pull request updates the  kick-off meeting information in the data/meetings.js file to reflect the new  start and end time. 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
