### PR TITLE
Doc: update Traceability KIT documentation for release 26.09

### DIFF
--- a/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/adoption-view.mdx
+++ b/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/adoption-view.mdx
@@ -73,7 +73,7 @@ Block Notifications enable the standardized and machine-readable exchange of inf
 
 They support time-critical containment processes by allowing suppliers to communicate affected parts and related containment information to their customers. Typical triggers include supplier self-disclosures and customer complaints.
 
-> :raised_hand: Detailed information of the specific data being exchanged are available in the [Development View](https://eclipse-tractusx.github.io/docs-kits/kits/traceability-kit/software-development-view/data-provider-development-view#aspect-models).
+> :raised_hand: Detailed information about the exchanged data can be found in the Development View.
 
 Block Notifications help business partners identify affected parts earlier, initiate containment measures faster and improve collaboration during quality incidents.
 

--- a/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/adoption-view.mdx
+++ b/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/adoption-view.mdx
@@ -69,11 +69,13 @@ The following figure illustrates, how quality investigations and alerts througho
 
 ### Block Notifications
 
-Equal to quality notifications, block notifications are a form of data exchange to transfer information about defect parts in a standardized way. Quality notifications in general and quality alerts in particular can be used for the (first) mainly **unstructured** contact between business partners to initiate e.g. a supplier self-disclosure. Block notifications, in contrast, are **structured** messages. They are used to report parts with critical defects, enriched with specific information, directly to business partners, as an immediate measure potentially following a preceding quality alert.
+Block Notifications enable the standardized and machine-readable exchange of information about potentially non-conforming parts between supply-chain partners.
+
+They support time-critical containment processes by allowing suppliers to communicate affected parts and related containment information to their customers. Typical triggers include supplier self-disclosures and customer complaints.
 
 > :raised_hand: Detailed information of the specific data being exchanged are available in the [Development View](https://eclipse-tractusx.github.io/docs-kits/kits/traceability-kit/software-development-view/data-provider-development-view#aspect-models).
 
-In this way, the customer can react quickly and precisely locate the parts based on the block information and sort them out at an early stage to prevent subsequent damage or major recalls and thus save costs and ensure a high quality of the vehicles, delivered to the customer. Block notifications should therefore significantly simplify the data exchange of block information in a standardized way and improve speed and quality.
+Block Notifications help business partners identify affected parts earlier, initiate containment measures faster and improve collaboration during quality incidents.
 
 The following figure gives an overview of how block notifications are exchanged between business partners:
 

--- a/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/architecture-view.mdx
+++ b/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/architecture-view.mdx
@@ -71,6 +71,7 @@ Data provisioning of Traceability is built on the data provisioning of the [Indu
   - Aspect model ["SoftwareInformation"](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main)
   - Aspect model ["CertificateSigningRequests"](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main)
   - Aspect model ["ZeroKmFailure"](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main)
+  - Aspect model ["SpecialCharacteristicsMeasurement"](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main)
 
 - Digital Twin "qualityTask"
   - Aspect model ["ZeroKmFailure"](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main)

--- a/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/architecture-view.mdx
+++ b/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/architecture-view.mdx
@@ -136,24 +136,12 @@ Catena-X is to be used to transfer this information in a standardized manner and
 
 #### Block Notification Interaction
 
-The interaction of block notifications is based on events that can be triggered by both the sender and the recipient. These events are represented by a status model and are used to track the progress of the parts that need to be blocked or respectively sorted out by the customer. Details about these status model and the Open API specification for Block Notifications are available in the [Developer View](software-development-view/data-provider.mdx).
+Block Notifications follow a lifecycle-based interaction model consisting of Create, Update, Remove and Feedback operations.
 
-> :raised_hand: Note that (from the current 25.09 release on) the Block Notification has always to be referred to the initial problem/defect via a problem ID. The initial problem/defect is the problem the Block Notification, as delemitation, was requested for. The infomation has to be provided via the data field "problemID" in the relevant notification. In this way, the Block Notification for a part can always be assigned to the correct defect, in the event of multiple defects for one particular part. This assignment is particularly also important in the event of an update.
+This allows business partners to exchange containment information, provide updates throughout an ongoing quality incident and communicate relevant feedback where required.
 
-**Scenario 1:** In this case, it is assumed that the sender sends a list of parts with the associated block information to the recipient. The block status of each part is set to ACTIVE by default.
+> :raised_hand: Detailed lifecycle rules, message structures and implementation requirements are described in the Development View and the corresponding Block Notification standard.
 
-When all block information has been received by the recipient, checked internally, further processed and finally all affected parts were blocked or sorted out, this information is sent back to the sender through a status update (PART_BLOCKED).
-
-> :raised_hand: Note that the update notification whether one or more parts have been blocked and therefore sorted out by the customer is **not mandatory**. The decision to provide suppliers with this information through a feedback notification **MUST** have been negotiated and accepted by both business partners before implemented.
-
-**Scenario 2:**
-In this case, the sender identified that the block information sent from Scenario 1 was sent incorrectly or unintentionally.
-
-In order to inform the recipient of this error, the block status of the affected parts is set to CANCELED via an update notification, so that these parts cannot be sorted out and used to be installed by the recipient.
-
-> :raised_hand: The CANCELED status can also be updated by the recipient if it has been determined that the part(s) are faultless and therefore does not need to be sorted out.
-
-![Block State Model Interaction](./assets/block-notification-state-model-interaction.svg)
 
 ## Runtime View
 
@@ -205,19 +193,17 @@ Below, the UML sequence diagram to update a quality alert is depicted.
 
 ### Processes for Sending, Updating and Resolving Block Notifications
 
-#### Sending and Receiving of Block Information
-Below, the UML sequence diagram to send and receive a block information is depicted.
+Block Notifications are exchanged between business partners using a lifecycle-based interaction model.
 
-![BlockNotificationSendReceive](./diagrams/block-notification-send-receive.svg)
+The lifecycle consists of the following operations:
+- Create
+- Update
+- Remove
+- Feedback
 
-#### Update of Block Information
-Below, the UML sequence diagram to update a block information is depicted.
-> :raised_hand: The process for sending update notifications regarding an ongoing blocking process must be carried out in the same way as sending block information for the first time. The differences are limited to the following changes:
-> - Another data asset “BlockNotificationStatusUpdate” is used for the update
-> - The data model of the notification is limited to the ID and block status of a part and therefore does not include full block information
-> - Both 'CANCELED' and 'PART_BLOCKED' can be set for the status depending on which case applies to the notification
+These operations allow business partners to communicate containment information, provide updates during an ongoing quality incident and exchange relevant feedback where required.
 
-![BlockNotificationUpdateStatus](./diagrams/block-notification-update-status.svg)
+> :raised_hand: Detailed lifecycle rules, message structures and implementation requirements are described in the Development View and the corresponding Block Notification standard.
 
 ## Standards
 

--- a/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/changelog.mdx
+++ b/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/changelog.mdx
@@ -25,12 +25,17 @@ Compatible for **release 26.09**.
 - Removed outdated blocking scenarios and status-model explanations
 - Removed references to deprecated block notification state transitions
 - Updated references to the standalone Block Notification standard
+- Added reference to the Special Characteristics standard
+- Updated Special Characteristics aspect model references
 
 - **Development View:**
 - Reworked Block Notification documentation to align with the standalone Block Notification standard
 - Simplified lifecycle and API descriptions
 - Removed obsolete status-model specific implementation guidance
 - Updated usage policy guidance for Block Notifications
+- Updated Special Characteristics aspect model version to 3.0.0
+- Added reference to the Special Characteristics standard
+- Replaced `manufacturerID` with `manufacturerBpn` in the Special Characteristics examples and data model descriptions
 
 ## [8.0.0] - 2026-02-17
 

--- a/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/changelog.mdx
+++ b/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/changelog.mdx
@@ -9,6 +9,28 @@ sidebar_position: 0
 
 All notable changes to this KIT will be documented in this file.
 
+## [9.0.0] - 2026-08-24
+
+Compatible for **release 26.09**.
+
+### Changed
+
+- **Adoption View:**
+- Reworked Block Notification description to align with the standalone Block Notification standard
+- Added clarification regarding temporary compatibility with legacy Quality Notifications
+
+- **Architecture View:**
+- Simplified Block Notification interaction concept
+- Replaced status-model based description with lifecycle-based interaction model (Create, Update, Remove)
+- Removed outdated blocking scenarios and status-model explanations
+- Removed references to deprecated block notification state transitions
+- Updated references to the standalone Block Notification standard
+
+- **Development View:**
+- Reworked Block Notification documentation to align with the standalone Block Notification standard
+- Simplified lifecycle and API descriptions
+- Removed obsolete status-model specific implementation guidance
+- Updated usage policy guidance for Block Notifications
 
 ## [8.0.0] - 2026-02-17
 

--- a/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/software-development-view/app-provider.mdx
+++ b/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/software-development-view/app-provider.mdx
@@ -38,28 +38,27 @@ Meanwhile, this notification API shall only be accessible after successful contr
 
 ## Block Notifications
 
-While quality notifications are primarily aimed at (first) contact between business partners, block notifications represent an extended form of data exchange in order to actively initiate an immediate measure to block or sort out the produced parts at the customer's production or logistics. As the quality notifications, block notifications take place between traceability applications or other application stacks, so that this functionality must be implemented by both business partners application.
+Block Notifications extend quality-related collaboration between business partners by enabling the standardized exchange of containment information.
 
-In this case, block notifications include a **notification status similar to quality notifications** to track communication, but **also include a new status model** for each individual part of the block notification to provide additional information. For example, whether the part was blocked or whether the process to block a part was canceled.
+They support time-critical actions by allowing suppliers and customers to exchange information about potentially non-conforming parts and related containment activities in a structured and machine-readable way.
 
-> :raised_hand: Since the Catena-x unique ID is used for the individually listed (damaged) parts in the block notification, the app provider should also provide functions for the standardized creation of digital twins of vehicles, parts and materials, as already mentioned in the quality notifications section.
+> :raised_hand: Since Catena-X IDs are used to identify the affected parts, applications supporting Block Notifications should also support the standardized creation and management of the corresponding Digital Twins.
 
 ### Block Status Model
 
-In order to track the blocking process in the Catena X network, a defined status model is used for each part of the block notification:
-![Block Status Model](../assets/block-notification-state-model.svg)
+Block Notifications follow a lifecycle-based interaction model consisting of:
 
-- ACTIVE means that the part has been identified as a damaged and safety-critical part and must therefore be blocked on the customer side.
-- PART_BLOCKED is used when the recipient has received the block notification and actually blocks / sorts out the damaged parts as a measure.
-- CANCELED serves as the update status of the component originally identified to be blocked if the supplier subsequently determines that the original part does meet safety requirements, is not damaged or that the information was sent by mistake. This status can also be set by the manufacturer if, after an (initial) analysis, the part does not require a block.
+- **Create** initiates a new Block Notification.
+- **Update** provides additional or corrected information for an existing Block Notification.
+- **Remove** cancels previously communicated containment information.
+
+This allows business partners to exchange containment information and provide updates throughout an ongoing quality incident.
 
 ### Block Notification API
 
-A standardized API and corresponding payloads are specified for block notification to enable and ensure the exchange of information that is critical to the blocking process in a standardized way. At this point, the notification API is focused on sending and receiving notifications with a full stack of block information and on updating a previously sent notification by changing the block status. The implemented endpoints shall be able to process the defined request body and respond with the HTTP status codes and - if required - reply with the defined response body. Meanwhile, the Block Notification API shall only be accessible after successful contract negotiation via Connector based on [Dataspace Protocol (DSP)](https://docs.internationaldataspaces.org/dataspace-protocol/), since the API is made available as part of an EDC data asset with usage policy attached. Please refer to the corresponding Block Notification API specification for more details:
+A standardized API enables the exchange of Block Notifications between business partners through the Catena-X data space.
 
-- [Block Notification API (v2.0.0)](https://eclipse-tractusx.github.io/api-hub/eclipse-tractusx.github.io/kit-traceability-block-notifications-openAPI-2.0.0/swagger-ui/) 
-
-> :raised_hand: From current release on (R25.09), **version 2.0.0 is mandatory** and must be supported by every App provider using block notification. The older version 1.0.0 will not be compatible anymore.
+> :raised_hand: Detailed API definitions, payload structures, lifecycle rules, versioning requirements and implementation details are described in the corresponding Block Notification standard.
 
 ## Asset Registration via Connector
 
@@ -122,7 +121,7 @@ As for usage policy, participants and related services must restrict the data us
 - Data Exchange Governance (leftOperand: “FrameworkAgreement”) – The official "Data Exchange Governance" is published on [Catena-X website](https://catena-x.net/en/catena-x-introduce-implement/governance-framework-for-data-space-operations)
 - at least one use case purpose (“UsagePurpose”) from the [ODRL policy repository](https://github.com/catenax-eV/cx-odrl-profile)
   - for quality notifications, the corresponding usage policy MUST be used (leftOperand: “qualityNotifications”)
-  - for block notifications, the same usage policy as quality notifications MUST be used (leftOperand: “qualityNotifications”)
+  - for block notifications, the Quality Notification usage purpose MUST be used until a dedicated Block Notification usage purpose becomes available (leftOperand: “qualityNotifications”)
 
 Additionally, respective usage policies MAY include the following policy rule:
 

--- a/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/software-development-view/parts/aspect-models.mdx
+++ b/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/software-development-view/parts/aspect-models.mdx
@@ -15,7 +15,7 @@ The following section shows an overview of all aspect models of the Traceability
 | PartInstance | TractionBatteryCode | 2.0.0 | | Traceability |  CX-0125 Traceability Use Case |
 | | SoftwareInformation | 1.0.0 | | Traceability | N/A |
 | | CertificateSigningRequests | 1.0.0 | | Traceability | N/A |
-| | SpecialCharacteristics | 1.0.0 | | Traceability | N/A |
+| | SpecialCharacteristics | 3.0.0 | | Traceability | CX-0xxx Special Characteristics |
 | qualityTask | ZeroKmFailure | 1.0.0 | | Traceability |  CX-0125 Traceability Use Case |
 
 ### TractionBatteryCode
@@ -158,7 +158,7 @@ To ensure manufactured components meet defined quality standards and specificati
 
 #### Aspect Model in GitHub
 
-- **Version 2.0.0**: [GitHub Repository](https://github.com/eclipse-tractusx/sldt-semantic-models/blob/main/io.catenax.special_characteristics.measurement/2.0.0/)
+- **Version 3.0.0**: [GitHub Repository](https://github.com/eclipse-tractusx/sldt-semantic-models/blob/main/io.catenax.special_characteristics.measurement/3.0.0/)
 
 #### Data Model
 
@@ -174,7 +174,7 @@ Below is the detailed description of the attributes used in the `SpecialCharacte
   ],
   "customerPartId": "PRT-12345",
   "revisionIndex": "01",
-  "manufacturerId": "BPNL000000000000",
+  "manufacturerBpn": "BPNL000000000000",
   "measurementType": "quantitativeMeasurement",
   "characteristicId": "F1",
   "results": [
@@ -194,7 +194,7 @@ Below is the detailed description of the attributes used in the `SpecialCharacte
 | `localIdentifiers`    | An array of local identifiers used to uniquely identify the part instance.  | –     | –          | –                  |
 | `customerPartId`      | The identifier of the part assigned by the customer.                        | String                                                                    | Mandatory          | "PRT-12345"                                                           |
 | `revisionIndex`       | The revision index of the part.                                             | String                                                                    | Mandatory          | "01"                                                                   |
-| `manufacturerId`      | The identifier of the manufacturer.                                         | String                                                                    | Mandatory          | "BPNL000000000000"                                                    |
+| `manufacturerBpn`     | Business Partner Number (BPNL, BPNS or BPNA) of the manufacturer            | String                                                                    | Mandatory          | "BPNL000000000000"                                                    |
 | `measurementType`     | The type of measurement being performed (e.g., quantitative, qualitative).  | String                                                                    | Optional          | "quantitativeMeasurement"                                            |
 | `characteristicId`    | The identifier of the characteristic being measured. Normally defined within the blueprint. | String                                                                    | Mandatory          | "F1"                                                                |
 | `results`             | An array of measurement results.                                            | –                                                          | –          | –                                                                                         |

--- a/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/software-development-view/parts/aspect-models.mdx
+++ b/docs-kits_versioned_docs/version-26.06/kits/traceability-kit/software-development-view/parts/aspect-models.mdx
@@ -15,7 +15,7 @@ The following section shows an overview of all aspect models of the Traceability
 | PartInstance | TractionBatteryCode | 2.0.0 | | Traceability |  CX-0125 Traceability Use Case |
 | | SoftwareInformation | 1.0.0 | | Traceability | N/A |
 | | CertificateSigningRequests | 1.0.0 | | Traceability | N/A |
-| | SpecialCharacteristics | 3.0.0 | | Traceability | CX-0xxx Special Characteristics |
+| | SpecialCharacteristics | 3.0.0 | | Traceability | CX-0163 Special Characteristics |
 | qualityTask | ZeroKmFailure | 1.0.0 | | Traceability |  CX-0125 Traceability Use Case |
 
 ### TractionBatteryCode


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
This PR aligns the Block Notification documentation across the Adoption, Architecture and Development Views with the standalone Block Notification standard by replacing the legacy status-model approach with a simplified lifecycle-based concept, updating the usage policy guidance and refreshing the changelog.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
